### PR TITLE
fix: now hover works on route step when scrolling

### DIFF
--- a/app/views/index/routing.html.jinja
+++ b/app/views/index/routing.html.jinja
@@ -131,7 +131,7 @@
                 </template>
 
                 <template class="step">
-                    <tr>
+                    <tr class="route-step">
                         <td class="icon">
                             <div></div>
                         </td>

--- a/app/views/index/routing.scss
+++ b/app/views/index/routing.scss
@@ -54,7 +54,6 @@
         }
     }
 
-    tr:hover,
     tr.hover {
         cursor: pointer;
 

--- a/app/views/index/routing.ts
+++ b/app/views/index/routing.ts
@@ -494,6 +494,39 @@ export const getRoutingController = (map: MaplibreMap): IndexController => {
         )
         routeContainer.classList.remove("d-none")
 
+        // Track current mouse position for hover detection
+        let mouseX = 0,
+            mouseY = 0
+        document.addEventListener(
+            "mousemove",
+            (e) => {
+                mouseX = e.clientX
+                mouseY = e.clientY
+            },
+            true,
+        )
+
+        // Re-evaluate hover state when scrolling occurs
+        // This handles the case where mouse doesn't move but content scrolls under it
+        let prevStepRowIndex = -1
+        document.addEventListener(
+            "scroll",
+            () => {
+                const elementUnderMouse = document.elementFromPoint(mouseX, mouseY)
+                const stepRow = elementUnderMouse.closest(".route-step")
+                const stepRowIndex = Array.from(stepsTableBody.children).indexOf(
+                    stepRow,
+                )
+                if (stepRowIndex === prevStepRowIndex) return
+                if (prevStepRowIndex !== -1) {
+                    setHover(prevStepRowIndex, false)
+                }
+                setHover(stepRowIndex, true)
+                prevStepRowIndex = stepRowIndex
+            },
+            true,
+        )
+
         // Update the route layer
         source.setData({ type: "FeatureCollection", features: lines })
         console.debug("Route showing", route.steps.length, "steps")


### PR DESCRIPTION
This PR closes issue #175 

## Problem
When users scroll the page without moving their mouse, mouseenter events are not fired. This meant the setHover function wasn't called, leaving hover states inconsistent. The routing step rows would not highlight properly during scroll operations

## Solution
Added a mousemove and scroll listener.
Listen for scroll events and trigger hover re-evaluation
Use elementFromPoint() to detect which element is under the mouse cursor
Only update hover state when the element under mouse actually changes

Recording
[screen-capture.webm](https://github.com/user-attachments/assets/7afad73b-22e5-4b47-a54c-bbc239834773)
