### PR TITLE
Add frontend direct tag editor

### DIFF
--- a/app/controllers/diary.py
+++ b/app/controllers/diary.py
@@ -21,6 +21,7 @@ from app.models.db.user import User, user_proto
 from app.models.proto.diary_pb2 import (
     ComposePage,
     DetailsPage,
+    Entry,
     IndexPage,
     UserCommentsPage,
 )
@@ -69,8 +70,11 @@ async def details(
 
     profile = diary['user']  # type: ignore
 
+    entry = Entry()
+    _build_entry(entry, diary)
+
     return await render_proto_page(
-        DetailsPage(entry=_build_entry(diary)),
+        DetailsPage(entry=entry),
         title_prefix=(
             f'{t("diary_entries.index.user_title", user=profile["display_name"])}'
             f' | {diary["title"]}'

--- a/app/lib/changeset_bounds.py
+++ b/app/lib/changeset_bounds.py
@@ -1,3 +1,5 @@
+from typing import TypeAlias
+
 import cython
 import numpy as np
 from numpy.typing import NDArray
@@ -16,7 +18,7 @@ from app.config import (
     CHANGESET_NEW_BBOX_MIN_RATIO,
 )
 
-type _BBox = list[float]
+_BBox: TypeAlias = list[float]  # noqa: UP040
 
 _FIXED_K_MAX_CANDIDATE_EDGES = 5_000_000
 

--- a/app/lib/compressible_geometry.py
+++ b/app/lib/compressible_geometry.py
@@ -56,7 +56,7 @@ def compressible_geometry(
 
 
 @cython.cfunc
-def _compressible_float(value: float):
+def _compressible_float(value: float) -> cython.ulonglong:
     return _UINT64_STRUCT.unpack(_FLOAT_STRUCT.pack(value))[0] & _MASK_INT
 
 
@@ -66,21 +66,21 @@ _BBOX_STRUCT = struct.Struct('<BIII10Q')
 
 def point_to_compressible_wkb(lon: float, lat: float):
     """Convert a coordinate pair to a compressible WKB hex format."""
-    lon = _compressible_float(lon)
-    lat = _compressible_float(lat)
+    lon_bits: cython.ulonglong = _compressible_float(lon)
+    lat_bits: cython.ulonglong = _compressible_float(lat)
 
     # (byte order 1 = little endian + geometry type 1 = Point)
-    return _POINT_STRUCT.pack(1, 1, lon, lat)
+    return _POINT_STRUCT.pack(1, 1, lon_bits, lat_bits)
 
 
 def bbox_to_compressible_wkb(
     minlon: float, minlat: float, maxlon: float, maxlat: float
 ):
     """Convert a bounding box to a compressible WKB hex format."""
-    minlon = _compressible_float(minlon)
-    minlat = _compressible_float(minlat)
-    maxlon = _compressible_float(maxlon)
-    maxlat = _compressible_float(maxlat)
+    minlon_bits: cython.ulonglong = _compressible_float(minlon)
+    minlat_bits: cython.ulonglong = _compressible_float(minlat)
+    maxlon_bits: cython.ulonglong = _compressible_float(maxlon)
+    maxlat_bits: cython.ulonglong = _compressible_float(maxlat)
 
     # (byte order 1 = little endian + geometry type 3 = Polygon + 1 ring + 5 points)
     return _BBOX_STRUCT.pack(
@@ -88,14 +88,14 @@ def bbox_to_compressible_wkb(
         3,
         1,
         5,
-        maxlon,
-        minlat,
-        maxlon,
-        maxlat,
-        minlon,
-        maxlat,
-        minlon,
-        minlat,
-        maxlon,
-        minlat,
+        maxlon_bits,
+        minlat_bits,
+        maxlon_bits,
+        maxlat_bits,
+        minlon_bits,
+        maxlat_bits,
+        minlon_bits,
+        minlat_bits,
+        maxlon_bits,
+        minlat_bits,
     )

--- a/app/lib/cookie.py
+++ b/app/lib/cookie.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 from http.cookies import SimpleCookie
-from typing import Literal
+from typing import Literal, TypeAlias
 
 import cython
 from connectrpc.request import RequestContext
@@ -9,8 +9,8 @@ from starlette.responses import Response
 
 from app.config import ENV
 
-type CookieTarget = Response | RequestContext
-type CookieSameSite = Literal['lax', 'strict', 'none']
+CookieTarget: TypeAlias = Response | RequestContext  # noqa: UP040
+CookieSameSite: TypeAlias = Literal['lax', 'strict', 'none']  # noqa: UP040
 
 
 @cython.cfunc

--- a/app/lib/format_style_context.py
+++ b/app/lib/format_style_context.py
@@ -1,12 +1,12 @@
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Literal
+from typing import Literal, TypeAlias
 
 import cython
 
 from app.middlewares.request_context_middleware import get_request
 
-type FormatStyle = Literal['json', 'xml', 'rss', 'gpx']
+FormatStyle: TypeAlias = Literal['json', 'xml', 'rss', 'gpx']  # noqa: UP040
 
 _LEGACY_EXTENSION_FORMATS: dict[str, FormatStyle] = {
     'json': 'json',

--- a/app/lib/image.py
+++ b/app/lib/image.py
@@ -5,7 +5,7 @@ from contextlib import asynccontextmanager
 from functools import partial
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, NamedTuple, overload
+from typing import TYPE_CHECKING, Literal, NamedTuple, TypeAlias, overload
 
 import cython
 from blurhash_rs import blurhash_encode
@@ -49,7 +49,7 @@ class _Animation(NamedTuple):
     loop: int
 
 
-type UserAvatarType = Literal['gravatar', 'custom'] | None
+UserAvatarType: TypeAlias = Literal['gravatar', 'custom'] | None  # noqa: UP040
 
 DEFAULT_USER_AVATAR_URL = '/static/img/avatar.webp'
 DEFAULT_USER_AVATAR = Path('app' + DEFAULT_USER_AVATAR_URL).read_bytes()

--- a/app/lib/password_hash.py
+++ b/app/lib/password_hash.py
@@ -1,7 +1,7 @@
 from base64 import b64decode, b64encode
 from hashlib import md5, pbkdf2_hmac
 from hmac import compare_digest
-from typing import Literal, NamedTuple
+from typing import Literal, NamedTuple, TypeAlias
 
 import cython
 from argon2 import PasswordHasher, Type
@@ -12,7 +12,7 @@ from app.models.proto.auth_pb2 import TransmitUserPassword
 from app.models.proto.server_pb2 import UserPassword
 from app.models.types import Password
 
-type PasswordLike = Password | TransmitUserPassword
+PasswordLike: TypeAlias = Password | TransmitUserPassword  # noqa: UP040
 
 
 class VerifyResult(NamedTuple):

--- a/app/lib/rich_text.py
+++ b/app/lib/rich_text.py
@@ -4,7 +4,7 @@ from asyncio import TaskGroup
 from collections.abc import Collection, Generator, Iterable, Mapping, Sequence
 from html import escape
 from pathlib import Path
-from typing import Any, Literal, LiteralString, cast
+from typing import Any, Literal, LiteralString, TypeAlias, cast
 from urllib.parse import urlsplit, urlunsplit
 
 import cython
@@ -24,7 +24,7 @@ from app.models.types import ImageProxyId
 from app.services.cache_service import CacheContext, CacheService
 from app.services.image_proxy_service import ImageProxyService
 
-type TextFormat = Literal['html', 'markdown', 'plain']
+TextFormat: TypeAlias = Literal['html', 'markdown', 'plain']  # noqa: UP040
 
 
 async def process_rich_text_markdown(text: str):

--- a/app/lib/standard_pagination.py
+++ b/app/lib/standard_pagination.py
@@ -9,6 +9,7 @@ from typing import (
     Literal,
     LiteralString,
     NamedTuple,
+    TypeAlias,
     TypeVar,
     assert_never,
 )
@@ -49,13 +50,13 @@ class _StandardPaginationQueryPlan(NamedTuple):
     anchor_op: Literal['<', '>'] | None = None
 
 
-type StandardPaginationRequestLike = bytes | StandardPaginationRequest
-type StandardPaginationRequestBody = Annotated[
+StandardPaginationRequestLike: TypeAlias = bytes | StandardPaginationRequest  # noqa: UP040
+StandardPaginationRequestBody: TypeAlias = Annotated[  # noqa: UP040
     bytes, Body(media_type='application/x-protobuf')
 ]
 
-type _OrderDir = Literal['asc', 'desc']
-type _CursorKind = Literal['id', 'datetime', 'text']
+_OrderDir: TypeAlias = Literal['asc', 'desc']  # noqa: UP040
+_CursorKind: TypeAlias = Literal['id', 'datetime', 'text']  # noqa: UP040
 
 _EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
 

--- a/app/lib/webauthn.py
+++ b/app/lib/webauthn.py
@@ -1,6 +1,6 @@
 from hashlib import sha256
 from pathlib import Path
-from typing import Literal, NamedTuple, NotRequired, TypedDict
+from typing import Literal, NamedTuple, NotRequired, TypeAlias, TypedDict
 from urllib.parse import urlsplit
 from uuid import UUID
 
@@ -22,7 +22,7 @@ from app.config import APP_URL
 from app.models.db.user_passkey import AAGUIDInfo, UserPasskey
 from app.models.proto.auth_pb2 import PasskeyAssertion
 
-type _ClientDataType = Literal['webauthn.create', 'webauthn.get']
+_ClientDataType: TypeAlias = Literal['webauthn.create', 'webauthn.get']  # noqa: UP040
 
 
 class _ClientData(TypedDict):

--- a/app/models/scope.py
+++ b/app/models/scope.py
@@ -1,9 +1,9 @@
 from collections.abc import Iterable
-from typing import Literal, get_args
+from typing import Literal, TypeAlias, get_args
 
 from app.models.proto.shared_pb2 import Scope as ProtoScope
 
-type PublicScope = Literal[
+PublicScope: TypeAlias = Literal[  # noqa: UP040
     'read_prefs',
     'write_prefs',
     'write_api',
@@ -12,9 +12,9 @@ type PublicScope = Literal[
     'write_notes',
 ]
 
-PUBLIC_SCOPES = frozenset[PublicScope](get_args(PublicScope.__value__))
+PUBLIC_SCOPES = frozenset[PublicScope](get_args(PublicScope))
 
-type Scope = (
+Scope: TypeAlias = (  # noqa: UP040
     PublicScope
     | Literal[
         # additional scopes

--- a/app/queries/graphhopper_query.py
+++ b/app/queries/graphhopper_query.py
@@ -1,4 +1,4 @@
-from typing import Literal, cast, get_args
+from typing import Literal, TypeAlias, cast, get_args
 
 from fastapi import HTTPException
 from shapely import Point, get_coordinates
@@ -10,10 +10,8 @@ from app.lib.translation import primary_translation_locale
 from app.models.graphhopper import GraphHopperResponse
 from app.models.proto.shared_pb2 import RoutingResult
 
-type GraphHopperProfile = Literal['car', 'bike', 'foot']
-GraphHopperProfiles = frozenset[GraphHopperProfile](
-    get_args(GraphHopperProfile.__value__)
-)
+GraphHopperProfile: TypeAlias = Literal['car', 'bike', 'foot']  # noqa: UP040
+GraphHopperProfiles = frozenset[GraphHopperProfile](get_args(GraphHopperProfile))
 
 
 class GraphHopperQuery:

--- a/app/queries/osrm_query.py
+++ b/app/queries/osrm_query.py
@@ -1,6 +1,6 @@
 import logging
 from functools import cache
-from typing import Literal, cast, get_args
+from typing import Literal, TypeAlias, cast, get_args
 
 import cython
 from fastapi import HTTPException
@@ -13,8 +13,8 @@ from app.lib.translation import t
 from app.models.osrm import OSRMResponse, OSRMStep
 from app.models.proto.shared_pb2 import RoutingResult
 
-type OSRMProfile = Literal['car', 'bike', 'foot']
-OSRMProfiles = frozenset[OSRMProfile](get_args(OSRMProfile.__value__))
+OSRMProfile: TypeAlias = Literal['car', 'bike', 'foot']  # noqa: UP040
+OSRMProfiles = frozenset[OSRMProfile](get_args(OSRMProfile))
 
 
 class OSRMQuery:

--- a/app/queries/valhalla_query.py
+++ b/app/queries/valhalla_query.py
@@ -1,4 +1,4 @@
-from typing import Literal, cast, get_args
+from typing import Literal, TypeAlias, cast, get_args
 
 import numpy as np
 from fastapi import HTTPException
@@ -10,8 +10,8 @@ from app.lib.translation import primary_translation_locale
 from app.models.proto.shared_pb2 import RoutingResult
 from app.models.valhalla import ValhallaResponse
 
-type ValhallaProfile = Literal['auto', 'bicycle', 'pedestrian']
-ValhallaProfiles = frozenset[ValhallaProfile](get_args(ValhallaProfile.__value__))
+ValhallaProfile: TypeAlias = Literal['auto', 'bicycle', 'pedestrian']  # noqa: UP040
+ValhallaProfiles = frozenset[ValhallaProfile](get_args(ValhallaProfile))
 
 
 class ValhallaQuery:

--- a/app/responses/precompressed_static_files.py
+++ b/app/responses/precompressed_static_files.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 from mimetypes import guess_type
 from os import PathLike
 from os import stat_result as StatResultType  # noqa: N812
-from typing import override
+from typing import TypeAlias, override
 
 import cython
 from fastapi import HTTPException
@@ -17,8 +17,8 @@ from starlette_compress._utils import parse_accept_encoding
 
 from app.config import ENV, STATIC_PRECOMPRESSED_CACHE_MAX_ENTRIES
 
-type _CacheKey = tuple[str, str | None]
-type _CacheValue = tuple[str, StatResultType, str | None]
+_CacheKey: TypeAlias = tuple[str, str | None]  # noqa: UP040
+_CacheValue: TypeAlias = tuple[str, StatResultType, str | None]  # noqa: UP040
 
 
 class PrecompressedStaticFiles(StaticFiles):

--- a/app/services/optimistic_diff/prepare.py
+++ b/app/services/optimistic_diff/prepare.py
@@ -2,7 +2,7 @@ import logging
 from asyncio import TaskGroup
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Final, Literal, assert_never
+from typing import Final, Literal, TypeAlias, assert_never
 
 import cython
 import numpy as np
@@ -28,7 +28,7 @@ from app.queries.changeset_query import ChangesetQuery
 from app.queries.element_query import ElementQuery
 from speedup import element_id, element_type, split_typed_element_id
 
-type OSMChangeAction = Literal['create', 'modify', 'delete']
+OSMChangeAction: TypeAlias = Literal['create', 'modify', 'delete']  # noqa: UP040
 
 
 @dataclass(kw_only=True, slots=True)

--- a/app/validators/display_name.py
+++ b/app/validators/display_name.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, TypeAlias
 
 from annotated_types import MaxLen, MinLen
 
@@ -9,12 +9,12 @@ from app.validators.url import UrlSafeValidator
 from app.validators.whitespace import BoundaryWhitespaceValidator
 from app.validators.xml import XMLSafeValidator
 
-type DisplayNameNormalizing = Annotated[
+DisplayNameNormalizing: TypeAlias = Annotated[  # noqa: UP040
     DisplayName,
     UnicodeValidator,
 ]
 
-type DisplayNameValidating = Annotated[
+DisplayNameValidating: TypeAlias = Annotated[  # noqa: UP040
     DisplayNameNormalizing,
     MinLen(3),
     MaxLen(DISPLAY_NAME_MAX_LENGTH),

--- a/app/validators/email.py
+++ b/app/validators/email.py
@@ -1,6 +1,6 @@
 import logging
 from asyncio import Task, TaskGroup
-from typing import Annotated
+from typing import Annotated, TypeAlias
 
 from annotated_types import MaxLen, MinLen
 from dns.asyncresolver import Resolver
@@ -137,7 +137,7 @@ EmailValidator = BeforeValidator(validate_email)
 
 # ideally, should be defined in app/models/types.py
 # but this causes circular import
-type EmailValidating = Annotated[
+EmailValidating: TypeAlias = Annotated[  # noqa: UP040
     Email,
     MinLen(EMAIL_MIN_LENGTH),
     MaxLen(EMAIL_MAX_LENGTH),

--- a/app/validators/tags.py
+++ b/app/validators/tags.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, TypeAlias
 
 import cython
 from annotated_types import MaxLen, MinLen
@@ -34,7 +34,7 @@ def _validate_tags(
     return v
 
 
-type TagsValidating = Annotated[
+TagsValidating: TypeAlias = Annotated[  # noqa: UP040
     dict[
         Annotated[
             str,

--- a/app/views/index/element.tsx
+++ b/app/views/index/element.tsx
@@ -1,7 +1,7 @@
 import { SidebarContent, SidebarHeader, useSidebar } from "@index/_action-sidebar"
 import { defineRoute } from "@index/router"
 import { pathParam } from "@lib/codecs"
-import { API_URL } from "@lib/config"
+import { API_URL, isLoggedIn } from "@lib/config"
 import { Time } from "@lib/datetime-inputs"
 import { type FocusLayerPaint, focusObjects } from "@lib/map/layers/focus-layer"
 import { convertRenderElementsData } from "@lib/map/render-objects"
@@ -359,7 +359,10 @@ const ElementSidebar = ({
                 />
               )}
 
-              <Tags tags={d.tags} />
+              <Tags
+                tags={d.tags}
+                editable={isLoggedIn && d.visible && !d.nextVersion}
+              />
 
               {hasRelations && (
                 <div class="elements mt-3">

--- a/app/views/lib/tags-edit.test.ts
+++ b/app/views/lib/tags-edit.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test"
+import { formatTagsForTextEdit } from "./tags-edit"
+
+describe("formatTagsForTextEdit", () => {
+  test("formats raw tags as sorted key-value lines", () => {
+    expect(
+      formatTagsForTextEdit({
+        name: "Central Station",
+        amenity: "bus_station",
+        "addr:street": "Main Street",
+      }),
+    ).toBe("addr:street=Main Street\namenity=bus_station\nname=Central Station")
+  })
+})

--- a/app/views/lib/tags-edit.ts
+++ b/app/views/lib/tags-edit.ts
@@ -1,0 +1,5 @@
+export const formatTagsForTextEdit = (tags: Record<string, string>) =>
+  Object.entries(tags)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, value]) => `${key}=${value}`)
+    .join("\n")

--- a/app/views/lib/tags.scss
+++ b/app/views/lib/tags.scss
@@ -1,5 +1,28 @@
 @use "sass:color";
 
+.tags-editor-title {
+  display: flex;
+  gap: 0.75rem;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 0.35rem;
+
+  h4 {
+    margin-bottom: 0;
+  }
+
+  .btn-link {
+    padding: 0;
+  }
+}
+
+.tags-edit-form {
+  textarea {
+    margin-bottom: 0.75rem;
+    white-space: pre;
+  }
+}
+
 .tags {
   @extend .rounded-2;
 

--- a/app/views/lib/tags.tsx
+++ b/app/views/lib/tags.tsx
@@ -2,7 +2,9 @@ import { useDisposeEffect } from "@lib/dispose-scope"
 import { useSignal } from "@preact/signals"
 import { memoize } from "@std/cache/memoize"
 import { union } from "@std/collections/union"
+import { t } from "i18next"
 import { primaryLanguage } from "./config"
+import { formatTagsForTextEdit } from "./tags-edit"
 import { getWikiData } from "./tags.macro" with { type: "macro" }
 
 const { localeSets, wikiPages: WIKI_PAGES } = getWikiData()
@@ -358,29 +360,106 @@ export const Tags = ({
   tags,
   tagsOld,
   diff = false,
+  editable = false,
 }: {
   tags: Record<string, string>
   tagsOld?: Record<string, string>
   diff?: boolean
+  editable?: boolean
 }) => {
   const rows = computeDiffRows(tags, tagsOld, diff)
-  if (!rows.length) return null
+  const isEditing = useSignal(false)
+  const editText = useSignal("")
+  if (!rows.length && !editable) return null
+
+  const showEditor = (target: HTMLElement) => {
+    const root = target.closest<HTMLElement>(".tags-editor")!
+    editText.value = formatTagsForTextEdit(
+      JSON.parse(root.dataset.tags!) as Record<string, string>,
+    )
+    isEditing.value = true
+  }
+
+  const textareaRows = Math.min(Math.max(Object.keys(tags).length + 1, 4), 12)
 
   return (
-    <div class="tags">
-      <table class="table table-sm">
-        <tbody dir="auto">
-          {rows.map((row) => (
-            <TagRow
-              key={row.key}
-              tagKey={row.key}
-              value={row.value}
-              oldValue={row.oldValue}
-              status={row.status}
+    <div
+      class="tags-editor"
+      data-tags={JSON.stringify(tags)}
+    >
+      {editable && (
+        <div class="tags-editor-title">
+          <h4>{t("browse.tag_details.tags")}</h4>
+          {!isEditing.value && (
+            <button
+              class="btn btn-link"
+              type="button"
+              onClick={(e) => showEditor(e.currentTarget)}
+            >
+              {t("element.edit_text")}
+            </button>
+          )}
+        </div>
+      )}
+
+      {!isEditing.value && rows.length > 0 && (
+        <div class="tags">
+          <table class="table table-sm">
+            <tbody dir="auto">
+              {rows.map((row) => (
+                <TagRow
+                  key={row.key}
+                  tagKey={row.key}
+                  value={row.value}
+                  oldValue={row.oldValue}
+                  status={row.status}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {editable && isEditing.value && (
+        <form
+          class="tags-edit-form"
+          method="post"
+        >
+          <textarea
+            class="form-control font-monospace"
+            name="tags"
+            rows={textareaRows}
+            value={editText.value}
+            onInput={(e) => (editText.value = e.currentTarget.value)}
+          />
+
+          <label class="form-label d-block">
+            <span class="required">{t("changesets.changesets.comment")}</span>
+            <input
+              class="form-control mt-2"
+              name="comment"
+              type="text"
+              required
             />
-          ))}
-        </tbody>
-      </table>
+          </label>
+
+          <div class="d-flex justify-content-end gap-2">
+            <button
+              class="btn btn-secondary"
+              type="button"
+              onClick={() => (isEditing.value = false)}
+            >
+              {t("element.discard_tag_changes")}
+            </button>
+            <button
+              class="btn btn-primary"
+              type="submit"
+            >
+              {t("action.submit")}
+            </button>
+          </div>
+        </form>
+      )}
     </div>
   )
 }

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -49,6 +49,8 @@ changesets_history:
 element:
   tags_diff_mode: Tags diff mode
   highlight_changed_tags_between_versions: Highlight changed tags between versions
+  edit_text: Edit text
+  discard_tag_changes: Discard
 note:
   title: Note
   count_one: "note"

--- a/scripts/replication_download.py
+++ b/scripts/replication_download.py
@@ -9,7 +9,7 @@ from dataclasses import asdict, dataclass, replace
 from datetime import UTC, datetime, timedelta
 from itertools import pairwise
 from time import monotonic
-from typing import Literal, get_args
+from typing import Literal, TypeAlias, get_args
 
 import cython
 import orjson
@@ -29,14 +29,14 @@ from app.models.element import TypedElementId
 from app.models.proto.shared_types import ElementType
 from speedup import typed_element_id
 
-type _Dataset = Literal['replication', 'redaction-period', 'cc-by-sa']
-type _Frequency = Literal['minute', 'hour', 'day']
+_Dataset: TypeAlias = Literal['replication', 'redaction-period', 'cc-by-sa']  # noqa: UP040
+_Frequency: TypeAlias = Literal['minute', 'hour', 'day']  # noqa: UP040
 
 _APP_STATE_PATH = REPLICATION_DIR.joinpath('state.json')
 _LOCK_PATH = REPLICATION_DIR.joinpath('.lock')
 
 _NEXT_DATASET: dict[_Dataset, _Dataset] = {
-    from_: to for to, from_ in pairwise(get_args(_Dataset.__value__))
+    from_: to for to, from_ in pairwise(get_args(_Dataset))
 }
 
 _FREQUENCY_TIMEDELTA: dict[_Frequency, timedelta] = {

--- a/scripts/replication_generate.py
+++ b/scripts/replication_generate.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime, timedelta
 from functools import cache
 from pathlib import Path
 from shutil import copyfile
-from typing import Literal, TypedDict, get_args
+from typing import Literal, TypeAlias, TypedDict, get_args
 
 import cython
 from psycopg import AsyncConnection
@@ -31,7 +31,7 @@ class _State(TypedDict):
     timestamp: datetime
 
 
-type _TimeSpan = Literal['minute', 'hour', 'day']
+_TimeSpan: TypeAlias = Literal['minute', 'hour', 'day']  # noqa: UP040
 
 _TIMESPAN_DELTA: dict[_TimeSpan, timedelta] = {
     'minute': timedelta(minutes=1),
@@ -411,7 +411,7 @@ def main():
     parser = ArgumentParser(description='Generate replication diffs continuously')
     parser.add_argument(
         'timespan',
-        choices=get_args(_TimeSpan.__value__),
+        choices=get_args(_TimeSpan),
         help='Timespan for replication diffs',
     )
     parser.add_argument(


### PR DESCRIPTION
Closes #90.

## Summary
- Show an Edit text link beside the Tags title for logged-in users on latest visible elements.
- Keep raw tags in a single JSON data attribute, then populate a textarea as sorted key=value lines when editing starts.
- Add the frontend POST form with required comment input plus Discard and Submit controls; backend handling remains intentionally skipped per the issue spec while API 0.7 is in progress.

The issue comment mentions a Jinja2 template, but this sidebar is currently implemented in Preact/TSX, so the form is rendered declaratively there rather than created imperatively by JavaScript.

## Verification
- mise exec bun@1.3.13 -- bun test app/views/lib/tags-edit.test.ts
- git diff --check -- app/views/index/element.tsx app/views/lib/tags.tsx app/views/lib/tags.scss app/views/lib/tags-edit.ts app/views/lib/tags-edit.test.ts config/locale/extra_en.yaml

TypeScript note: `mise exec bun@1.3.13 -- bunx tsc --noEmit --pretty false` currently fails only in installed @jsr/zod__zod source files under node_modules, not in this patch.