### PR TITLE
fix: handle decompression bomb uploads in settings

### DIFF
--- a/app/services/oauth2_application_service.py
+++ b/app/services/oauth2_application_service.py
@@ -3,6 +3,7 @@ from asyncio import TaskGroup
 from typing import Any
 
 from fastapi import UploadFile
+from PIL import DecompressionBombError
 from pydantic import SecretStr
 from rfc3986 import URIReference
 from zid import zid
@@ -204,7 +205,10 @@ class OAuth2ApplicationService:
                 client_id: ClientId
                 old_avatar_id, client_id = row
 
-            avatar_id = await ImageService.upload_avatar(data) if data else None
+            try:
+                avatar_id = await ImageService.upload_avatar(data) if data else None
+            except DecompressionBombError:
+                StandardFeedback.raise_error(None, t('validation.image_file_too_big'))
 
             await conn.execute(
                 """

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -5,6 +5,7 @@ from random import random
 from typing import Any
 
 from fastapi import UploadFile
+from PIL import DecompressionBombError
 from psycopg import AsyncConnection
 from psycopg.sql import SQL, Composable
 from pydantic import SecretStr
@@ -116,11 +117,14 @@ class UserService:
         old_avatar_id = user['avatar_id']
 
         data = await avatar_file.read()
-        avatar_id = (
-            await ImageService.upload_avatar(data)
-            if data and avatar_type == 'custom'
-            else None
-        )
+        try:
+            avatar_id = (
+                await ImageService.upload_avatar(data)
+                if data and avatar_type == 'custom'
+                else None
+            )
+        except DecompressionBombError:
+            StandardFeedback.raise_error(None, t('validation.image_file_too_big'))
 
         async with db(True) as conn:
             await conn.execute(
@@ -153,7 +157,10 @@ class UserService:
         old_background_id = user['background_id']
 
         data = await background_file.read()
-        background_id = await ImageService.upload_background(data) if data else None
+        try:
+            background_id = await ImageService.upload_background(data) if data else None
+        except DecompressionBombError:
+            StandardFeedback.raise_error(None, t('validation.image_file_too_big'))
 
         async with db(True) as conn:
             await conn.execute(

--- a/tests/controllers/test_web_settings.py
+++ b/tests/controllers/test_web_settings.py
@@ -1,4 +1,5 @@
 from httpx import AsyncClient
+from PIL import DecompressionBombError
 from starlette import status
 
 from app.queries.user_profile_query import UserProfileQuery
@@ -62,3 +63,38 @@ async def test_update_socials_roundtrip(client: AsyncClient):
 
     profile = await UserProfileQuery.get_by_user_id(user_id)
     assert profile['socials'] == []
+
+
+async def test_update_custom_avatar_decompression_bomb(client: AsyncClient, monkeypatch):
+    client.headers['Authorization'] = 'User user1'
+
+    async def fail_upload_avatar(*args, **kwargs):
+        raise DecompressionBombError('too big')
+
+    monkeypatch.setattr('app.services.user_service.ImageService.upload_avatar', fail_upload_avatar)
+
+    r = await client.post(
+        '/api/web/settings/avatar',
+        data={'avatar_type': 'custom'},
+        files={'avatar_file': ('avatar.png', b'fake-image', 'image/png')},
+    )
+    assert r.status_code == status.HTTP_400_BAD_REQUEST, r.text
+    assert r.json()['detail'][0]['msg'] == 'Image file is too big'
+
+
+async def test_update_background_decompression_bomb(client: AsyncClient, monkeypatch):
+    client.headers['Authorization'] = 'User user1'
+
+    async def fail_upload_background(*args, **kwargs):
+        raise DecompressionBombError('too big')
+
+    monkeypatch.setattr(
+        'app.services.user_service.ImageService.upload_background', fail_upload_background
+    )
+
+    r = await client.post(
+        '/api/web/settings/background',
+        files={'background_file': ('background.png', b'fake-image', 'image/png')},
+    )
+    assert r.status_code == status.HTTP_400_BAD_REQUEST, r.text
+    assert r.json()['detail'][0]['msg'] == 'Image file is too big'

--- a/tests/services/test_oauth2_application_service.py
+++ b/tests/services/test_oauth2_application_service.py
@@ -1,9 +1,12 @@
 import pytest
 from fastapi import HTTPException
+from PIL import DecompressionBombError
+from starlette import status
 
 from app.config import OAUTH_APP_URI_LIMIT, OAUTH_APP_URI_MAX_LENGTH
 from app.lib.locale import DEFAULT_LOCALE
 from app.lib.translation import translation_context
+from app.models.db.oauth2_application import SYSTEM_APP_WEB_CLIENT_ID
 from app.services.oauth2_application_service import OAuth2ApplicationService
 
 
@@ -57,3 +60,22 @@ def test_validate_redirect_uris(uris, expected):
             assert sorted(result) == sorted(expected)
         except HTTPException:
             assert expected is None, 'Expected validation to succeed, but it failed'
+
+
+async def test_update_avatar_decompression_bomb(monkeypatch):
+    async def fail_upload_avatar(*args, **kwargs):
+        raise DecompressionBombError('too big')
+
+    monkeypatch.setattr(
+        'app.services.oauth2_application_service.ImageService.upload_avatar', fail_upload_avatar
+    )
+
+    with translation_context(DEFAULT_LOCALE):
+        with pytest.raises(HTTPException) as exc_info:
+            await OAuth2ApplicationService.update_avatar(
+                SYSTEM_APP_WEB_CLIENT_ID,
+                avatar_file=None,  # type: ignore[arg-type]
+            )
+
+    assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert exc_info.value.detail[0]['msg'] == 'Image file is too big'


### PR DESCRIPTION
## Summary
- catch Pillow decompression bomb errors during user avatar/background uploads and OAuth app avatar uploads
- convert those failures into the existing standard feedback validation message instead of surfacing a generic 500
- add regression tests for the user settings and OAuth app upload flows

## Testing
- python -m pytest tests/controllers/test_web_settings.py tests/services/test_oauth2_application_service.py -q *(fails during test startup due to existing repo issue: ImportError: cannot import name 'typed_element_id' from 'speedup')*
- python -m compileall app/services/user_service.py app/services/oauth2_application_service.py tests/controllers/test_web_settings.py tests/services/test_oauth2_application_service.py
- python - <<'PY' ... compile(...) ... PY
- git diff --check

Fixes #31
