### PR TITLE
fix: display friendly error on too big avatar image upload

### DIFF
--- a/app/exceptions/image_mixin.py
+++ b/app/exceptions/image_mixin.py
@@ -12,6 +12,12 @@ class ImageExceptionsMixin:
     def image_too_big(self) -> NoReturn:
         raise APIError(status.HTTP_422_UNPROCESSABLE_CONTENT, detail='Image is too big')
 
+    def image_not_readable(self) -> NoReturn:
+        raise APIError(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail='The uploaded file is not a valid image or is corrupted',
+        )
+
     def image_inappropriate(self) -> NoReturn:
         raise APIError(
             status.HTTP_422_UNPROCESSABLE_CONTENT,

--- a/app/lib/image.py
+++ b/app/lib/image.py
@@ -9,7 +9,8 @@ from typing import TYPE_CHECKING, Literal, NamedTuple, overload
 
 import cython
 from blurhash_rs import blurhash_encode
-from PIL import ImageOps, ImageSequence
+from PIL import ImageOps, ImageSequence, UnidentifiedImageError
+from PIL.Image import DecompressionBombError
 from PIL.Image import Image as PILImage
 from PIL.Image import Resampling
 from PIL.Image import open as open_image
@@ -243,8 +244,13 @@ async def _normalize_image(
     - Megapixels: downscale
     - File size: reduce quality
     """
-    img = open_image(BytesIO(data))
-    ImageOps.exif_transpose(img, in_place=True)
+    try:
+        img = open_image(BytesIO(data))
+        ImageOps.exif_transpose(img, in_place=True)
+    except DecompressionBombError:
+        raise_for.image_too_big()
+    except (UnidentifiedImageError, OSError, SyntaxError):
+        raise_for.image_not_readable()
 
     # normalize shape ratio
     img_width: cython.size_t

--- a/app/views/settings/applications/edit.ts
+++ b/app/views/settings/applications/edit.ts
@@ -7,7 +7,14 @@ mount("settings-application-edit-body", (body) => {
     const avatarImage = avatarForm.querySelector("img.avatar")!
     const avatarFileInput = avatarForm.querySelector("input[name=avatar_file]")!
 
+    const avatarMaxFileSize = 10 * 1024 * 1024 // 10 MB
     avatarFileInput.addEventListener("change", () => {
+        const file = (avatarFileInput as HTMLInputElement).files?.[0]
+        if (file && file.size > avatarMaxFileSize) {
+            alert(t("validation.image_file_too_big"))
+            ;(avatarFileInput as HTMLInputElement).value = ""
+            return
+        }
         avatarForm.requestSubmit()
     })
 

--- a/app/views/user/profile/profile.ts
+++ b/app/views/user/profile/profile.ts
@@ -23,7 +23,14 @@ mount("user-profile-body", (body) => {
         const avatarTypeInput = avatarForm.querySelector("input[name=avatar_type]")!
         const avatarFileInput = avatarForm.querySelector("input[name=avatar_file]")!
 
+        const avatarMaxFileSize = 10 * 1024 * 1024 // 10 MB
         avatarFileInput.addEventListener("change", () => {
+            const file = (avatarFileInput as HTMLInputElement).files?.[0]
+            if (file && file.size > avatarMaxFileSize) {
+                alert(i18next.t("validation.image_file_too_big"))
+                ;(avatarFileInput as HTMLInputElement).value = ""
+                return
+            }
             avatarTypeInput.value = "custom"
             avatarForm.requestSubmit()
         })
@@ -61,7 +68,14 @@ mount("user-profile-body", (body) => {
             "input[name=background_file]",
         )!
 
+        const backgroundMaxFileSize = 10 * 1024 * 1024 // 10 MB
         backgroundFileInput.addEventListener("change", () => {
+            const file = (backgroundFileInput as HTMLInputElement).files?.[0]
+            if (file && file.size > backgroundMaxFileSize) {
+                alert(i18next.t("validation.image_file_too_big"))
+                ;(backgroundFileInput as HTMLInputElement).value = ""
+                return
+            }
             backgroundForm.requestSubmit()
         })
 

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -578,6 +578,7 @@ validation:
   user_not_found: User {{user}} not found
   you_can_send_message_to_at_most_limit_recipients: "You can send a message to at most {{limit}} recipients"
   incomplete_location_information: Incomplete location information
+  image_file_too_big: The selected image file is too large. Please choose a smaller image.
 action:
   go_back: Go back
   authorize: Authorize


### PR DESCRIPTION
## Summary

Fixes #31 — Improves error handling for oversized and invalid avatar/background image uploads.

### Backend
- Wraps `open_image()` / `exif_transpose()` in `_normalize_image()` with try/except to catch:
  - `DecompressionBombError` → reuses existing `image_too_big()` (422)
  - `UnidentifiedImageError`, `OSError`, `SyntaxError` → new `image_not_readable()` (422)
- Adds `image_not_readable()` to `ImageExceptionsMixin` returning a user-friendly error message

### Frontend
- Adds client-side file size validation (10 MB) on avatar and background file inputs:
  - User profile avatar upload (`profile.ts`)
  - User profile background upload (`profile.ts`)
  - OAuth application avatar upload (`edit.ts`)
- Shows localized error via `i18next` before upload is attempted

### Translation
- Adds `validation.image_file_too_big` to `extra_en.yaml`

### Files changed
- `app/lib/image.py` — catch decompression errors
- `app/exceptions/image_mixin.py` — add `image_not_readable()`
- `app/views/user/profile/profile.ts` — frontend validation
- `app/views/settings/applications/edit.ts` — frontend validation
- `config/locale/extra_en.yaml` — error message translation