### PR TITLE
Add changeset diff mode

### DIFF
--- a/app/controllers/diary.py
+++ b/app/controllers/diary.py
@@ -21,6 +21,7 @@ from app.models.db.user import User, user_proto
 from app.models.proto.diary_pb2 import (
     ComposePage,
     DetailsPage,
+    Entry,
     IndexPage,
     UserCommentsPage,
 )
@@ -69,8 +70,11 @@ async def details(
 
     profile = diary['user']  # type: ignore
 
+    entry = Entry()
+    _build_entry(entry, diary)
+
     return await render_proto_page(
-        DetailsPage(entry=_build_entry(diary)),
+        DetailsPage(entry=entry),
         title_prefix=(
             f'{t("diary_entries.index.user_title", user=profile["display_name"])}'
             f' | {diary["title"]}'

--- a/app/lib/changeset_bounds.py
+++ b/app/lib/changeset_bounds.py
@@ -1,3 +1,5 @@
+from typing import TypeAlias
+
 import cython
 import numpy as np
 from numpy.typing import NDArray
@@ -16,7 +18,7 @@ from app.config import (
     CHANGESET_NEW_BBOX_MIN_RATIO,
 )
 
-type _BBox = list[float]
+_BBox: TypeAlias = list[float]  # noqa: UP040
 
 _FIXED_K_MAX_CANDIDATE_EDGES = 5_000_000
 

--- a/app/lib/compressible_geometry.py
+++ b/app/lib/compressible_geometry.py
@@ -56,7 +56,7 @@ def compressible_geometry(
 
 
 @cython.cfunc
-def _compressible_float(value: float):
+def _compressible_float(value: float) -> cython.ulonglong:
     return _UINT64_STRUCT.unpack(_FLOAT_STRUCT.pack(value))[0] & _MASK_INT
 
 
@@ -66,21 +66,21 @@ _BBOX_STRUCT = struct.Struct('<BIII10Q')
 
 def point_to_compressible_wkb(lon: float, lat: float):
     """Convert a coordinate pair to a compressible WKB hex format."""
-    lon = _compressible_float(lon)
-    lat = _compressible_float(lat)
+    lon_bits: cython.ulonglong = _compressible_float(lon)
+    lat_bits: cython.ulonglong = _compressible_float(lat)
 
     # (byte order 1 = little endian + geometry type 1 = Point)
-    return _POINT_STRUCT.pack(1, 1, lon, lat)
+    return _POINT_STRUCT.pack(1, 1, lon_bits, lat_bits)
 
 
 def bbox_to_compressible_wkb(
     minlon: float, minlat: float, maxlon: float, maxlat: float
 ):
     """Convert a bounding box to a compressible WKB hex format."""
-    minlon = _compressible_float(minlon)
-    minlat = _compressible_float(minlat)
-    maxlon = _compressible_float(maxlon)
-    maxlat = _compressible_float(maxlat)
+    minlon_bits: cython.ulonglong = _compressible_float(minlon)
+    minlat_bits: cython.ulonglong = _compressible_float(minlat)
+    maxlon_bits: cython.ulonglong = _compressible_float(maxlon)
+    maxlat_bits: cython.ulonglong = _compressible_float(maxlat)
 
     # (byte order 1 = little endian + geometry type 3 = Polygon + 1 ring + 5 points)
     return _BBOX_STRUCT.pack(
@@ -88,14 +88,14 @@ def bbox_to_compressible_wkb(
         3,
         1,
         5,
-        maxlon,
-        minlat,
-        maxlon,
-        maxlat,
-        minlon,
-        maxlat,
-        minlon,
-        minlat,
-        maxlon,
-        minlat,
+        maxlon_bits,
+        minlat_bits,
+        maxlon_bits,
+        maxlat_bits,
+        minlon_bits,
+        maxlat_bits,
+        minlon_bits,
+        minlat_bits,
+        maxlon_bits,
+        minlat_bits,
     )

--- a/app/lib/cookie.py
+++ b/app/lib/cookie.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 from http.cookies import SimpleCookie
-from typing import Literal
+from typing import Literal, TypeAlias
 
 import cython
 from connectrpc.request import RequestContext
@@ -9,8 +9,8 @@ from starlette.responses import Response
 
 from app.config import ENV
 
-type CookieTarget = Response | RequestContext
-type CookieSameSite = Literal['lax', 'strict', 'none']
+CookieTarget: TypeAlias = Response | RequestContext  # noqa: UP040
+CookieSameSite: TypeAlias = Literal['lax', 'strict', 'none']  # noqa: UP040
 
 
 @cython.cfunc

--- a/app/lib/format_style_context.py
+++ b/app/lib/format_style_context.py
@@ -1,12 +1,12 @@
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Literal
+from typing import Literal, TypeAlias
 
 import cython
 
 from app.middlewares.request_context_middleware import get_request
 
-type FormatStyle = Literal['json', 'xml', 'rss', 'gpx']
+FormatStyle: TypeAlias = Literal['json', 'xml', 'rss', 'gpx']  # noqa: UP040
 
 _LEGACY_EXTENSION_FORMATS: dict[str, FormatStyle] = {
     'json': 'json',

--- a/app/lib/image.py
+++ b/app/lib/image.py
@@ -5,7 +5,7 @@ from contextlib import asynccontextmanager
 from functools import partial
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, NamedTuple, overload
+from typing import TYPE_CHECKING, Literal, NamedTuple, TypeAlias, overload
 
 import cython
 from blurhash_rs import blurhash_encode
@@ -49,7 +49,7 @@ class _Animation(NamedTuple):
     loop: int
 
 
-type UserAvatarType = Literal['gravatar', 'custom'] | None
+UserAvatarType: TypeAlias = Literal['gravatar', 'custom'] | None  # noqa: UP040
 
 DEFAULT_USER_AVATAR_URL = '/static/img/avatar.webp'
 DEFAULT_USER_AVATAR = Path('app' + DEFAULT_USER_AVATAR_URL).read_bytes()

--- a/app/lib/password_hash.py
+++ b/app/lib/password_hash.py
@@ -1,7 +1,7 @@
 from base64 import b64decode, b64encode
 from hashlib import md5, pbkdf2_hmac
 from hmac import compare_digest
-from typing import Literal, NamedTuple
+from typing import Literal, NamedTuple, TypeAlias
 
 import cython
 from argon2 import PasswordHasher, Type
@@ -12,7 +12,7 @@ from app.models.proto.auth_pb2 import TransmitUserPassword
 from app.models.proto.server_pb2 import UserPassword
 from app.models.types import Password
 
-type PasswordLike = Password | TransmitUserPassword
+PasswordLike: TypeAlias = Password | TransmitUserPassword  # noqa: UP040
 
 
 class VerifyResult(NamedTuple):

--- a/app/lib/rich_text.py
+++ b/app/lib/rich_text.py
@@ -4,7 +4,7 @@ from asyncio import TaskGroup
 from collections.abc import Collection, Generator, Iterable, Mapping, Sequence
 from html import escape
 from pathlib import Path
-from typing import Any, Literal, LiteralString, cast
+from typing import Any, Literal, LiteralString, TypeAlias, cast
 from urllib.parse import urlsplit, urlunsplit
 
 import cython
@@ -24,7 +24,7 @@ from app.models.types import ImageProxyId
 from app.services.cache_service import CacheContext, CacheService
 from app.services.image_proxy_service import ImageProxyService
 
-type TextFormat = Literal['html', 'markdown', 'plain']
+TextFormat: TypeAlias = Literal['html', 'markdown', 'plain']  # noqa: UP040
 
 
 async def process_rich_text_markdown(text: str):

--- a/app/lib/standard_pagination.py
+++ b/app/lib/standard_pagination.py
@@ -9,6 +9,7 @@ from typing import (
     Literal,
     LiteralString,
     NamedTuple,
+    TypeAlias,
     TypeVar,
     assert_never,
 )
@@ -49,13 +50,13 @@ class _StandardPaginationQueryPlan(NamedTuple):
     anchor_op: Literal['<', '>'] | None = None
 
 
-type StandardPaginationRequestLike = bytes | StandardPaginationRequest
-type StandardPaginationRequestBody = Annotated[
+StandardPaginationRequestLike: TypeAlias = bytes | StandardPaginationRequest  # noqa: UP040
+StandardPaginationRequestBody: TypeAlias = Annotated[  # noqa: UP040
     bytes, Body(media_type='application/x-protobuf')
 ]
 
-type _OrderDir = Literal['asc', 'desc']
-type _CursorKind = Literal['id', 'datetime', 'text']
+_OrderDir: TypeAlias = Literal['asc', 'desc']  # noqa: UP040
+_CursorKind: TypeAlias = Literal['id', 'datetime', 'text']  # noqa: UP040
 
 _EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
 

--- a/app/lib/webauthn.py
+++ b/app/lib/webauthn.py
@@ -1,6 +1,6 @@
 from hashlib import sha256
 from pathlib import Path
-from typing import Literal, NamedTuple, NotRequired, TypedDict
+from typing import Literal, NamedTuple, NotRequired, TypeAlias, TypedDict
 from urllib.parse import urlsplit
 from uuid import UUID
 
@@ -22,7 +22,7 @@ from app.config import APP_URL
 from app.models.db.user_passkey import AAGUIDInfo, UserPasskey
 from app.models.proto.auth_pb2 import PasskeyAssertion
 
-type _ClientDataType = Literal['webauthn.create', 'webauthn.get']
+_ClientDataType: TypeAlias = Literal['webauthn.create', 'webauthn.get']  # noqa: UP040
 
 
 class _ClientData(TypedDict):

--- a/app/models/proto/changeset.proto
+++ b/app/models/proto/changeset.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package changeset;
 
+import "app/models/proto/element.proto";
 import "app/models/proto/shared.proto";
 import "buf/validate/validate.proto";
 
@@ -11,6 +12,10 @@ service Service {
   }
 
   rpc Get(GetRequest) returns (GetResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+
+  rpc GetDiff(GetDiffRequest) returns (GetDiffResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
 
@@ -64,8 +69,27 @@ message GetRequest {
   uint64 id = 1 [(buf.validate.field).uint64.gt = 0];
 }
 
+message GetDiffRequest {
+  uint64 id = 1 [(buf.validate.field).uint64.gt = 0];
+}
+
 message GetResponse {
   Data changeset = 1 [(buf.validate.field).required = true];
+}
+
+enum DiffAction {
+  create = 0;
+  modify = 1;
+  delete = 2;
+}
+
+message GetDiffResponse {
+  message Element {
+    DiffAction action = 1;
+    element.RenderData render = 2 [(buf.validate.field).required = true];
+  }
+
+  repeated Element elements = 1;
 }
 
 message GetCommentsRequest {

--- a/app/models/scope.py
+++ b/app/models/scope.py
@@ -1,9 +1,9 @@
 from collections.abc import Iterable
-from typing import Literal, get_args
+from typing import Literal, TypeAlias, get_args
 
 from app.models.proto.shared_pb2 import Scope as ProtoScope
 
-type PublicScope = Literal[
+PublicScope: TypeAlias = Literal[  # noqa: UP040
     'read_prefs',
     'write_prefs',
     'write_api',
@@ -12,9 +12,9 @@ type PublicScope = Literal[
     'write_notes',
 ]
 
-PUBLIC_SCOPES = frozenset[PublicScope](get_args(PublicScope.__value__))
+PUBLIC_SCOPES = frozenset[PublicScope](get_args(PublicScope))
 
-type Scope = (
+Scope: TypeAlias = (  # noqa: UP040
     PublicScope
     | Literal[
         # additional scopes

--- a/app/queries/graphhopper_query.py
+++ b/app/queries/graphhopper_query.py
@@ -1,4 +1,4 @@
-from typing import Literal, cast, get_args
+from typing import Literal, TypeAlias, cast, get_args
 
 from fastapi import HTTPException
 from shapely import Point, get_coordinates
@@ -10,10 +10,8 @@ from app.lib.translation import primary_translation_locale
 from app.models.graphhopper import GraphHopperResponse
 from app.models.proto.shared_pb2 import RoutingResult
 
-type GraphHopperProfile = Literal['car', 'bike', 'foot']
-GraphHopperProfiles = frozenset[GraphHopperProfile](
-    get_args(GraphHopperProfile.__value__)
-)
+GraphHopperProfile: TypeAlias = Literal['car', 'bike', 'foot']  # noqa: UP040
+GraphHopperProfiles = frozenset[GraphHopperProfile](get_args(GraphHopperProfile))
 
 
 class GraphHopperQuery:

--- a/app/queries/osrm_query.py
+++ b/app/queries/osrm_query.py
@@ -1,6 +1,6 @@
 import logging
 from functools import cache
-from typing import Literal, cast, get_args
+from typing import Literal, TypeAlias, cast, get_args
 
 import cython
 from fastapi import HTTPException
@@ -13,8 +13,8 @@ from app.lib.translation import t
 from app.models.osrm import OSRMResponse, OSRMStep
 from app.models.proto.shared_pb2 import RoutingResult
 
-type OSRMProfile = Literal['car', 'bike', 'foot']
-OSRMProfiles = frozenset[OSRMProfile](get_args(OSRMProfile.__value__))
+OSRMProfile: TypeAlias = Literal['car', 'bike', 'foot']  # noqa: UP040
+OSRMProfiles = frozenset[OSRMProfile](get_args(OSRMProfile))
 
 
 class OSRMQuery:

--- a/app/queries/valhalla_query.py
+++ b/app/queries/valhalla_query.py
@@ -1,4 +1,4 @@
-from typing import Literal, cast, get_args
+from typing import Literal, TypeAlias, cast, get_args
 
 import numpy as np
 from fastapi import HTTPException
@@ -10,8 +10,8 @@ from app.lib.translation import primary_translation_locale
 from app.models.proto.shared_pb2 import RoutingResult
 from app.models.valhalla import ValhallaResponse
 
-type ValhallaProfile = Literal['auto', 'bicycle', 'pedestrian']
-ValhallaProfiles = frozenset[ValhallaProfile](get_args(ValhallaProfile.__value__))
+ValhallaProfile: TypeAlias = Literal['auto', 'bicycle', 'pedestrian']  # noqa: UP040
+ValhallaProfiles = frozenset[ValhallaProfile](get_args(ValhallaProfile))
 
 
 class ValhallaQuery:

--- a/app/responses/precompressed_static_files.py
+++ b/app/responses/precompressed_static_files.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 from mimetypes import guess_type
 from os import PathLike
 from os import stat_result as StatResultType  # noqa: N812
-from typing import override
+from typing import TypeAlias, override
 
 import cython
 from fastapi import HTTPException
@@ -17,8 +17,8 @@ from starlette_compress._utils import parse_accept_encoding
 
 from app.config import ENV, STATIC_PRECOMPRESSED_CACHE_MAX_ENTRIES
 
-type _CacheKey = tuple[str, str | None]
-type _CacheValue = tuple[str, StatResultType, str | None]
+_CacheKey: TypeAlias = tuple[str, str | None]  # noqa: UP040
+_CacheValue: TypeAlias = tuple[str, StatResultType, str | None]  # noqa: UP040
 
 
 class PrecompressedStaticFiles(StaticFiles):

--- a/app/rpc/changeset.py
+++ b/app/rpc/changeset.py
@@ -27,7 +27,9 @@ from app.models.db.changeset_comment import (
     ChangesetComment,
     changeset_comments_resolve_rich_text,
 )
+from app.models.db.element import Element
 from app.models.db.user import user_proto
+from app.models.element import TypedElementId
 from app.models.proto.changeset_connect import (
     Service,
     ServiceASGIApplication,
@@ -36,8 +38,11 @@ from app.models.proto.changeset_pb2 import (
     AddCommentRequest,
     AddCommentResponse,
     Data,
+    DiffAction,
     GetCommentsRequest,
     GetCommentsResponse,
+    GetDiffRequest,
+    GetDiffResponse,
     GetMapRequest,
     GetMapResponse,
     GetRequest,
@@ -56,6 +61,7 @@ from app.queries.user_subscription_query import UserSubscriptionQuery
 from app.services.changeset_comment_service import ChangesetCommentService
 from app.services.user_subscription_service import UserSubscriptionService
 from app.validators.unicode import normalize_display_name
+from speedup import element_type
 
 
 class _Service(Service):
@@ -144,6 +150,11 @@ class _Service(Service):
     async def get(self, request: GetRequest, ctx: RequestContext):
         id = ChangesetId(request.id)
         return GetResponse(changeset=await _build_data(id))
+
+    @override
+    async def get_diff(self, request: GetDiffRequest, ctx: RequestContext):
+        id = ChangesetId(request.id)
+        return await _build_diff(id)
 
     @override
     async def get_comments(self, request: GetCommentsRequest, ctx: RequestContext):
@@ -257,6 +268,78 @@ async def _build_data(changeset_id: ChangesetId):
     if next_changeset_id is not None:
         result.next_changeset_id = next_changeset_id
     return result
+
+
+async def _build_diff(changeset_id: ChangesetId):
+    if await ChangesetQuery.find_by_id(changeset_id) is None:
+        raise_for.changeset_not_found(changeset_id)
+
+    elements = await ElementQuery.find_by_changeset(changeset_id, sort_by='sequence_id')
+    if not elements:
+        return GetDiffResponse()
+
+    prev_refs: list[tuple[TypedElementId, int]] = [
+        (element['typed_id'], element['version'] - 1)
+        for element in elements
+        if not element['visible'] and element['version'] > 1
+    ]
+    prev_elements = await ElementQuery.find_by_versioned_refs(
+        prev_refs, limit=len(prev_refs)
+    )
+    prev_type_id_map = {element['typed_id']: element for element in prev_elements}
+
+    async with TaskGroup() as tg:
+        tasks = [
+            (
+                element,
+                tg.create_task(
+                    _render_diff_element(
+                        prev_type_id_map[element['typed_id']]
+                        if not element['visible']
+                        and element['typed_id'] in prev_type_id_map
+                        else element
+                    )
+                ),
+            )
+            for element in elements
+        ]
+
+    response = GetDiffResponse()
+    for element, task in tasks:
+        item = response.elements.add()
+        item.action = _changeset_element_action(element)
+        item.render.CopyFrom(task.result())
+    return response
+
+
+async def _render_diff_element(element: Element):
+    if not element['visible']:
+        return FormatRender.encode_elements([], detailed=True)
+
+    type = element_type(element['typed_id'])
+    if type == 'node':
+        return FormatRender.encode_elements([element], detailed=True)
+
+    if type == 'way':
+        members = element['members']
+        if not members:
+            return FormatRender.encode_elements([], detailed=True)
+        nodes = await ElementQuery.find_by_refs(
+            members,
+            at_sequence_id=element['sequence_id'],
+            limit=len(members),
+        )
+        return FormatRender.encode_elements([element, *nodes], detailed=True)
+
+    return FormatRender.encode_elements([], detailed=True)
+
+
+def _changeset_element_action(element: Element):
+    if not element['visible']:
+        return DiffAction.delete
+    if element['version'] == 1:
+        return DiffAction.create
+    return DiffAction.modify
 
 
 async def _build_comments(

--- a/app/services/optimistic_diff/prepare.py
+++ b/app/services/optimistic_diff/prepare.py
@@ -2,7 +2,7 @@ import logging
 from asyncio import TaskGroup
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Final, Literal, assert_never
+from typing import Final, Literal, TypeAlias, assert_never
 
 import cython
 import numpy as np
@@ -28,7 +28,7 @@ from app.queries.changeset_query import ChangesetQuery
 from app.queries.element_query import ElementQuery
 from speedup import element_id, element_type, split_typed_element_id
 
-type OSMChangeAction = Literal['create', 'modify', 'delete']
+OSMChangeAction: TypeAlias = Literal['create', 'modify', 'delete']  # noqa: UP040
 
 
 @dataclass(kw_only=True, slots=True)

--- a/app/validators/display_name.py
+++ b/app/validators/display_name.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, TypeAlias
 
 from annotated_types import MaxLen, MinLen
 
@@ -9,12 +9,12 @@ from app.validators.url import UrlSafeValidator
 from app.validators.whitespace import BoundaryWhitespaceValidator
 from app.validators.xml import XMLSafeValidator
 
-type DisplayNameNormalizing = Annotated[
+DisplayNameNormalizing: TypeAlias = Annotated[  # noqa: UP040
     DisplayName,
     UnicodeValidator,
 ]
 
-type DisplayNameValidating = Annotated[
+DisplayNameValidating: TypeAlias = Annotated[  # noqa: UP040
     DisplayNameNormalizing,
     MinLen(3),
     MaxLen(DISPLAY_NAME_MAX_LENGTH),

--- a/app/validators/email.py
+++ b/app/validators/email.py
@@ -1,6 +1,6 @@
 import logging
 from asyncio import Task, TaskGroup
-from typing import Annotated
+from typing import Annotated, TypeAlias
 
 from annotated_types import MaxLen, MinLen
 from dns.asyncresolver import Resolver
@@ -137,7 +137,7 @@ EmailValidator = BeforeValidator(validate_email)
 
 # ideally, should be defined in app/models/types.py
 # but this causes circular import
-type EmailValidating = Annotated[
+EmailValidating: TypeAlias = Annotated[  # noqa: UP040
     Email,
     MinLen(EMAIL_MIN_LENGTH),
     MaxLen(EMAIL_MAX_LENGTH),

--- a/app/validators/tags.py
+++ b/app/validators/tags.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, TypeAlias
 
 import cython
 from annotated_types import MaxLen, MinLen
@@ -34,7 +34,7 @@ def _validate_tags(
     return v
 
 
-type TagsValidating = Annotated[
+TagsValidating: TypeAlias = Annotated[  # noqa: UP040
     dict[
         Annotated[
             str,

--- a/app/views/index/changeset.scss
+++ b/app/views/index/changeset.scss
@@ -16,4 +16,51 @@
     background: rgba($success, 0.3);
     border: 1px solid rgba($success, 0.5);
   }
+
+  .changeset-diff-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+    margin-bottom: 0.75rem;
+
+    .form-text {
+      flex-basis: 100%;
+      margin-top: 0;
+    }
+  }
+
+  .changeset-diff-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    font-size: 0.8125rem;
+    color: var(--bs-secondary-color);
+
+    span {
+      display: inline-flex;
+      gap: 0.25rem;
+      align-items: center;
+
+      &::before {
+        display: inline-block;
+        width: 0.65rem;
+        height: 0.65rem;
+        content: "";
+        border-radius: 50%;
+      }
+    }
+
+    .diff-create::before {
+      background: #22c55e;
+    }
+
+    .diff-modify::before {
+      background: #f59e0b;
+    }
+
+    .diff-delete::before {
+      background: #ef4444;
+    }
+  }
 }

--- a/app/views/index/changeset.tsx
+++ b/app/views/index/changeset.tsx
@@ -13,13 +13,24 @@ import { useDisposeSignalEffect } from "@lib/dispose-scope"
 import { makeBoundsMinimumSize } from "@lib/map/bounds"
 import { type FocusLayerPaint, focusObjects } from "@lib/map/layers/focus-layer"
 import {
+  addMapLayer,
+  emptyFeatureCollection,
+  hasMapLayer,
+  layersConfig,
+  type LayerId,
+} from "@lib/map/layers/layers"
+import { convertRenderElementsData, renderObjects } from "@lib/map/render-objects"
+import {
   type AddCommentResponseValid,
   type DataValid,
+  DiffAction,
+  type GetDiffResponse_ElementValid,
   Service,
   type Data_Element as Element,
   type GetCommentsResponse_CommentValid,
   type GetCommentsResponseValid,
 } from "@lib/proto/changeset_pb"
+import { connectErrorToMessage, rpcClient } from "@lib/rpc"
 import { ElementType } from "@lib/proto/shared_pb"
 import { ReportButton } from "@lib/report"
 import { StandardForm } from "@lib/standard-form"
@@ -27,7 +38,7 @@ import { PageOrder, StandardPagination } from "@lib/standard-pagination"
 import { Tags } from "@lib/tags"
 import { setPageTitle } from "@lib/title"
 import { showLoginModal } from "../user/login"
-import type { OSMChangeset } from "@lib/types"
+import type { OSMDiffAction, OSMChangeset, OSMObject } from "@lib/types"
 import {
   type ReadonlySignal,
   type Signal,
@@ -36,7 +47,11 @@ import {
   useSignalEffect,
 } from "@preact/signals"
 import { t } from "i18next"
-import type { Map as MaplibreMap } from "maplibre-gl"
+import type {
+  ExpressionSpecification,
+  GeoJSONSource,
+  Map as MaplibreMap,
+} from "maplibre-gl"
 
 const focusPaint: FocusLayerPaint = {
   "fill-opacity": 0,
@@ -44,6 +59,46 @@ const focusPaint: FocusLayerPaint = {
   "line-opacity": 1,
   "line-width": 3,
 }
+
+const DIFF_LAYER_ID = "changeset-diff" as LayerId
+const diffActionColor: ExpressionSpecification = [
+  "match",
+  ["get", "diffAction"],
+  "create",
+  "#22c55e",
+  "modify",
+  "#f59e0b",
+  "delete",
+  "#ef4444",
+  "#f90",
+]
+
+layersConfig.set(DIFF_LAYER_ID, {
+  specification: {
+    type: "geojson",
+    data: emptyFeatureCollection,
+  },
+  layerTypes: ["fill", "line", "circle"],
+  layerOptions: {
+    layout: {
+      "line-cap": "round",
+      "line-join": "round",
+    },
+    paint: {
+      "circle-color": diffActionColor,
+      "circle-opacity": 0.9,
+      "circle-radius": 7,
+      "circle-stroke-color": "#fff",
+      "circle-stroke-width": 2,
+      "fill-color": diffActionColor,
+      "fill-opacity": 0.18,
+      "line-color": diffActionColor,
+      "line-opacity": 0.95,
+      "line-width": 4,
+    },
+  },
+  priority: 139,
+})
 
 export const ChangesetStats = ({
   numCreate,
@@ -68,6 +123,71 @@ const getChangesetElementsTitle = (type: ElementType) => {
     return (count: string) => t("browse.changeset.way", { count })
   return (count: string) => t("browse.changeset.relation", { count })
 }
+
+const getDiffAction = (action: DiffAction): OSMDiffAction => {
+  switch (action) {
+    case DiffAction.create:
+      return "create"
+    case DiffAction.modify:
+      return "modify"
+    case DiffAction.delete:
+      return "delete"
+  }
+  return "modify"
+}
+
+const getChangesetDiffObjects = (
+  elements: GetDiffResponse_ElementValid[],
+): OSMObject[] => {
+  const objects: OSMObject[] = []
+  for (const element of elements) {
+    const diffAction = getDiffAction(element.action)
+    for (const object of convertRenderElementsData(element.render)) {
+      objects.push({ ...object, diffAction })
+    }
+  }
+  return objects
+}
+
+const ChangesetDiffControls = ({
+  enabled,
+  error,
+  pending,
+}: {
+  enabled: Signal<boolean>
+  error: ReadonlySignal<string | null>
+  pending: ReadonlySignal<boolean>
+}) => (
+  <div class="changeset-diff-controls">
+    <button
+      class={`btn btn-sm ${enabled.value ? "btn-primary" : "btn-soft"}`}
+      type="button"
+      aria-pressed={enabled.value}
+      onClick={() => (enabled.value = !enabled.value)}
+    >
+      {pending.value ? (
+        <span
+          class="spinner-border spinner-border-sm me-1"
+          aria-hidden="true"
+        />
+      ) : (
+        <i class="bi bi-intersect me-1" />
+      )}
+      {t("changeset.diff_mode")}
+    </button>
+    {enabled.value && (
+      <div
+        class="changeset-diff-legend"
+        aria-label={t("changeset.diff_legend")}
+      >
+        <span class="diff-create">{t("changeset.created")}</span>
+        <span class="diff-modify">{t("changeset.modified")}</span>
+        <span class="diff-delete">{t("changeset.deleted")}</span>
+      </div>
+    )}
+    {error.value && <div class="form-text text-danger">{error.value}</div>}
+  </div>
+)
 
 const ChangesetHeader = ({ data }: { data: DataValid }) => {
   const isOpen = !data.closedAt
@@ -324,6 +444,11 @@ const ChangesetSidebar = ({
   map: MaplibreMap
   id: ReadonlySignal<bigint>
 }) => {
+  const diffMode = useSignal(false)
+  const diffObjects = useSignal<OSMObject[] | null>(null)
+  const diffPending = useSignal(false)
+  const diffError = useSignal<string | null>(null)
+  const diffChangesetId = useSignal<bigint | null>(null)
   const isSubscribed = useSignal(false)
   const preloadedComments = useSignal<GetCommentsResponseValid | null>(null)
 
@@ -341,6 +466,12 @@ const ChangesetSidebar = ({
     } else if (r.tag === "ready") {
       const d = r.data
       isSubscribed.value = d.isSubscribed
+      if (diffChangesetId.peek() !== d.id) {
+        diffChangesetId.value = d.id
+        diffObjects.value = null
+        diffPending.value = false
+        diffError.value = null
+      }
       setPageTitle(`${t("browse.in_changeset")}: ${d.id}`)
     }
   })
@@ -360,11 +491,55 @@ const ChangesetSidebar = ({
 
   // Effect: Map focus
   useDisposeSignalEffect((scope) => {
-    if (!data.value?.bounds.length) return
+    if (!data.value?.bounds.length || diffMode.value) {
+      focusObjects(map)
+      return
+    }
 
     scope.defer(() => focusObjects(map))
     scope.map(map, "zoomend", () => refocus())
     refocus(true)
+  })
+
+  // Effect: Changeset diff mode
+  useDisposeSignalEffect((scope) => {
+    const clearDiff = () =>
+      map.getSource<GeoJSONSource>(DIFF_LAYER_ID)?.setData(emptyFeatureCollection)
+    scope.defer(clearDiff)
+
+    const d = data.value
+    if (!diffMode.value || !d) {
+      clearDiff()
+      diffPending.value = false
+      return
+    }
+
+    if (!hasMapLayer(map, DIFF_LAYER_ID)) addMapLayer(map, DIFF_LAYER_ID)
+    const cachedObjects = diffObjects.value
+    if (cachedObjects) {
+      map.getSource<GeoJSONSource>(DIFF_LAYER_ID)?.setData(renderObjects(cachedObjects))
+      return
+    }
+
+    diffPending.value = true
+    diffError.value = null
+    void rpcClient(Service)
+      .getDiff({ id: d.id }, { signal: scope.signal })
+      .then((response) => {
+        scope.signal.throwIfAborted()
+        const objects = getChangesetDiffObjects(response.elements)
+        diffObjects.value = objects
+        map.getSource<GeoJSONSource>(DIFF_LAYER_ID)?.setData(renderObjects(objects))
+      })
+      .catch((error: unknown) => {
+        if (scope.signal.aborted) return
+        console.error("ChangesetDiff: Failed to fetch", error)
+        diffError.value = connectErrorToMessage(error)
+        clearDiff()
+      })
+      .finally(() => {
+        if (!scope.signal.aborted) diffPending.value = false
+      })
   })
 
   return (
@@ -387,6 +562,11 @@ const ChangesetSidebar = ({
             </SidebarHeader>
 
             <ChangesetHeader data={d} />
+            <ChangesetDiffControls
+              enabled={diffMode}
+              error={diffError}
+              pending={diffPending}
+            />
             <Tags tags={d.tags} />
 
             {/* Report button */}

--- a/app/views/lib/map/render-objects.ts
+++ b/app/views/lib/map/render-objects.ts
@@ -62,6 +62,7 @@ export const renderObjects = (
       properties: {
         type: "node",
         id: node.id.toString(),
+        diffAction: node.diffAction,
       },
       geometry: {
         type: "Point",
@@ -74,6 +75,7 @@ export const renderObjects = (
     const properties = {
       type: "way",
       id: way.id.toString(),
+      diffAction: way.diffAction,
     }
     features.push({
       type: "Feature",

--- a/app/views/lib/types.ts
+++ b/app/views/lib/types.ts
@@ -1,10 +1,13 @@
 import type { Status } from "@lib/proto/note_pb"
 
+export type OSMDiffAction = "create" | "modify" | "delete"
+
 export interface OSMNode {
   type: "node"
   id: bigint
   geom: [number, number]
   version?: bigint
+  diffAction?: OSMDiffAction
 }
 
 export interface OSMWay {
@@ -13,6 +16,7 @@ export interface OSMWay {
   geom: [number, number][]
   version?: bigint
   area?: boolean
+  diffAction?: OSMDiffAction
 }
 
 interface OSMRelation {

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -43,6 +43,11 @@ changeset:
   count_one: "changeset"
   count_other: "changesets"
   viewing_edits_from_date: Viewing edits from {{date}}
+  diff_mode: Diff mode
+  diff_legend: Changeset diff legend
+  created: Created
+  modified: Modified
+  deleted: Deleted
 changesets_history:
   changesets_above: Changesets above
   changesets_below: Changesets below

--- a/scripts/replication_download.py
+++ b/scripts/replication_download.py
@@ -9,7 +9,7 @@ from dataclasses import asdict, dataclass, replace
 from datetime import UTC, datetime, timedelta
 from itertools import pairwise
 from time import monotonic
-from typing import Literal, get_args
+from typing import Literal, TypeAlias, get_args
 
 import cython
 import orjson
@@ -29,14 +29,14 @@ from app.models.element import TypedElementId
 from app.models.proto.shared_types import ElementType
 from speedup import typed_element_id
 
-type _Dataset = Literal['replication', 'redaction-period', 'cc-by-sa']
-type _Frequency = Literal['minute', 'hour', 'day']
+_Dataset: TypeAlias = Literal['replication', 'redaction-period', 'cc-by-sa']  # noqa: UP040
+_Frequency: TypeAlias = Literal['minute', 'hour', 'day']  # noqa: UP040
 
 _APP_STATE_PATH = REPLICATION_DIR.joinpath('state.json')
 _LOCK_PATH = REPLICATION_DIR.joinpath('.lock')
 
 _NEXT_DATASET: dict[_Dataset, _Dataset] = {
-    from_: to for to, from_ in pairwise(get_args(_Dataset.__value__))
+    from_: to for to, from_ in pairwise(get_args(_Dataset))
 }
 
 _FREQUENCY_TIMEDELTA: dict[_Frequency, timedelta] = {

--- a/scripts/replication_generate.py
+++ b/scripts/replication_generate.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime, timedelta
 from functools import cache
 from pathlib import Path
 from shutil import copyfile
-from typing import Literal, TypedDict, get_args
+from typing import Literal, TypeAlias, TypedDict, get_args
 
 import cython
 from psycopg import AsyncConnection
@@ -31,7 +31,7 @@ class _State(TypedDict):
     timestamp: datetime
 
 
-type _TimeSpan = Literal['minute', 'hour', 'day']
+_TimeSpan: TypeAlias = Literal['minute', 'hour', 'day']  # noqa: UP040
 
 _TIMESPAN_DELTA: dict[_TimeSpan, timedelta] = {
     'minute': timedelta(minutes=1),
@@ -411,7 +411,7 @@ def main():
     parser = ArgumentParser(description='Generate replication diffs continuously')
     parser.add_argument(
         'timespan',
-        choices=get_args(_TimeSpan.__value__),
+        choices=get_args(_TimeSpan),
         help='Timespan for replication diffs',
     )
     parser.add_argument(


### PR DESCRIPTION
Fixes #7.

## Summary
- add a dedicated changeset GetDiff RPC that returns renderable changed nodes/ways with create/modify/delete actions
- add a changeset page diff toggle that lazy-loads diff geometry without refreshing the page
- render diff objects on a dedicated map layer with created/modified/deleted coloring and legend

## Verification
- env PATH="$PWD/.venv/bin:$PWD/node_modules/.bin:$PATH" sh shellscripts/proto-pipeline.sh
- buf lint --path app/models/proto
- uv run ruff check app/format/element_list.py app/rpc/changeset.py
- python -m py_compile app/format/element_list.py app/rpc/changeset.py
- uv run python Cython cythonize smoke for app/format/element_list.py and app/rpc/changeset.py
- env PATH="$PWD/node_modules/.bin:$PATH" mise exec bun@1.3.13 -- bunx tsc --noEmit --pretty false --skipLibCheck (no app errors; existing @jsr/zod__zod node_modules type errors remain)

## Notes
A full local Vite build reached module/chunk rendering but is blocked in this checkout by the existing rolldown-vite legacy polyfill `emitFile` prebuilt-chunk issue.