### PR TITLE
feat: reject edits at the null island (0, 0)

### DIFF
--- a/app/exceptions/diff_mixin.py
+++ b/app/exceptions/diff_mixin.py
@@ -21,3 +21,7 @@ class DiffExceptionsMixin:
     @abstractmethod
     def diff_update_bad_version(self, element: 'ElementInit') -> NoReturn:
         raise NotImplementedError
+
+    @abstractmethod
+    def diff_null_island(self, count: int) -> NoReturn:
+        raise NotImplementedError

--- a/app/exceptions/note_mixin.py
+++ b/app/exceptions/note_mixin.py
@@ -19,5 +19,9 @@ class NoteExceptionsMixin:
         raise NotImplementedError
 
     @abstractmethod
+    def note_null_island(self) -> NoReturn:
+        raise NotImplementedError
+
+    @abstractmethod
     def notes_query_area_too_big(self) -> NoReturn:
         raise NotImplementedError

--- a/app/exceptions06/diff_mixin.py
+++ b/app/exceptions06/diff_mixin.py
@@ -52,3 +52,11 @@ class DiffExceptions06Mixin(DiffExceptionsMixin):
             status.HTTP_412_PRECONDITION_FAILED,
             detail=f'Update action requires version >= 1, got {element["version"] - 1}',
         )
+
+    @override
+    def diff_null_island(self, count: int) -> NoReturn:
+        raise APIError(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f'Changeset contains {count} nodes at the null island (0, 0). '
+            'This is typically caused by a software bug in the editor.',
+        )

--- a/app/exceptions06/note_mixin.py
+++ b/app/exceptions06/note_mixin.py
@@ -29,6 +29,14 @@ class NoteExceptions06Mixin(NoteExceptionsMixin):
         )
 
     @override
+    def note_null_island(self) -> NoReturn:
+        raise APIError(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail='Creating notes at the null island (0, 0) is not allowed. '
+            'This is typically caused by a software bug.',
+        )
+
+    @override
     def notes_query_area_too_big(self) -> NoReturn:
         raise APIError(
             status.HTTP_400_BAD_REQUEST,

--- a/app/services/note_service.py
+++ b/app/services/note_service.py
@@ -37,7 +37,10 @@ class NoteService:
         """Create a note and return its id."""
         point = validate_geometry(Point(lon, lat))
 
+        # Reject notes at the null island (0, 0) for non-moderators
         user = auth_user()
+        if point.x == 0.0 and point.y == 0.0 and not user_is_moderator(user):
+            raise_for.note_null_island()
         if user is not None:
             # Prevent OAuth to create user-authorized note
             scopes = auth_scopes()

--- a/app/services/optimistic_diff/prepare.py
+++ b/app/services/optimistic_diff/prepare.py
@@ -12,6 +12,7 @@ from shapely import Point, bounds, box
 from app.lib.auth_context import auth_user
 from app.lib.changeset_bounds import extend_changeset_bounds
 from app.lib.exceptions_context import raise_for
+from app.models.db.user import user_is_moderator
 from app.models.db.changeset import Changeset, changeset_increase_size
 from app.models.db.element import Element, ElementInit
 from app.models.element import (
@@ -208,6 +209,16 @@ class OptimisticDiffPrepare:
                 )
             else:
                 entry.current = element
+
+        # Check for null island nodes (reject if 2+ nodes at 0,0)
+        if not user_is_moderator(auth_user()):
+            null_island_count: cython.size_t = 0
+            for element in apply_elements:
+                point = element.get('point')
+                if point is not None and point.x == 0.0 and point.y == 0.0:
+                    null_island_count += 1
+            if null_island_count >= 2:
+                raise_for.diff_null_island(null_island_count)
 
         self._update_changeset_size(
             num_create=num_create,

--- a/tests/controllers/test_api06_note.py
+++ b/tests/controllers/test_api06_note.py
@@ -17,7 +17,7 @@ async def test_note_create_xml(client: AsyncClient):
 
     r = await client.post(
         '/api/0.6/notes',
-        params={'lon': 0, 'lat': 0, 'text': test_note_create_xml.__qualname__},
+        params={'lon': 1, 'lat': 1, 'text': test_note_create_xml.__qualname__},
     )
     assert r.is_success, r.text
     note: dict = XMLToDict.parse(r.content)['osm']['note'][0]  # type: ignore
@@ -26,8 +26,8 @@ async def test_note_create_xml(client: AsyncClient):
     assert_model(
         note,
         {
-            '@lat': 0.0,
-            '@lon': 0.0,
+            '@lat': 1.0,
+            '@lon': 1.0,
             'id': PositiveInt,
             'status': 'open',
             'url': str,
@@ -51,7 +51,7 @@ async def test_note_create_json(client: AsyncClient):
 
     r = await client.post(
         '/api/0.6/notes.json',
-        json={'lon': 0, 'lat': 0, 'text': test_note_create_json.__qualname__},
+        json={'lon': 1, 'lat': 1, 'text': test_note_create_json.__qualname__},
     )
     assert r.is_success, r.text
     props = r.json()['properties']
@@ -72,7 +72,7 @@ async def test_note_create_gpx(client: AsyncClient):
 
     r = await client.post(
         '/api/0.6/notes.gpx',
-        params={'lon': 0, 'lat': 0, 'text': test_note_create_gpx.__qualname__},
+        params={'lon': 1, 'lat': 1, 'text': test_note_create_gpx.__qualname__},
     )
     assert r.is_success, r.text
     waypoint: dict = XMLToDict.parse(r.content)['gpx']['wpt']  # type: ignore
@@ -80,8 +80,8 @@ async def test_note_create_gpx(client: AsyncClient):
     assert_model(
         waypoint,
         {
-            '@lat': 0.0,
-            '@lon': 0.0,
+            '@lat': 1.0,
+            '@lon': 1.0,
             'time': datetime,
             'name': str,
             'link': dict,
@@ -94,7 +94,7 @@ async def test_note_create_gpx(client: AsyncClient):
 async def test_note_create_anonymous(client: AsyncClient):
     r = await client.post(
         '/api/0.6/notes.json',
-        json={'lon': 0, 'lat': 0, 'text': test_note_create_anonymous.__qualname__},
+        json={'lon': 1, 'lat': 1, 'text': test_note_create_anonymous.__qualname__},
     )
     assert r.is_success, r.text
     props = r.json()['properties']
@@ -116,7 +116,7 @@ async def test_note_crud(client: AsyncClient):
     # Step 1: Create a note
     r = await client.post(
         '/api/0.6/notes.json',
-        json={'lon': 0, 'lat': 0, 'text': test_note_crud.__qualname__},
+        json={'lon': 1, 'lat': 1, 'text': test_note_crud.__qualname__},
     )
     assert r.is_success, r.text
     props = r.json()['properties']
@@ -224,7 +224,7 @@ async def test_note_crud(client: AsyncClient):
     [
         {'lon': 181, 'lat': 0, 'text': 'Invalid longitude'},
         {'lon': 0, 'lat': 91, 'text': 'Invalid latitude'},
-        {'lon': 0, 'lat': 0, 'text': ''},
+        {'lon': 1, 'lat': 1, 'text': ''},
     ],
 )
 async def test_note_bad_input(client: AsyncClient, input_data):
@@ -264,7 +264,7 @@ async def test_note_search(client: AsyncClient):
     text = f'{test_note_search.__qualname__} {search_text}'
     r = await client.post(
         '/api/0.6/notes.json',
-        json={'lon': 0, 'lat': 0, 'text': text},
+        json={'lon': 1, 'lat': 1, 'text': text},
     )
     assert r.is_success, r.text
 

--- a/tests/controllers/test_oauth2.py
+++ b/tests/controllers/test_oauth2.py
@@ -369,7 +369,7 @@ async def test_access_token_in_form(client: AsyncClient, valid_scope):
     # Attempt to create a note using the token in form data
     r = await client.post(
         '/api/0.6/notes',
-        params={'lon': 0, 'lat': 0, 'text': test_access_token_in_form.__qualname__},
+        params={'lon': 1, 'lat': 1, 'text': test_access_token_in_form.__qualname__},
         data={'access_token': access_token},
     )
 

--- a/tests/middlewares/test_request_body_middleware.py
+++ b/tests/middlewares/test_request_body_middleware.py
@@ -78,7 +78,7 @@ async def test_compressed_json(
 
     # Setup test data
     text = f'{test_compressed_json.__qualname__}: {encoding}'
-    content = orjson.dumps({'lon': 0, 'lat': 0, 'text': text})
+    content = orjson.dumps({'lon': 1, 'lat': 1, 'text': text})
 
     # Execute request with compressed JSON
     r = await client.post(
@@ -166,7 +166,7 @@ async def test_passthrough_unsupported_compression(client: AsyncClient):
 
     # Setup test data
     text = 'unknown compression'
-    content = orjson.dumps({'lon': 0, 'lat': 0, 'text': text})
+    content = orjson.dumps({'lon': 1, 'lat': 1, 'text': text})
 
     # Execute request with unsupported compression header
     r = await client.post(
@@ -207,7 +207,7 @@ async def test_size_limit_after_decompression(
 
     # Create data that's small when compressed but exceeds limits when decompressed
     content = compress(
-        orjson.dumps({'lon': 0, 'lat': 0, 'text': 'A' * REQUEST_BODY_MAX_SIZE})
+        orjson.dumps({'lon': 1, 'lat': 1, 'text': 'A' * REQUEST_BODY_MAX_SIZE})
     )
     assert len(content) < REQUEST_BODY_MAX_SIZE, (
         'Compressed content must be under size limit'

--- a/tests/models/test_note_comment.py
+++ b/tests/models/test_note_comment.py
@@ -10,7 +10,7 @@ async def test_note_comments_resolve_rich_text():
     user = await UserQuery.find_by_display_name(DisplayName('user1'))
     with auth_context(user, frozenset(('web_user',))):
         note_id = await NoteService.create(
-            0, 0, test_note_comments_resolve_rich_text.__qualname__
+            1, 1, test_note_comments_resolve_rich_text.__qualname__
         )
         header = await NoteCommentQuery.find_header(note_id)
         assert header is not None


### PR DESCRIPTION
## Summary

Implements null island (0, 0) rejection as described in #128 and the follow-up discussion.

### Changeset uploads
- Counts nodes with coordinates exactly `(0.0, 0.0)` during diff preparation
- Rejects the changeset if **2 or more** null island nodes are found (per @Zaczero's suggestion to allow legitimate single-node edits like the [null island buoy](https://www.openstreetmap.org/node/3815077900))
- Returns HTTP 422 with a descriptive error message

### Note creation
- Rejects note creation at exactly `(0, 0)` coordinates
- Returns HTTP 422 with a descriptive error message

### Moderator bypass
Both restrictions are bypassed for moderators and administrators.

### Changes
- `app/exceptions/diff_mixin.py` — Added abstract `diff_null_island()` method
- `app/exceptions06/diff_mixin.py` — Implemented `diff_null_island()` with 422 error
- `app/exceptions/note_mixin.py` — Added abstract `note_null_island()` method
- `app/exceptions06/note_mixin.py` — Implemented `note_null_island()` with 422 error
- `app/services/optimistic_diff/prepare.py` — Added null island count check after element processing loop
- `app/services/note_service.py` — Added null island check in `create()`

Closes #128