### PR TITLE
fix: reject node uploads at null island (0,0)

### DIFF
--- a/app/format/api06_element.py
+++ b/app/format/api06_element.py
@@ -384,6 +384,13 @@ def _decode_element_unsafe(
         and (lat := data.get('@lat')) is not None
         else None
     )
+
+    # Reject nodes placed at null island (0, 0) — always an editor bug, never intentional
+    if type == 'node' and point is not None:
+        coords = get_coordinates(point)[0]
+        if coords[0] == 0.0 and coords[1] == 0.0:
+            raise ValueError('Node coordinates at null island (0, 0) are not allowed')
+
     members = None
     members_roles = None
 

--- a/tests/controllers/test_api06_changeset.py
+++ b/tests/controllers/test_api06_changeset.py
@@ -132,7 +132,7 @@ async def test_changeset_upload(client: AsyncClient):
         content=XMLToDict.unparse({
             'osmChange': {
                 'create': [
-                    ('node', {'@id': -1, '@lat': 0, '@lon': 0}),
+                    ('node', {'@id': -1, '@lat': 1.0, '@lon': 2.0}),
                     ('way', {'@id': -1, 'nd': [{'@ref': -1}]}),
                 ]
             }
@@ -157,12 +157,55 @@ async def test_changeset_upload(client: AsyncClient):
             '@updated_at': datetime,
             '@closed_at': datetime,
             '@changes_count': 2,
-            '@min_lat': 0.0,
-            '@max_lat': 0.0,
-            '@min_lon': 0.0,
-            '@max_lon': 0.0,
+            '@min_lat': 1.0,
+            '@max_lat': 1.0,
+            '@min_lon': 2.0,
+            '@max_lon': 2.0,
         },
     )
+
+
+async def test_changeset_upload_null_island(client: AsyncClient):
+    client.headers['Authorization'] = 'User user1'
+
+    # Create a changeset
+    r = await client.put(
+        '/api/0.6/changeset/create',
+        content=XMLToDict.unparse({
+            'osm': {
+                'changeset': {
+                    'tag': [
+                        {
+                            '@k': 'created_by',
+                            '@v': test_changeset_upload_null_island.__name__,
+                        }
+                    ]
+                }
+            }
+        }),
+    )
+    assert r.is_success, r.text
+    changeset_id = int(r.text)
+
+    # Attempt to upload a node at null island (0, 0) — must be rejected
+    r = await client.post(
+        f'/api/0.6/changeset/{changeset_id}/upload',
+        content=XMLToDict.unparse({
+            'osmChange': {'create': [('node', {'@id': -1, '@lat': 0, '@lon': 0})]}
+        }),
+    )
+    assert r.status_code == status.HTTP_400_BAD_REQUEST, r.text
+
+    # Also reject a modify action placing a node at null island
+    r = await client.post(
+        f'/api/0.6/changeset/{changeset_id}/upload',
+        content=XMLToDict.unparse({
+            'osmChange': {
+                'modify': [('node', {'@id': 1, '@version': 1, '@lat': 0, '@lon': 0})]
+            }
+        }),
+    )
+    assert r.status_code == status.HTTP_400_BAD_REQUEST, r.text
 
 
 @pytest.mark.parametrize('include', [True, False])
@@ -285,7 +328,7 @@ async def test_changeset_upload_closed(client: AsyncClient):
     r = await client.post(
         f'/api/0.6/changeset/{changeset_id}/upload',
         content=XMLToDict.unparse({
-            'osmChange': {'create': [('node', {'@id': -1, '@lat': 0, '@lon': 0})]}
+            'osmChange': {'create': [('node', {'@id': -1, '@lat': 1.0, '@lon': 2.0})]}
         }),
     )
     assert r.status_code == status.HTTP_409_CONFLICT, r.text


### PR DESCRIPTION
## Summary

Nodes placed at coordinates (0, 0) — "null island" — are always the result of a buggy editor, never intentional. This PR adds server-side validation that rejects any upload containing a node at exactly lat=0, lon=0.

## Changes

### `app/format/api06_element.py`
Added a null island check in `_decode_element_unsafe()`, the shared decode path used by:
- The bulk osmChange upload endpoint (`POST /api/0.6/changeset/{id}/upload`)
- The single-element API (`PUT /api/0.6/node/create`, `PUT /api/0.6/node/{id}`)

When a node element is decoded with both coordinates rounding to exactly 0.0 (at 7 decimal place precision), a `ValueError` is raised, which the calling endpoint converts to a `400 Bad Request` response with a clear message.

### `tests/controllers/test_api06_changeset.py`
- Updated `test_changeset_upload` and `test_changeset_upload_closed` to use non-null-island coordinates (lat=1.0, lon=2.0) instead of (0, 0)
- Added new test `test_changeset_upload_null_island` that verifies both `create` and `modify` actions with null island coordinates return `400 Bad Request`

Fixes #128

/claim #128