### PR TITLE
feat: implement edit_help=1 tutorial redirect

### DIFF
--- a/app/views/lib/map/main-map.ts
+++ b/app/views/lib/map/main-map.ts
@@ -137,5 +137,11 @@ const configureMainMap = (container: HTMLElement) => {
     handleEditRemotePath()
 }
 
+// Handle edit_help=1 query parameter: redirect logged-in users to the editor walkthrough
+const searchParams = new URLSearchParams(window.location.search)
+if (searchParams.get("edit_help") === "1" && config.userConfig) {
+    window.location.replace("/edit#walkthrough=true")
+}
+
 const mapContainer = document.querySelector("div.main-map")
 if (mapContainer) configureMainMap(mapContainer)


### PR DESCRIPTION
## Summary
- When `?edit_help=1` is in the URL and the user is logged in, redirects to `/edit#walkthrough=true`
- This launches the iD editor's built-in walkthrough tutorial (same behavior as the existing OSM website)
- Uses `location.replace()` so the back button doesn't loop back to the redirect
- Anonymous users are unaffected — the `/edit` page requires login, so they'll be prompted naturally
- Links from `welcome.html.jinja`, `banner.html.jinja`, and `fixthemap.html.jinja` that already point to `/?edit_help=1` will now work

## Changes
- `app/views/lib/map/main-map.ts`: 6 lines added — check for `edit_help` query param + `config.userConfig` before map initialization

Closes #28