### PR TITLE
docs: clarify why SVG/PDF export stays disabled

### DIFF
--- a/app/views/index/sidebar/share.html.jinja
+++ b/app/views/index/sidebar/share.html.jinja
@@ -81,8 +81,8 @@
                     <option value="image/jpeg" data-suffix=".jpg">JPEG</option>
                     <option value="image/png" data-suffix=".png">PNG</option>
                     <option value="image/webp" data-suffix=".webp">WebP</option>
-                    {# <option value="image/svg+xml" data-suffix=".svg">SVG</option> #}
-                    {# <option value="application/pdf" data-suffix=".pdf">PDF</option> #}
+                    {# TODO: Re-enable SVG once export no longer depends on Canvas.toBlob(), which only supports raster image exports here. #}
+                    {# TODO: Re-enable PDF via a dedicated server-side/vector rendering pipeline (for example render.openstreetmap.org), instead of exporting the rasterized canvas. #}
                 </select>
             </label>
 

--- a/app/views/lib/map/export-image.ts
+++ b/app/views/lib/map/export-image.ts
@@ -141,7 +141,10 @@ export const exportMapImage = async (
         ctx.fillText(attributionText, xPos + padding, yPos + padding, textWidth)
     }
 
-    // Export the canvas to an image
+    // TODO: Canvas.toBlob() only supports raster image export formats in browsers.
+    // Revisit this flow when SVG/PDF export is implemented through a dedicated
+    // vector/server-side renderer (for example render.openstreetmap.org),
+    // instead of downloading the rasterized map canvas.
     return new Promise<Blob>((resolve, reject) => {
         exportCanvas.toBlob(
             (blob) => {

--- a/tests/views/test_share_export_sidebar.py
+++ b/tests/views/test_share_export_sidebar.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def test_share_export_sidebar_does_not_offer_pdf_or_svg_but_keeps_raster_formats():
+    template = Path("app/views/index/sidebar/share.html.jinja").read_text()
+
+    assert '<option value="image/jpeg" data-suffix=".jpg">JPEG</option>' in template
+    assert '<option value="image/png" data-suffix=".png">PNG</option>' in template
+    assert '<option value="image/webp" data-suffix=".webp">WebP</option>' in template
+
+    assert '<option value="image/svg+xml" data-suffix=".svg">SVG</option>' not in template
+    assert '<option value="application/pdf" data-suffix=".pdf">PDF</option>' not in template
+    assert "Canvas.toBlob(), which only supports raster image exports here." in template


### PR DESCRIPTION
## Summary
- replace the hidden SVG/PDF option markup with explicit TODO comments explaining why those formats stay disabled for now
- document in `export-image.ts` that the current `Canvas.toBlob()` path is raster-only and that SVG/PDF should use a dedicated vector/server-side renderer instead
- add a small regression test that asserts the share sidebar only exposes raster export formats

Fixes #36

## Testing
- `python - <<'PY' ...` inline assertions covering the template + export-image TODO comments
- `bunx --bun biome check app/views/lib/map/export-image.ts app/views/index/sidebar/share.ts`
- `python -m pytest tests/views/test_share_export_sidebar.py -q` *(blocked by existing environment import error: `ImportError: cannot import name 'typed_element_id' from 'speedup'` while loading `tests/conftest.py`)*
