### PR TITLE
Display OpenStreetMap trademark required notice

### DIFF
--- a/app/views/test-site.html.jinja
+++ b/app/views/test-site.html.jinja
@@ -41,6 +41,10 @@
                     <a href="https://github.com/openstreetmap-ng/openstreetmap-ng" target="_blank">
                         an independent open-source project</a>.
                 </p>
+                <p class="card-text">
+                        OpenStreetMap is a trademark of the OpenStreetMap Foundation, and is used with their permission. OpenStreetMap-NG are not endorsed by or affiliated with the OpenStreetMap Foundation. 
+                </p>
+
             </div>
         </div>
 


### PR DESCRIPTION
as required per https://osmfoundation.org/wiki/Trademark_Policy#3.3.6._Use_in_software_projects

(also see discussion in https://community.openstreetmap.org/t/use-of-openstreetmap-ng-domain/132716 for background and other possible issues)