### PR TITLE
fix: display friendly error messages for image upload failures

### DIFF
--- a/app/exceptions/image_mixin.py
+++ b/app/exceptions/image_mixin.py
@@ -17,3 +17,15 @@ class ImageExceptionsMixin:
             status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail='Image violates content policy',
         )
+
+    def image_invalid_format(self) -> NoReturn:
+        raise APIError(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail='Image format is not supported or the file is corrupted',
+        )
+
+    def image_decompression_failed(self) -> NoReturn:
+        raise APIError(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail='Failed to process the image; it may be corrupted or too large',
+        )

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -562,6 +562,9 @@ time:
   never: Never
 validation:
   invalid_value: Invalid value
+  image_file_too_large: The image file is too large. Please upload a smaller file.
+  image_invalid_format: The image format is not supported or the file is corrupted.
+  image_decompression_failed: Failed to process the image. The file may be corrupted or too large.
   display_name_is_taken: This display name is already taken
   new_email_is_current: The new email address is the same as the current one
   invalid_email_address: Invalid email address


### PR DESCRIPTION
## Summary

- Handle PIL exceptions when opening image files and convert them to user-friendly error messages
- Catch `UnidentifiedImageError` for unsupported/corrupted image formats
- Catch `DecompressionBombError` for images that are too large to safely decompress

Fixes #31

## Test plan

- [ ] Upload an avatar with an unsupported format (e.g., .txt renamed to .png)
- [ ] Upload a very large image that triggers decompression bomb protection
- [ ] Verify friendly error messages are displayed instead of stack traces
- [ ] Verify normal image uploads still work correctly