### PR TITLE
Resolved issue #145 (Update _base-fetch.ts )

### DIFF
--- a/app/static/js/index/_base-fetch.ts
+++ b/app/static/js/index/_base-fetch.ts
@@ -21,8 +21,16 @@ export const getBaseFetchController = (
 
     let abortController: AbortController | null = null
 
+
+    // store scroll position
+    let scrollPosition: number = 0
+    let sidebarScrollPosition: number = 0
+
+
     /** On sidebar loading, display loading content */
     const onSidebarLoading = () => {
+        scrollPosition = window.scrollY
+        sidebarScrollPosition = dynamicContent.scrollTop
         dynamicContent.innerHTML = loadingHtml
     }
 
@@ -31,6 +39,14 @@ export const getBaseFetchController = (
         dynamicContent.innerHTML = html
         resolveDatetime(dynamicContent)
         configureActionSidebar(sidebar)
+
+          // Restore global scroll position
+        window.setTimeout(() => {
+            window.scrollTo(0, scrollPosition)
+        }, 50)
+
+        // Restore sidebar scroll position
+        dynamicContent.scrollTop = sidebarScrollPosition
     }
 
     return {


### PR DESCRIPTION
**### Problem Description:**

When calling the load() method of the BaseFetchController, it fetches new data for the sidebar, potentially replacing the sidebar content. This results in a page reload, and typically when this happens in a web page, the browser resets the scroll position to the top. This behavior is common when performing DOM updates that replace large portions of the content.

In this case, the issue specifically occurs when baseFetch.load() is called. This triggers an "unload" of the current sidebar content and a "load" of new sidebar content. During this transition, the page loses its scroll position and starts from the top again, which is an undesired behavior, especially for users interacting with the sidebar or the page content.

**### Solution:**

To solve this issue, we need to detect successive "unload/load" actions on the same page and restore the scroll position before the sidebar is unloaded. This can be achieved by saving the current scroll position before unloading the sidebar content and then restoring it after the new content has been loaded again.

**### Steps to Fix the Issue:**

- Track the Scroll Position Before Unloading the Sidebar

- Before unloading the current sidebar content, we need to capture the current scroll position of the sidebar (or the page if needed). Restore the Scroll Position After Sidebar Content is Loaded:

- Once the new sidebar content is loaded and displayed, we should restore the scroll position to the previously saved value.

 
**### Implementation Plan:**

Save the Scroll Position

- Track the sidebar scroll position (dynamicContent.scrollTop) before unloading the current content. Load New Content.

- Fetch new content and replace the old sidebar content. Restore the Scroll Position.

- After the new sidebar content has been loaded, restore the saved scroll position for both the global page (window.scrollY) and the sidebar (dynamicContent.scrollTop).

**### Code Changes:**

Modify the BaseFetchController to save the scroll position before the sidebar is unloaded. Restore the scroll position after the new content has been loaded.



(Done With changes let me know if changes are working proper)