### PR TITLE
Async trace compression

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "[python]": {
-    "editor.defaultFormatter": "charliermarsh.ruff"
+    "editor.defaultFormatter": "ms-python.autopep8"
   },
   "[scss]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "[python]": {
-    "editor.defaultFormatter": "ms-python.autopep8"
+    "editor.defaultFormatter": "charliermarsh.ruff"
   },
   "[scss]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/app/config.py
+++ b/app/config.py
@@ -53,7 +53,7 @@ SMTP_PASS: SecretStr = Field()
 # -------------------- System Configuration --------------------
 
 # Core settings
-ENV: Literal['dev', 'test', 'prod'] = 'dev' # 'prod'
+ENV: Literal['dev', 'test', 'prod'] = 'prod'
 LOG_LEVEL = 'INFO' if ENV == 'prod' else 'DEBUG'
 LEGACY_HIGH_PRECISION_TIME = False
 LEGACY_SEQUENCE_ID_MARGIN = False

--- a/app/config.py
+++ b/app/config.py
@@ -53,7 +53,7 @@ SMTP_PASS: SecretStr = Field()
 # -------------------- System Configuration --------------------
 
 # Core settings
-ENV: Literal['dev', 'test', 'prod'] = 'prod'
+ENV: Literal['dev', 'test', 'prod'] = 'dev' # 'prod'
 LOG_LEVEL = 'INFO' if ENV == 'prod' else 'DEBUG'
 LEGACY_HIGH_PRECISION_TIME = False
 LEGACY_SEQUENCE_ID_MARGIN = False
@@ -252,7 +252,8 @@ TRACE_FILE_UNCOMPRESSED_MAX_SIZE = 80 * _MB
 TRACE_FILE_ARCHIVE_MAX_FILES = 10
 TRACE_FILE_MAX_LAYERS = 2
 TRACE_FILE_COMPRESS_ZSTD_THREADS = 4
-TRACE_FILE_COMPRESS_ZSTD_LEVEL = 6
+TRACE_FILE_PRECOMPRESS_ZSTD_LEVEL = 6
+TRACE_FILE_COMPRESS_ZSTD_LEVEL = 22
 TRACE_POINT_QUERY_AREA_MAX_SIZE: float = 0.25  # in square degrees
 TRACE_POINT_QUERY_DEFAULT_LIMIT = 5_000
 TRACE_POINT_QUERY_MAX_LIMIT = 5_000

--- a/app/lib/trace_file.py
+++ b/app/lib/trace_file.py
@@ -201,7 +201,7 @@ _ZSTD_COMPRESS = ZstdCompressor(level=TRACE_FILE_COMPRESS_ZSTD_LEVEL, threads=TR
 _ZSTD_DECOMPRESS = ZstdDecompressor().decompress
 _ZSTD_SUFFIX = '.zst'
 _ZSTD_PRECOMPRESSED_METADATA: dict[str, str] = {'zstd_level': str(TRACE_FILE_PRECOMPRESS_ZSTD_LEVEL)}
-_ZSTD_COMPRESSED_METADATA: dict[str, str] = {'zstd_level': str(TRACE_FILE_PRECOMPRESS_ZSTD_LEVEL)}
+_ZSTD_COMPRESSED_METADATA: dict[str, str] = {'zstd_level': str(TRACE_FILE_COMPRESS_ZSTD_LEVEL)}
 
 
 class _ZstdProcessor(_TraceProcessor):

--- a/app/lib/trace_file.py
+++ b/app/lib/trace_file.py
@@ -14,6 +14,7 @@ from zstandard import ZstdCompressor, ZstdDecompressor, ZstdError
 
 from app.config import (
     TRACE_FILE_ARCHIVE_MAX_FILES,
+    TRACE_FILE_PRECOMPRESS_ZSTD_LEVEL,
     TRACE_FILE_COMPRESS_ZSTD_LEVEL,
     TRACE_FILE_COMPRESS_ZSTD_THREADS,
     TRACE_FILE_MAX_LAYERS,
@@ -61,12 +62,21 @@ class TraceFile:
         raise_for.trace_file_archive_too_deep()
 
     @staticmethod
+    async def precompress(buffer: bytes) -> _CompressResult:
+        """Compress the trace file buffer. Returns the compressed buffer and the file name suffix."""
+        loop = get_running_loop()
+        result = await loop.run_in_executor(None, _ZSTD_PRECOMPRESS, buffer)
+        logging.debug('Trace file zstd-precompressed size is %s', sizestr(len(result)))
+        return _CompressResult(result, _ZSTD_SUFFIX, _ZSTD_PRECOMPRESSED_METADATA)
+
+
+    @staticmethod
     async def compress(buffer: bytes) -> _CompressResult:
         """Compress the trace file buffer. Returns the compressed buffer and the file name suffix."""
         loop = get_running_loop()
         result = await loop.run_in_executor(None, _ZSTD_COMPRESS, buffer)
         logging.debug('Trace file zstd-compressed size is %s', sizestr(len(result)))
-        return _CompressResult(result, _ZSTD_SUFFIX, _ZSTD_METADATA)
+        return _CompressResult(result, _ZSTD_SUFFIX, _ZSTD_COMPRESSED_METADATA)
 
     @staticmethod
     def decompress_if_needed(buffer: bytes, file_id: StorageKey) -> bytes:
@@ -186,10 +196,12 @@ class _ZipProcessor(_TraceProcessor):
         return result
 
 
+_ZSTD_PRECOMPRESS = ZstdCompressor(level=TRACE_FILE_PRECOMPRESS_ZSTD_LEVEL, threads=TRACE_FILE_COMPRESS_ZSTD_THREADS).compress
 _ZSTD_COMPRESS = ZstdCompressor(level=TRACE_FILE_COMPRESS_ZSTD_LEVEL, threads=TRACE_FILE_COMPRESS_ZSTD_THREADS).compress
 _ZSTD_DECOMPRESS = ZstdDecompressor().decompress
 _ZSTD_SUFFIX = '.zst'
-_ZSTD_METADATA: dict[str, str] = {'zstd_level': str(TRACE_FILE_COMPRESS_ZSTD_LEVEL)}
+_ZSTD_PRECOMPRESSED_METADATA: dict[str, str] = {'zstd_level': str(TRACE_FILE_PRECOMPRESS_ZSTD_LEVEL)}
+_ZSTD_COMPRESSED_METADATA: dict[str, str] = {'zstd_level': str(TRACE_FILE_PRECOMPRESS_ZSTD_LEVEL)}
 
 
 class _ZstdProcessor(_TraceProcessor):


### PR DESCRIPTION
Fixes #100

- All previous compression functions were renamed to `precompress` accordingly.   
- After precompressing, a task is added using the `asyncio.create_task` function (not `loop.run_in_executor`).  
- This function compresses using level 22, then uploads to the database, overrides the previous database entry, and then deletes the previous file.  
- If inserting the new file into the database fails, the new file is deleted so the old one remains.  
- I have tested it regarding error handling, but it might not properly handle some edge cases.


Edit: I have no idea what causes segfault error in cython