### PR TITLE
feat(map): add hybrid aerial base layer mode

### DIFF
--- a/app/views/index/sidebar/layers.html.jinja
+++ b/app/views/index/sidebar/layers.html.jinja
@@ -59,6 +59,11 @@
                                 class="vector">{{ t('map.layers.vector') }}</span></label>
                     </li>
 
+                    <li class="base layer" data-layer-id="hybrid">
+                        <div class="map-container"></div>
+                        <label>{{ t('map.layers.liberty' ) }} + {{ t('map.layers.esri_world_imagery' ) }}</label>
+                    </li>
+
                     <li class="base layer mb-1" data-layer-id="hot">
                         <div class="map-container"></div>
                         <label>{{ t('javascripts.map.base.hot' ) }}</label>

--- a/app/views/lib/map/layers/layers.ts
+++ b/app/views/lib/map/layers/layers.ts
@@ -64,6 +64,36 @@ const hotosmCredit = i18next.t("javascripts.map.hotosm_credit", {
 const aerialEsriCredit =
     "Esri, Maxar, Earthstar Geographics, and the GIS User Community"
 
+const libertyHybridStyle = (() => {
+    const vectorOverlayLayers = libertyStyle.layers.filter(
+        ({ type }) => type === "line" || type === "symbol" || type === "circle",
+    )
+
+    return {
+        ...libertyStyle,
+        sources: {
+            aerial_underlay: {
+                type: "raster",
+                maxzoom: 23,
+                tiles: [
+                    "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+                ],
+                tileSize: 256,
+                attribution: aerialEsriCredit,
+            },
+            ...libertyStyle.sources,
+        },
+        layers: [
+            {
+                id: "aerial_underlay",
+                type: "raster",
+                source: "aerial_underlay",
+            },
+            ...vectorOverlayLayers,
+        ],
+    } as StyleSpecification
+})()
+
 export const emptyFeatureCollection: FeatureCollection = {
     type: "FeatureCollection",
     features: [],
@@ -108,6 +138,14 @@ layersConfig.set("liberty" as LayerId, {
     vectorStyle: libertyStyle,
     isBaseLayer: true,
     layerCode: "L" as LayerCode,
+})
+
+layersConfig.set("hybrid" as LayerId, {
+    specification: { type: "vector" },
+    // @ts-expect-error
+    vectorStyle: libertyHybridStyle,
+    isBaseLayer: true,
+    layerCode: "I" as LayerCode,
 })
 
 layersConfig.set("cyclosm" as LayerId, {


### PR DESCRIPTION
## Summary
- add a new base map mode `hybrid` in the Layers sidebar
- implement hybrid style as:
  - Esri World Imagery raster underlay (100% opacity)
  - Liberty vector overlays limited to `line` / `symbol` / `circle` layers
- intentionally exclude polygon/background fill layers from the Liberty overlay set (so landuse-style fills do not cover imagery)

## Why
- addresses #182: "hybrid" aerial mode where imagery is the base and key vector features remain visible on top.

## Validation
- `bunx --bun biome check app/views/lib/map/layers/layers.ts app/views/index/sidebar/layers.html.jinja`

Refs #182
