### PR TITLE
Fix pathlib warning

### DIFF
--- a/app/controllers/feed_changeset.py
+++ b/app/controllers/feed_changeset.py
@@ -1,7 +1,6 @@
-from pathlib import Path
 from typing import Annotated
 
-from fastapi import APIRouter, Query, Response
+from fastapi import APIRouter, Path, Query, Response
 from feedgen.feed import FeedGenerator
 from pydantic import PositiveInt
 from shapely.geometry.base import BaseGeometry


### PR DESCRIPTION
Wrong import was used which caused:
app/controllers/feed_changeset.py:38: DeprecationWarning: support for supplying keyword arguments to pathlib.PurePath is deprecated and scheduled for removal in Python 3.14
    display_name: Annotated[str, Path(min_length=1, max_length=DISPLAY_NAME_MAX_LENGTH)],
