### PR TITLE
feat: better mailbox tools — search, selection, and bulk actions

### DIFF
--- a/app/controllers/web_messages.py
+++ b/app/controllers/web_messages.py
@@ -1,7 +1,7 @@
 from asyncio import TaskGroup
 from typing import Annotated
 
-from fastapi import APIRouter, Form, Response
+from fastapi import APIRouter, Form, Query, Response
 from psycopg.sql import SQL
 from starlette import status
 
@@ -129,24 +129,100 @@ async def delete_message(
     return Response(None, status.HTTP_204_NO_CONTENT)
 
 
+@router.post('/bulk/read')
+async def bulk_mark_read(
+    _: Annotated[User, web_user()],
+    message_id: Annotated[list[int], Form(min_length=1)],
+):
+    await MessageService.bulk_set_state(
+        [MessageId(mid) for mid in message_id], read=True
+    )
+    return Response(None, status.HTTP_204_NO_CONTENT)
+
+
+@router.post('/bulk/unread')
+async def bulk_mark_unread(
+    _: Annotated[User, web_user()],
+    message_id: Annotated[list[int], Form(min_length=1)],
+):
+    await MessageService.bulk_set_state(
+        [MessageId(mid) for mid in message_id], read=False
+    )
+    return Response(None, status.HTTP_204_NO_CONTENT)
+
+
+@router.post('/bulk/delete')
+async def bulk_delete(
+    _: Annotated[User, web_user()],
+    message_id: Annotated[list[int], Form(min_length=1)],
+):
+    count = await MessageService.bulk_delete_messages(
+        [MessageId(mid) for mid in message_id]
+    )
+    return {'deleted': count}
+
+
+def _build_search_conditions(
+    q: str | None,
+    after: str | None,
+    before: str | None,
+) -> tuple[list[SQL], list[object]]:
+    """Build additional WHERE conditions from search/filter parameters."""
+    conditions: list[SQL] = []
+    params: list[object] = []
+
+    if q:
+        conditions.append(SQL("""
+            (subject ILIKE %s OR body ILIKE %s
+             OR EXISTS (
+                SELECT 1 FROM "user"
+                WHERE "user".id = from_user_id
+                AND "user".display_name ILIKE %s
+             ))
+        """))
+        escaped = q.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
+        pattern = f'%{escaped}%'
+        params.extend((pattern, pattern, pattern))
+
+    if after:
+        conditions.append(SQL('created_at >= %s::timestamptz'))
+        params.append(after)
+
+    if before:
+        conditions.append(SQL('created_at < %s::timestamptz'))
+        params.append(before)
+
+    return conditions, params
+
+
 @router.post('/inbox')
 async def inbox_page(
     user: Annotated[User, web_user()],
+    q: Annotated[str | None, Query(max_length=200)] = None,
+    after: Annotated[str | None, Query()] = None,
+    before: Annotated[str | None, Query()] = None,
     sp_state: StandardPaginationStateBody = b'',
 ):
+    base_conditions = [SQL("""
+        EXISTS (
+            SELECT 1 FROM message_recipient
+            WHERE message_id = id
+              AND user_id = %s
+              AND NOT hidden
+        )
+    """)]
+    base_params: list[object] = [user['id']]
+
+    search_conditions, search_params = _build_search_conditions(q, after, before)
+    all_conditions = base_conditions + search_conditions
+    all_params = base_params + search_params
+
     messages, state = await sp_paginate_table(
         Message,
         sp_state,
         table='message',
-        where=SQL("""
-            EXISTS (
-                SELECT 1 FROM message_recipient
-                WHERE message_id = id
-                  AND user_id = %s
-                  AND NOT hidden
-            )
-        """),
-        params=(user['id'],),
+        where=SQL(' AND ').join(all_conditions),
+        params=tuple(all_params),
         page_size=MESSAGES_INBOX_PAGE_SIZE,
         cursor_column='id',
         cursor_kind='id',
@@ -183,14 +259,24 @@ async def inbox_page(
 @router.post('/outbox')
 async def outbox_page(
     user: Annotated[User, web_user()],
+    q: Annotated[str | None, Query(max_length=200)] = None,
+    after: Annotated[str | None, Query()] = None,
+    before: Annotated[str | None, Query()] = None,
     sp_state: StandardPaginationStateBody = b'',
 ):
+    base_conditions = [SQL('from_user_id = %s AND NOT from_user_hidden')]
+    base_params: list[object] = [user['id']]
+
+    search_conditions, search_params = _build_search_conditions(q, after, before)
+    all_conditions = base_conditions + search_conditions
+    all_params = base_params + search_params
+
     messages, state = await sp_paginate_table(
         Message,
         sp_state,
         table='message',
-        where=SQL('from_user_id = %s AND NOT from_user_hidden'),
-        params=(user['id'],),
+        where=SQL(' AND ').join(all_conditions),
+        params=tuple(all_params),
         page_size=MESSAGES_INBOX_PAGE_SIZE,
         cursor_column='id',
         cursor_kind='id',

--- a/app/services/message_service.py
+++ b/app/services/message_service.py
@@ -210,6 +210,97 @@ class MessageService:
                 )
                 # message_recipient is deleted by cascade
 
+    @staticmethod
+    async def bulk_set_state(message_ids: list[MessageId], *, read: bool) -> int:
+        """Mark multiple messages as read or unread."""
+        if not message_ids:
+            return 0
+
+        user_id = auth_user(required=True)['id']
+
+        async with db(True) as conn:
+            result = await conn.execute(
+                """
+                UPDATE message_recipient
+                SET read = %s
+                WHERE message_id = ANY(%s)
+                AND user_id = %s
+                AND NOT hidden
+                """,
+                (read, message_ids, user_id),
+            )
+            return result.rowcount
+
+    @staticmethod
+    async def bulk_delete_messages(message_ids: list[MessageId]) -> int:
+        """Delete multiple messages. Returns number of messages processed."""
+        if not message_ids:
+            return 0
+
+        user_id = auth_user(required=True)['id']
+        count = 0
+
+        async with db(True) as conn:
+            # Lock all messages at once
+            async with await conn.execute(
+                """
+                SELECT id, from_user_id FROM message
+                WHERE id = ANY(%s)
+                FOR UPDATE
+                """,
+                (message_ids,),
+            ) as r:
+                rows = await r.fetchall()
+
+            sender_ids: list[MessageId] = []
+            recipient_ids: list[MessageId] = []
+            for row in rows:
+                mid, from_user_id = row
+                if from_user_id == user_id:
+                    sender_ids.append(mid)
+                else:
+                    recipient_ids.append(mid)
+
+            # Hide from sender view
+            if sender_ids:
+                result = await conn.execute(
+                    """
+                    UPDATE message SET from_user_hidden = TRUE
+                    WHERE id = ANY(%s) AND NOT from_user_hidden
+                    """,
+                    (sender_ids,),
+                )
+                count += result.rowcount
+
+            # Hide from recipient view
+            if recipient_ids:
+                result = await conn.execute(
+                    """
+                    UPDATE message_recipient SET hidden = TRUE
+                    WHERE message_id = ANY(%s) AND user_id = %s AND NOT hidden
+                    """,
+                    (recipient_ids, user_id),
+                )
+                count += result.rowcount
+
+            # Clean up messages where no one has access anymore
+            all_ids = sender_ids + recipient_ids
+            if all_ids:
+                await conn.execute(
+                    """
+                    DELETE FROM message
+                    WHERE id = ANY(%s)
+                    AND from_user_hidden
+                    AND NOT EXISTS (
+                        SELECT 1 FROM message_recipient
+                        WHERE message_id = message.id AND NOT hidden
+                    )
+                    """,
+                    (all_ids,),
+                )
+
+        return count
+
 
 async def _send_activity_email(message: Message) -> None:
     assert 'recipients' in message, 'Message recipients must be set'

--- a/app/views/messages/index.scss
+++ b/app/views/messages/index.scss
@@ -5,6 +5,32 @@
         }
     }
 
+    .messages-search {
+        .input-group {
+            max-width: 100%;
+        }
+    }
+
+    .bulk-action-bar {
+        border: 1px solid var(--bs-border-color);
+    }
+
+    .social-entry {
+        &.selected {
+            background-color: var(--bs-primary-bg-subtle);
+        }
+
+        .message-checkbox {
+            flex-shrink: 0;
+            position: relative;
+            z-index: 2;
+
+            .form-check-input {
+                cursor: pointer;
+            }
+        }
+    }
+
     .message-preview {
         border: unset;
 

--- a/app/views/messages/index.tsx
+++ b/app/views/messages/index.tsx
@@ -41,6 +41,20 @@ const getMessageFromPageUrl = () => {
   }
 }
 
+const buildActionUrl = (
+  baseAction: string,
+  query: string,
+  dateAfter: string,
+  dateBefore: string,
+) => {
+  const params = new URLSearchParams()
+  if (query) params.set("q", query)
+  if (dateAfter) params.set("after", dateAfter)
+  if (dateBefore) params.set("before", dateBefore)
+  const qs = params.toString()
+  return qs ? `${baseAction}?${qs}` : baseAction
+}
+
 const summaryUserLink = (user: MessagePage_Summary_User) => (
   <a href={`/user/${user.displayName}`}>
     <img
@@ -89,12 +103,16 @@ const MessagesListItem = ({
   message,
   inbox,
   openMessageId,
+  selected,
   onOpen,
+  onToggleSelect,
 }: {
   message: MessagePage_Summary
   inbox: boolean
   openMessageId: bigint | null
+  selected: boolean
   onOpen: (messageId: bigint) => void
+  onToggleSelect: (messageId: bigint) => void
 }) => {
   const messageId = message.id
   const isUnread = inbox && message.unread
@@ -118,48 +136,65 @@ const MessagesListItem = ({
     onOpen(messageId)
   }
 
+  const handleCheckbox = (event: Event) => {
+    event.stopPropagation()
+    onToggleSelect(messageId)
+  }
+
   return (
     <li
-      class={`social-entry clickable ${isUnread ? "unread" : ""} ${
-        isActive ? "active" : ""
-      }`}
+      class={`social-entry clickable ${isUnread ? "unread" : ""} ${isActive ? "active" : ""} ${selected ? "selected" : ""}`}
     >
-      <p class="header text-muted d-flex justify-content-between">
-        {inbox ? (
-          <span>
-            {summaryUserLink(message.sender!)} {t("messages.action_sent")}{" "}
-            <Time
-              unix={message.time}
-              relativeStyle="long"
-            />
-          </span>
-        ) : (
-          <span>
-            {summaryRecipients(message)} {t("messages.action_delivered")}{" "}
-            <Time
-              unix={message.time}
-              relativeStyle="long"
-            />
-          </span>
-        )}
-        <span>
-          <a
-            class="stretched-link"
-            href={`?show=${messageId}`}
-            onClick={handleOpen}
-            onKeyDown={handleOpen}
-          >
-            <span class="visually-hidden">{message.subject}</span>
-          </a>
-          <span class="unread-badge badge text-bg-primary">
-            <i class="bi bi-bell-fill me-1" />
-            {t("state.unread")}
-          </span>
-        </span>
-      </p>
-      <div class="body">
-        <h6 class="title">{message.subject}</h6>
-        <p class="description">{message.bodyPreview}</p>
+      <div class="d-flex align-items-start">
+        <div class="message-checkbox me-2 mt-1">
+          <input
+            type="checkbox"
+            class="form-check-input"
+            checked={selected}
+            onChange={handleCheckbox}
+            onClick={(e) => e.stopPropagation()}
+            aria-label={message.subject}
+          />
+        </div>
+        <div class="flex-grow-1 min-w-0">
+          <p class="header text-muted d-flex justify-content-between">
+            {inbox ? (
+              <span>
+                {summaryUserLink(message.sender!)} {t("messages.action_sent")}{" "}
+                <Time
+                  unix={message.time}
+                  relativeStyle="long"
+                />
+              </span>
+            ) : (
+              <span>
+                {summaryRecipients(message)} {t("messages.action_delivered")}{" "}
+                <Time
+                  unix={message.time}
+                  relativeStyle="long"
+                />
+              </span>
+            )}
+            <span>
+              <a
+                class="stretched-link"
+                href={`?show=${messageId}`}
+                onClick={handleOpen}
+                onKeyDown={handleOpen}
+              >
+                <span class="visually-hidden">{message.subject}</span>
+              </a>
+              <span class="unread-badge badge text-bg-primary">
+                <i class="bi bi-bell-fill me-1" />
+                {t("state.unread")}
+              </span>
+            </span>
+          </p>
+          <div class="body">
+            <h6 class="title">{message.subject}</h6>
+            <p class="description">{message.bodyPreview}</p>
+          </div>
+        </div>
       </div>
     </li>
   )
@@ -344,11 +379,189 @@ const MessagePreview = ({
   )
 }
 
+const SearchBar = ({
+  onSearch,
+}: {
+  onSearch: (query: string, dateAfter: string, dateBefore: string) => void
+}) => {
+  const queryRef = useRef<HTMLInputElement>(null)
+  const dateAfterRef = useRef<HTMLInputElement>(null)
+  const dateBeforeRef = useRef<HTMLInputElement>(null)
+  const expanded = useSignal(false)
+
+  const handleSubmit = (event: Event) => {
+    event.preventDefault()
+    onSearch(
+      queryRef.current?.value ?? "",
+      dateAfterRef.current?.value ?? "",
+      dateBeforeRef.current?.value ?? "",
+    )
+  }
+
+  const handleClear = () => {
+    if (queryRef.current) queryRef.current.value = ""
+    if (dateAfterRef.current) dateAfterRef.current.value = ""
+    if (dateBeforeRef.current) dateBeforeRef.current.value = ""
+    expanded.value = false
+    onSearch("", "", "")
+  }
+
+  return (
+    <form
+      class="messages-search mb-3"
+      onSubmit={handleSubmit}
+    >
+      <div class="input-group">
+        <input
+          type="text"
+          class="form-control"
+          placeholder={t("messages.search_placeholder")}
+          ref={queryRef}
+          aria-label={t("messages.search_placeholder")}
+        />
+        <button
+          class="btn btn-outline-secondary"
+          type="button"
+          onClick={() => {
+            expanded.value = !expanded.value
+          }}
+          title={t("messages.date_after")}
+        >
+          <i class="bi bi-calendar-range" />
+        </button>
+        <button
+          class="btn btn-outline-secondary"
+          type="submit"
+        >
+          <i class="bi bi-search" />
+        </button>
+      </div>
+      {expanded.value && (
+        <div class="row g-2 mt-2">
+          <div class="col-sm-6">
+            <label class="form-label small text-muted mb-1">
+              {t("messages.date_after")}
+            </label>
+            <input
+              type="date"
+              class="form-control form-control-sm"
+              ref={dateAfterRef}
+            />
+          </div>
+          <div class="col-sm-6">
+            <label class="form-label small text-muted mb-1">
+              {t("messages.date_before")}
+            </label>
+            <input
+              type="date"
+              class="form-control form-control-sm"
+              ref={dateBeforeRef}
+            />
+          </div>
+        </div>
+      )}
+      <div class="mt-2 d-flex gap-2">
+        <button
+          class="btn btn-sm btn-link text-muted p-0"
+          type="button"
+          onClick={handleClear}
+        >
+          {t("action.reset_filters")}
+        </button>
+      </div>
+    </form>
+  )
+}
+
+const BulkActionBar = ({
+  selectedCount,
+  inbox,
+  totalVisible,
+  onSelectAll,
+  onDeselectAll,
+  onBulkRead,
+  onBulkUnread,
+  onBulkDelete,
+}: {
+  selectedCount: number
+  inbox: boolean
+  totalVisible: number
+  onSelectAll: () => void
+  onDeselectAll: () => void
+  onBulkRead: () => void
+  onBulkUnread: () => void
+  onBulkDelete: () => void
+}) => {
+  if (selectedCount === 0) return null
+
+  const allSelected = selectedCount === totalVisible && totalVisible > 0
+
+  return (
+    <div class="bulk-action-bar d-flex align-items-center gap-2 mb-2 p-2 bg-body-secondary rounded">
+      <span class="fw-medium small">
+        {t("messages.selected_count", { count: selectedCount })}
+      </span>
+      <button
+        class="btn btn-sm btn-outline-secondary"
+        type="button"
+        onClick={allSelected ? onDeselectAll : onSelectAll}
+      >
+        {allSelected ? t("messages.deselect_all") : t("messages.select_all")}
+      </button>
+      <div class="vr" />
+      {inbox && (
+        <>
+          <button
+            class="btn btn-sm btn-soft"
+            type="button"
+            onClick={onBulkRead}
+          >
+            <i class="bi bi-envelope-open me-1" />
+            {t("messages.mark_read")}
+          </button>
+          <button
+            class="btn btn-sm btn-soft"
+            type="button"
+            onClick={onBulkUnread}
+          >
+            <i class="bi bi-envelope me-1" />
+            {t("messages.mark_unread")}
+          </button>
+        </>
+      )}
+      <button
+        class="btn btn-sm btn-soft text-danger"
+        type="button"
+        onClick={onBulkDelete}
+      >
+        <i class="bi bi-trash me-1" />
+        {t("messages.message_summary.destroy_button")}
+      </button>
+    </div>
+  )
+}
+
 const MessagesIndex = ({ inbox, action }: { inbox: boolean; action: string }) => {
   const messages = useSignal<MessagePage_Summary[]>([])
   const openMessageId = useSignal<bigint | null>(null)
   const previewState = useSignal<PreviewState>({ status: "closed" })
   const previewRef = useRef<HTMLDivElement>(null)
+
+  // Search state
+  const searchQuery = useSignal("")
+  const searchDateAfter = useSignal("")
+  const searchDateBefore = useSignal("")
+  const searchKey = useSignal(0)
+
+  // Selection state: persists across page navigations
+  const selectedIds = useSignal<Set<bigint>>(new Set())
+
+  const currentAction = buildActionUrl(
+    action,
+    searchQuery.value,
+    searchDateAfter.value,
+    searchDateBefore.value,
+  )
 
   const updateMessageUnread = (messageId: bigint, unread: boolean) => {
     messages.value = messages.value.map((message) => {
@@ -360,6 +573,16 @@ const MessagesIndex = ({ inbox, action }: { inbox: boolean; action: string }) =>
 
   const removeMessage = (messageId: bigint) => {
     messages.value = messages.value.filter((message) => message.id !== messageId)
+    const next = new Set(selectedIds.value)
+    next.delete(messageId)
+    selectedIds.value = next
+  }
+
+  const removeMessages = (ids: Set<bigint>) => {
+    messages.value = messages.value.filter((message) => !ids.has(message.id))
+    const next = new Set(selectedIds.value)
+    for (const id of ids) next.delete(id)
+    selectedIds.value = next
   }
 
   const openMessage = (messageId: bigint) => {
@@ -382,6 +605,32 @@ const MessagesIndex = ({ inbox, action }: { inbox: boolean; action: string }) =>
   const closeMessage = () => {
     openMessageId.value = null
     updatePageUrl(null)
+  }
+
+  const toggleSelect = (messageId: bigint) => {
+    const next = new Set(selectedIds.value)
+    if (next.has(messageId)) next.delete(messageId)
+    else next.add(messageId)
+    selectedIds.value = next
+  }
+
+  const selectAllVisible = () => {
+    const next = new Set(selectedIds.value)
+    for (const msg of messages.value) next.add(msg.id)
+    selectedIds.value = next
+  }
+
+  const deselectAll = () => {
+    selectedIds.value = new Set()
+  }
+
+  const handleSearch = (query: string, dateAfter: string, dateBefore: string) => {
+    searchQuery.value = query
+    searchDateAfter.value = dateAfter
+    searchDateBefore.value = dateBefore
+    searchKey.value += 1
+    selectedIds.value = new Set()
+    closeMessage()
   }
 
   const markMessageUnread = async () => {
@@ -416,6 +665,87 @@ const MessagesIndex = ({ inbox, action }: { inbox: boolean; action: string }) =>
       closeMessage()
     } catch (error) {
       console.error("Messages: Failed to delete", messageId, error)
+      alert(error.message)
+    }
+  }
+
+  // Bulk actions
+  const bulkMarkRead = async () => {
+    const ids = [...selectedIds.value]
+    if (!ids.length) return
+    try {
+      const body = new URLSearchParams()
+      for (const id of ids) body.append("message_id", id.toString())
+      const resp = await fetch("/api/web/messages/bulk/read", {
+        method: "POST",
+        body,
+        priority: "high",
+      })
+      assert(resp.ok, `${resp.status} ${resp.statusText}`)
+
+      // Count how many were actually unread before marking
+      let unreadCount = 0
+      messages.value = messages.value.map((msg) => {
+        if (!selectedIds.value.has(msg.id)) return msg
+        if (msg.unread) unreadCount++
+        return msg.unread ? { ...msg, unread: false } : msg
+      })
+      if (unreadCount) changeUnreadMessagesBadge(-unreadCount)
+      selectedIds.value = new Set()
+    } catch (error) {
+      console.error("Messages: Failed to bulk mark read", error)
+      alert(error.message)
+    }
+  }
+
+  const bulkMarkUnread = async () => {
+    const ids = [...selectedIds.value]
+    if (!ids.length) return
+    try {
+      const body = new URLSearchParams()
+      for (const id of ids) body.append("message_id", id.toString())
+      const resp = await fetch("/api/web/messages/bulk/unread", {
+        method: "POST",
+        body,
+        priority: "high",
+      })
+      assert(resp.ok, `${resp.status} ${resp.statusText}`)
+
+      let readCount = 0
+      messages.value = messages.value.map((msg) => {
+        if (!selectedIds.value.has(msg.id)) return msg
+        if (!msg.unread) readCount++
+        return !msg.unread ? { ...msg, unread: true } : msg
+      })
+      if (readCount) changeUnreadMessagesBadge(readCount)
+      selectedIds.value = new Set()
+    } catch (error) {
+      console.error("Messages: Failed to bulk mark unread", error)
+      alert(error.message)
+    }
+  }
+
+  const bulkDelete = async () => {
+    const ids = [...selectedIds.value]
+    if (!ids.length) return
+    if (
+      !confirm(t("messages.bulk_delete_confirmation", { count: ids.length }))
+    )
+      return
+    try {
+      const body = new URLSearchParams()
+      for (const id of ids) body.append("message_id", id.toString())
+      const resp = await fetch("/api/web/messages/bulk/delete", {
+        method: "POST",
+        body,
+        priority: "high",
+      })
+      assert(resp.ok, `${resp.status} ${resp.statusText}`)
+      const removed = new Set(ids.map((id) => BigInt(id)))
+      removeMessages(removed)
+      closeMessage()
+    } catch (error) {
+      console.error("Messages: Failed to bulk delete", error)
       alert(error.message)
     }
   }
@@ -467,12 +797,26 @@ const MessagesIndex = ({ inbox, action }: { inbox: boolean; action: string }) =>
     previewRef.current?.scrollIntoView({ behavior: "smooth", block: "start" })
   })
 
+  const selectedCount = selectedIds.value.size
+
   return (
     <div class="row flex-wrap-reverse">
       <div class="col-lg">
+        <SearchBar onSearch={handleSearch} />
+        <BulkActionBar
+          selectedCount={selectedCount}
+          inbox={inbox}
+          totalVisible={messages.value.length}
+          onSelectAll={selectAllVisible}
+          onDeselectAll={deselectAll}
+          onBulkRead={bulkMarkRead}
+          onBulkUnread={bulkMarkUnread}
+          onBulkDelete={bulkDelete}
+        />
         <div>
           <StandardPagination
-            action={action}
+            key={searchKey.value}
+            action={currentAction}
             protobuf={MessagePageSchema}
             onLoad={(data) => {
               messages.value = data.messages
@@ -495,7 +839,9 @@ const MessagesIndex = ({ inbox, action }: { inbox: boolean; action: string }) =>
                       message={message}
                       inbox={inbox}
                       openMessageId={openMessageId.value}
+                      selected={selectedIds.value.has(message.id)}
                       onOpen={openMessage}
+                      onToggleSelect={toggleSelect}
                       key={message.id}
                     />
                   ))

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -158,6 +158,7 @@ follows:
 messages:
   description: Your private messages with other map users.
   delete_confirmation: Are you sure you want to delete this message?
+  bulk_delete_confirmation: Are you sure you want to delete {{count}} selected messages?
   action_sent: sent
   action_delivered: delivered
   user_sent_you_a_message_on_platform_subject: "{user} sent you a message on {platform}: {subject}"
@@ -165,6 +166,15 @@ messages:
   user_sent_you_and_others_a_message_on_platform_subject_other: "{user} sent you and {count} others a message on {platform}: {subject}"
   to_prefix: To
   reply_all: Reply all
+  search_placeholder: Search by user or subject
+  date_after: After
+  date_before: Before
+  selected_count_one: "{{count}} selected"
+  selected_count_other: "{{count}} selected"
+  select_all: Select all
+  deselect_all: Deselect all
+  mark_read: Mark read
+  mark_unread: Mark unread
   compose:
     description: Send a new private message to another map user.
     recipients: Recipients

--- a/tests/controllers/test_web_messages.py
+++ b/tests/controllers/test_web_messages.py
@@ -16,6 +16,20 @@ from app.queries.user_query import UserQuery
 from tests.utils.assert_model import assert_model
 
 
+async def _send_message(
+    client: AsyncClient, subject: str, body: str, recipient: str
+) -> MessageId:
+    """Helper to send a message and return its ID."""
+    r = await client.post(
+        '/api/web/messages',
+        data={'subject': subject, 'body': body, 'recipient': recipient},
+    )
+    assert r.is_success, r.text
+    parsed_url = urlsplit(r.json()['redirect_url'])
+    query_params = parse_qs(parsed_url.query, strict_parsing=True)
+    return MessageId(int(query_params['show'][0]))
+
+
 async def test_message_crud(client: AsyncClient):
     user1 = await UserQuery.find_by_display_name(DisplayName('user1'))
 
@@ -118,3 +132,91 @@ async def test_message_crud(client: AsyncClient):
 
         with pytest.raises(APIError, match='Message not found'):
             await MessageQuery.get_by_id(message_id)
+
+
+async def test_bulk_mark_read(client: AsyncClient):
+    client.headers['Authorization'] = 'User user1'
+    mid1 = await _send_message(client, 'Bulk Read 1', 'Body 1', 'user2')
+    mid2 = await _send_message(client, 'Bulk Read 2', 'Body 2', 'user2')
+
+    # Switch to recipient
+    client.headers['Authorization'] = 'User user2'
+
+    # Bulk mark as read
+    r = await client.post(
+        '/api/web/messages/bulk/read',
+        data={'message_id': [str(mid1), str(mid2)]},
+    )
+    assert r.status_code == status.HTTP_204_NO_CONTENT
+
+    # Verify both are read
+    user2 = await UserQuery.find_by_display_name(DisplayName('user2'))
+    with auth_context(user2):
+        m1 = await MessageQuery.get_by_id(mid1)
+        m2 = await MessageQuery.get_by_id(mid2)
+        assert m1['recipients'][0]['read']  # type: ignore
+        assert m2['recipients'][0]['read']  # type: ignore
+
+
+async def test_bulk_mark_unread(client: AsyncClient):
+    client.headers['Authorization'] = 'User user1'
+    mid1 = await _send_message(client, 'Bulk Unread 1', 'Body 1', 'user2')
+
+    # Switch to recipient and read the message first
+    client.headers['Authorization'] = 'User user2'
+    r = await client.get(f'/api/web/messages/{mid1}')
+    assert r.is_success
+
+    # Bulk mark as unread
+    r = await client.post(
+        '/api/web/messages/bulk/unread',
+        data={'message_id': [str(mid1)]},
+    )
+    assert r.status_code == status.HTTP_204_NO_CONTENT
+
+    # Verify it is unread
+    user2 = await UserQuery.find_by_display_name(DisplayName('user2'))
+    with auth_context(user2):
+        m = await MessageQuery.get_by_id(mid1)
+        assert not m['recipients'][0]['read']  # type: ignore
+
+
+async def test_bulk_delete(client: AsyncClient):
+    client.headers['Authorization'] = 'User user1'
+    mid1 = await _send_message(client, 'Bulk Del 1', 'Body 1', 'user2')
+    mid2 = await _send_message(client, 'Bulk Del 2', 'Body 2', 'user2')
+
+    # Switch to recipient
+    client.headers['Authorization'] = 'User user2'
+
+    # Bulk delete
+    r = await client.post(
+        '/api/web/messages/bulk/delete',
+        data={'message_id': [str(mid1), str(mid2)]},
+    )
+    assert r.is_success
+    assert r.json()['deleted'] == 2
+
+    # Verify messages are hidden from recipient
+    r = await client.get(f'/api/web/messages/{mid1}')
+    assert r.status_code == status.HTTP_404_NOT_FOUND
+    r = await client.get(f'/api/web/messages/{mid2}')
+    assert r.status_code == status.HTTP_404_NOT_FOUND
+
+
+async def test_inbox_search(client: AsyncClient):
+    client.headers['Authorization'] = 'User user1'
+    await _send_message(client, 'Unique Search Subject XYZ', 'Body', 'user2')
+    await _send_message(client, 'Another Message', 'Body', 'user2')
+
+    # Switch to recipient
+    client.headers['Authorization'] = 'User user2'
+
+    # Search by subject
+    r = await client.post(
+        '/api/web/messages/inbox?q=Unique+Search+Subject',
+        headers={'Content-Type': 'application/x-protobuf'},
+        content=b'',
+    )
+    assert r.is_success
+    assert 'X-StandardPagination' in r.headers


### PR DESCRIPTION
## Summary

Adds advanced mailbox tools as described in #165:

- **Search**: filter messages by user, subject, or body text with a search bar; ILIKE with proper escaping for special characters
- **Date range filter**: collapsible date picker to filter messages by date (after/before)
- **Message selection**: per-message checkboxes with select all / deselect all
- **Bulk actions**: mark selected messages as read/unread, delete selected messages
- **Selection persistence**: selected message IDs are preserved across page navigations
- **Search resets pagination**: changing search terms forces a fresh pagination state

### Backend changes
- `POST /api/web/messages/bulk/read` — bulk mark as read
- `POST /api/web/messages/bulk/unread` — bulk mark as unread
- `POST /api/web/messages/bulk/delete` — bulk delete
- `?q=`, `?after=`, `?before=` query params on inbox/outbox endpoints
- `MessageService.bulk_set_state()` and `MessageService.bulk_delete_messages()` methods

### Frontend changes
- `SearchBar` component with collapsible date range filter
- `BulkActionBar` component showing selected count and action buttons
- Per-message checkboxes integrated into the existing list items
- Selection state management via Preact signals (persists across pages)

### Not yet implemented (future increments per issue description)
- Delete old messages by configurable age (e.g., "Older than 3 weeks")

Fixes #165

/claim #165

## Test plan
- [ ] Verify search by subject returns matching messages
- [ ] Verify search by user name returns matching messages
- [ ] Verify date range filter works correctly
- [ ] Verify selecting individual messages via checkboxes
- [ ] Verify "Select all" selects all visible messages
- [ ] Verify bulk "Mark read" marks selected messages as read
- [ ] Verify bulk "Mark unread" marks selected messages as unread
- [ ] Verify bulk "Delete" deletes selected messages with confirmation
- [ ] Verify selection persists across page navigations
- [ ] Verify changing search terms resets pagination and selection
- [ ] Run existing test suite: `test_web_messages`, `test_web_messages_pagination`
- [ ] Run new tests: `test_bulk_mark_read`, `test_bulk_mark_unread`, `test_bulk_delete`, `test_inbox_search`