### PR TITLE
Append #osm-ng hashtag when creating notes from web UI

### DIFF
--- a/app/controllers/web_note.py
+++ b/app/controllers/web_note.py
@@ -1,6 +1,7 @@
 from asyncio import TaskGroup
 from typing import Annotated, Literal
 
+import re2
 from fastapi import APIRouter, Form, Query, Response
 from psycopg.sql import SQL
 from starlette import status
@@ -37,6 +38,16 @@ from app.services.note_service import NoteService
 from app.utils import id_response
 
 router = APIRouter(prefix='/api/web/note')
+_NOTE_SOURCE_HASHTAG = '#osm-ng'
+_NOTE_SOURCE_HASHTAG_RE = re2.compile(r'(?i)(^|\s)#osm-ng(?=\s|$)')
+
+
+def _append_note_source_hashtag(text: str) -> str:
+    if _NOTE_SOURCE_HASHTAG_RE.search(text):
+        return text
+
+    separator = '' if text.endswith('\n') else '\n'
+    return f'{text}{separator}{_NOTE_SOURCE_HASHTAG}'
 
 
 @router.post('')
@@ -45,7 +56,7 @@ async def create_note(
     lat: Annotated[Latitude, Form()],
     text: Annotated[str, Form(min_length=1, max_length=NOTE_COMMENT_BODY_MAX_LENGTH)],
 ):
-    note_id = await NoteService.create(lon, lat, text)
+    note_id = await NoteService.create(lon, lat, _append_note_source_hashtag(text))
     return id_response(note_id)
 
 

--- a/tests/controllers/test_api06_note.py
+++ b/tests/controllers/test_api06_note.py
@@ -3,6 +3,7 @@ from random import uniform
 
 import pytest
 from annotated_types import Len
+from app.models.proto.shared_pb2 import IdResponse
 from httpx import AsyncClient
 from pydantic import PositiveInt
 from starlette import status
@@ -108,6 +109,58 @@ async def test_note_create_anonymous(client: AsyncClient):
         },
     )
     assert 'user' not in props['comments'][0]
+
+
+async def test_web_note_create_appends_osm_ng_hashtag(client: AsyncClient):
+    body = test_web_note_create_appends_osm_ng_hashtag.__qualname__
+
+    r = await client.post(
+        '/api/web/note',
+        data={'lon': 0, 'lat': 0, 'text': body},
+    )
+    assert r.is_success, r.text
+
+    id_response = IdResponse()
+    id_response.ParseFromString(r.content)
+    note_id = id_response.id
+    assert note_id > 0
+
+    r = await client.get(f'/api/0.6/notes/{note_id}.json')
+    assert r.is_success, r.text
+    props = r.json()['properties']
+    assert_model(
+        props['comments'][0],
+        {
+            'action': 'opened',
+            'text': f'{body}\n#osm-ng',
+        },
+    )
+
+
+async def test_web_note_create_does_not_duplicate_osm_ng_hashtag(client: AsyncClient):
+    body = f'{test_web_note_create_does_not_duplicate_osm_ng_hashtag.__qualname__}\n#osm-ng'
+
+    r = await client.post(
+        '/api/web/note',
+        data={'lon': 0, 'lat': 0, 'text': body},
+    )
+    assert r.is_success, r.text
+
+    id_response = IdResponse()
+    id_response.ParseFromString(r.content)
+    note_id = id_response.id
+    assert note_id > 0
+
+    r = await client.get(f'/api/0.6/notes/{note_id}.json')
+    assert r.is_success, r.text
+    props = r.json()['properties']
+    assert_model(
+        props['comments'][0],
+        {
+            'action': 'opened',
+            'text': body,
+        },
+    )
 
 
 async def test_note_crud(client: AsyncClient):


### PR DESCRIPTION
## Summary
- append `#osm-ng` to note text when creating notes via `/api/web/note`
- keep existing hashtag unchanged when the text already contains `#osm-ng` (case-insensitive)
- add regression tests covering append and no-duplicate behavior

Fixes #76

## Validation
- `uvx ruff check app/controllers/web_note.py tests/controllers/test_api06_note.py`
- full pytest run is currently blocked in this local sparse/dev setup because generated protobuf python modules are absent (`app.models.proto.server_pb2`)
