### PR TITLE
Add TODO comments for SVG/PDF export via render.openstreetmap.org

### DIFF
--- a/app/views/index/sidebar/share.html.jinja
+++ b/app/views/index/sidebar/share.html.jinja
@@ -81,6 +81,9 @@
                     <option value="image/jpeg" data-suffix=".jpg">JPEG</option>
                     <option value="image/png" data-suffix=".png">PNG</option>
                     <option value="image/webp" data-suffix=".webp">WebP</option>
+                    {# TODO: SVG and PDF export requires server-side rendering via
+                       https://render.openstreetmap.org/ since Canvas.toBlob() only
+                       supports raster formats. See #36. #}
                     {# <option value="image/svg+xml" data-suffix=".svg">SVG</option> #}
                     {# <option value="application/pdf" data-suffix=".pdf">PDF</option> #}
                 </select>

--- a/app/views/lib/map/export-image.ts
+++ b/app/views/lib/map/export-image.ts
@@ -142,6 +142,9 @@ export const exportMapImage = async (
     }
 
     // Export the canvas to an image
+    // TODO: Canvas.toBlob() only supports raster formats (JPEG, PNG, WebP).
+    // To support SVG and PDF export, use the render.openstreetmap.org service
+    // for server-side rendering. See https://github.com/openstreetmap-ng/openstreetmap-ng/issues/36
     return new Promise<Blob>((resolve, reject) => {
         exportCanvas.toBlob(
             (blob) => {


### PR DESCRIPTION
## Summary

- Add TODO comments to the export format selector template (`share.html.jinja`) explaining why SVG and PDF options are hidden: `Canvas.toBlob()` only supports raster formats (JPEG, PNG, WebP)
- Add TODO comments to the export image TypeScript module (`export-image.ts`) documenting the planned approach of using `render.openstreetmap.org` for server-side SVG/PDF rendering
- The SVG/PDF `<option>` elements were already commented out in the template; this PR adds the missing documentation explaining why and what the path forward is

Closes #36

## Test plan

- [ ] Verify that the export sidebar still shows only JPEG, PNG, and WebP format options
- [ ] Verify that image export still works correctly for all three raster formats
- [ ] Confirm TODO comments are present in both modified files