### PR TITLE
feat(login): add password visibility toggle

### DIFF
--- a/app/views/user/_login-body.html.jinja
+++ b/app/views/user/_login-body.html.jinja
@@ -26,6 +26,13 @@
                     <input type="password" class="form-control mt-2" data-name="password"
                         autocomplete="current-password" required>
                 </label>
+                <div class="form-check mb-3">
+                    <label class="form-check-label">
+                        <input class="form-check-input" type="checkbox" data-action="toggle-password"
+                            autocomplete="off">
+                        {{ t('profiles.edit.show') }}
+                    </label>
+                </div>
 
                 <div class="d-flex justify-content-between align-items-center mx-1 mb-3">
                     <div class="form-check">

--- a/app/views/user/_login-body.ts
+++ b/app/views/user/_login-body.ts
@@ -25,6 +25,9 @@ if (loginForm) {
         "input[name=display_name_or_email]",
     )!
     const passwordInput = loginForm.querySelector("input[data-name=password]")!
+    const togglePasswordInput = loginForm.querySelector(
+        "input[data-action=toggle-password]",
+    )!
     const rememberInput = loginForm.querySelector("input[name=remember]")!
 
     let conditionalMediationAbort: AbortController | undefined
@@ -210,6 +213,10 @@ if (loginForm) {
             },
         },
     )
+
+    togglePasswordInput.addEventListener("change", () => {
+        passwordInput.type = togglePasswordInput.checked ? "text" : "password"
+    })
 
     // Delegated click handler for login UI actions
     loginForm.addEventListener("click", (e: Event) => {


### PR DESCRIPTION
## Summary
- add a **Show password** checkbox to the shared login form (`_login-body`)
- wire checkbox state to toggle password input type between `password` and `text`
- keep behavior shared for both `/login` page and `#loginModal` flow

## Why
- `#45` discussion explicitly requested a show-password option for usability

## Validation
- `bunx --bun biome check app/views/user/_login-body.ts`

Refs #45
