### PR TITLE
fix: return validation error for unreadable avatar uploads

### DIFF
--- a/app/lib/image.py
+++ b/app/lib/image.py
@@ -9,7 +9,8 @@ from typing import TYPE_CHECKING, Literal, NamedTuple, overload
 
 import cython
 from blurhash_rs import blurhash_encode
-from PIL import ImageOps, ImageSequence
+from PIL import ImageOps, ImageSequence, UnidentifiedImageError
+from PIL.Image import DecompressionBombError
 from PIL.Image import Image as PILImage
 from PIL.Image import Resampling
 from PIL.Image import open as open_image
@@ -243,7 +244,10 @@ async def _normalize_image(
     - Megapixels: downscale
     - File size: reduce quality
     """
-    img = open_image(BytesIO(data))
+    try:
+        img = open_image(BytesIO(data))
+    except (UnidentifiedImageError, DecompressionBombError):
+        raise_for.image_not_readable()
     ImageOps.exif_transpose(img, in_place=True)
 
     # normalize shape ratio

--- a/tests/controllers/test_web_settings.py
+++ b/tests/controllers/test_web_settings.py
@@ -62,3 +62,18 @@ async def test_update_socials_roundtrip(client: AsyncClient):
 
     profile = await UserProfileQuery.get_by_user_id(user_id)
     assert profile['socials'] == []
+
+
+async def test_update_avatar_with_invalid_image_returns_readable_validation_error(
+    client: AsyncClient,
+):
+    client.headers['Authorization'] = 'User user1'
+
+    r = await client.post(
+        '/api/web/settings/avatar',
+        data={'avatar_type': 'custom'},
+        files={'avatar_file': ('bad.txt', b'not-an-image', 'text/plain')},
+    )
+
+    assert r.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT, r.text
+    assert r.json() == {'detail': 'Image is not readable'}


### PR DESCRIPTION
## Summary
- return the existing "Image is not readable" validation response when avatar uploads are not valid images
- catch Pillow unreadable/decompression errors before image normalization crashes
- add a web settings regression test for invalid avatar uploads

## Testing
- `python3 -m compileall app/lib/image.py tests/controllers/test_web_settings.py tests/lib/test_image.py`
- `PYTHONPATH=. pytest tests/lib/test_image.py tests/controllers/test_web_settings.py -q` *(fails in this environment because the optional `speedup` extension is unavailable during import, before the targeted tests run)*

Fixes #31
