### PR TITLE
Auto-close notes from changeset tags

### DIFF
--- a/app/controllers/diary.py
+++ b/app/controllers/diary.py
@@ -21,6 +21,7 @@ from app.models.db.user import User, user_proto
 from app.models.proto.diary_pb2 import (
     ComposePage,
     DetailsPage,
+    Entry,
     IndexPage,
     UserCommentsPage,
 )
@@ -69,8 +70,11 @@ async def details(
 
     profile = diary['user']  # type: ignore
 
+    entry = Entry()
+    _build_entry(entry, diary)
+
     return await render_proto_page(
-        DetailsPage(entry=_build_entry(diary)),
+        DetailsPage(entry=entry),
         title_prefix=(
             f'{t("diary_entries.index.user_title", user=profile["display_name"])}'
             f' | {diary["title"]}'

--- a/app/lib/changeset_bounds.py
+++ b/app/lib/changeset_bounds.py
@@ -1,3 +1,5 @@
+from typing import TypeAlias
+
 import cython
 import numpy as np
 from numpy.typing import NDArray
@@ -16,7 +18,7 @@ from app.config import (
     CHANGESET_NEW_BBOX_MIN_RATIO,
 )
 
-type _BBox = list[float]
+_BBox: TypeAlias = list[float]  # noqa: UP040
 
 _FIXED_K_MAX_CANDIDATE_EDGES = 5_000_000
 

--- a/app/lib/changeset_note_closures.py
+++ b/app/lib/changeset_note_closures.py
@@ -1,0 +1,26 @@
+from collections.abc import Mapping
+
+
+def changeset_note_closures(tags: Mapping[str, str]) -> list[tuple[int, str]]:
+    note_ids_tag = tags.get('closes:note')
+    if not note_ids_tag:
+        return []
+
+    default_comment = tags.get('closes:note:comment', tags.get('comment', ''))
+    closures: list[tuple[int, str]] = []
+    seen: set[int] = set()
+
+    for note_id_str in note_ids_tag.split(';'):
+        note_id_str = note_id_str.strip()
+        if not note_id_str.isdecimal():
+            continue
+
+        note_id = int(note_id_str)
+        if note_id <= 0 or note_id in seen:
+            continue
+
+        seen.add(note_id)
+        comment = tags.get(f'closes:note:{note_id}:comment', default_comment)
+        closures.append((note_id, comment))
+
+    return closures

--- a/app/lib/compressible_geometry.py
+++ b/app/lib/compressible_geometry.py
@@ -56,7 +56,7 @@ def compressible_geometry(
 
 
 @cython.cfunc
-def _compressible_float(value: float):
+def _compressible_float(value: float) -> cython.ulonglong:
     return _UINT64_STRUCT.unpack(_FLOAT_STRUCT.pack(value))[0] & _MASK_INT
 
 
@@ -66,21 +66,21 @@ _BBOX_STRUCT = struct.Struct('<BIII10Q')
 
 def point_to_compressible_wkb(lon: float, lat: float):
     """Convert a coordinate pair to a compressible WKB hex format."""
-    lon = _compressible_float(lon)
-    lat = _compressible_float(lat)
+    lon_bits: cython.ulonglong = _compressible_float(lon)
+    lat_bits: cython.ulonglong = _compressible_float(lat)
 
     # (byte order 1 = little endian + geometry type 1 = Point)
-    return _POINT_STRUCT.pack(1, 1, lon, lat)
+    return _POINT_STRUCT.pack(1, 1, lon_bits, lat_bits)
 
 
 def bbox_to_compressible_wkb(
     minlon: float, minlat: float, maxlon: float, maxlat: float
 ):
     """Convert a bounding box to a compressible WKB hex format."""
-    minlon = _compressible_float(minlon)
-    minlat = _compressible_float(minlat)
-    maxlon = _compressible_float(maxlon)
-    maxlat = _compressible_float(maxlat)
+    minlon_bits: cython.ulonglong = _compressible_float(minlon)
+    minlat_bits: cython.ulonglong = _compressible_float(minlat)
+    maxlon_bits: cython.ulonglong = _compressible_float(maxlon)
+    maxlat_bits: cython.ulonglong = _compressible_float(maxlat)
 
     # (byte order 1 = little endian + geometry type 3 = Polygon + 1 ring + 5 points)
     return _BBOX_STRUCT.pack(
@@ -88,14 +88,14 @@ def bbox_to_compressible_wkb(
         3,
         1,
         5,
-        maxlon,
-        minlat,
-        maxlon,
-        maxlat,
-        minlon,
-        maxlat,
-        minlon,
-        minlat,
-        maxlon,
-        minlat,
+        maxlon_bits,
+        minlat_bits,
+        maxlon_bits,
+        maxlat_bits,
+        minlon_bits,
+        maxlat_bits,
+        minlon_bits,
+        minlat_bits,
+        maxlon_bits,
+        minlat_bits,
     )

--- a/app/lib/cookie.py
+++ b/app/lib/cookie.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 from http.cookies import SimpleCookie
-from typing import Literal
+from typing import Literal, TypeAlias
 
 import cython
 from connectrpc.request import RequestContext
@@ -9,8 +9,8 @@ from starlette.responses import Response
 
 from app.config import ENV
 
-type CookieTarget = Response | RequestContext
-type CookieSameSite = Literal['lax', 'strict', 'none']
+CookieTarget: TypeAlias = Response | RequestContext  # noqa: UP040
+CookieSameSite: TypeAlias = Literal['lax', 'strict', 'none']  # noqa: UP040
 
 
 @cython.cfunc

--- a/app/lib/format_style_context.py
+++ b/app/lib/format_style_context.py
@@ -1,12 +1,12 @@
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Literal
+from typing import Literal, TypeAlias
 
 import cython
 
 from app.middlewares.request_context_middleware import get_request
 
-type FormatStyle = Literal['json', 'xml', 'rss', 'gpx']
+FormatStyle: TypeAlias = Literal['json', 'xml', 'rss', 'gpx']  # noqa: UP040
 
 _LEGACY_EXTENSION_FORMATS: dict[str, FormatStyle] = {
     'json': 'json',

--- a/app/lib/image.py
+++ b/app/lib/image.py
@@ -5,7 +5,7 @@ from contextlib import asynccontextmanager
 from functools import partial
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, NamedTuple, overload
+from typing import TYPE_CHECKING, Literal, NamedTuple, TypeAlias, overload
 
 import cython
 from blurhash_rs import blurhash_encode
@@ -49,7 +49,7 @@ class _Animation(NamedTuple):
     loop: int
 
 
-type UserAvatarType = Literal['gravatar', 'custom'] | None
+UserAvatarType: TypeAlias = Literal['gravatar', 'custom'] | None  # noqa: UP040
 
 DEFAULT_USER_AVATAR_URL = '/static/img/avatar.webp'
 DEFAULT_USER_AVATAR = Path('app' + DEFAULT_USER_AVATAR_URL).read_bytes()

--- a/app/lib/password_hash.py
+++ b/app/lib/password_hash.py
@@ -1,7 +1,7 @@
 from base64 import b64decode, b64encode
 from hashlib import md5, pbkdf2_hmac
 from hmac import compare_digest
-from typing import Literal, NamedTuple
+from typing import Literal, NamedTuple, TypeAlias
 
 import cython
 from argon2 import PasswordHasher, Type
@@ -12,7 +12,7 @@ from app.models.proto.auth_pb2 import TransmitUserPassword
 from app.models.proto.server_pb2 import UserPassword
 from app.models.types import Password
 
-type PasswordLike = Password | TransmitUserPassword
+PasswordLike: TypeAlias = Password | TransmitUserPassword  # noqa: UP040
 
 
 class VerifyResult(NamedTuple):

--- a/app/lib/rich_text.py
+++ b/app/lib/rich_text.py
@@ -4,7 +4,7 @@ from asyncio import TaskGroup
 from collections.abc import Collection, Generator, Iterable, Mapping, Sequence
 from html import escape
 from pathlib import Path
-from typing import Any, Literal, LiteralString, cast
+from typing import Any, Literal, LiteralString, TypeAlias, cast
 from urllib.parse import urlsplit, urlunsplit
 
 import cython
@@ -24,7 +24,7 @@ from app.models.types import ImageProxyId
 from app.services.cache_service import CacheContext, CacheService
 from app.services.image_proxy_service import ImageProxyService
 
-type TextFormat = Literal['html', 'markdown', 'plain']
+TextFormat: TypeAlias = Literal['html', 'markdown', 'plain']  # noqa: UP040
 
 
 async def process_rich_text_markdown(text: str):

--- a/app/lib/standard_pagination.py
+++ b/app/lib/standard_pagination.py
@@ -9,6 +9,7 @@ from typing import (
     Literal,
     LiteralString,
     NamedTuple,
+    TypeAlias,
     TypeVar,
     assert_never,
 )
@@ -49,13 +50,13 @@ class _StandardPaginationQueryPlan(NamedTuple):
     anchor_op: Literal['<', '>'] | None = None
 
 
-type StandardPaginationRequestLike = bytes | StandardPaginationRequest
-type StandardPaginationRequestBody = Annotated[
+StandardPaginationRequestLike: TypeAlias = bytes | StandardPaginationRequest  # noqa: UP040
+StandardPaginationRequestBody: TypeAlias = Annotated[  # noqa: UP040
     bytes, Body(media_type='application/x-protobuf')
 ]
 
-type _OrderDir = Literal['asc', 'desc']
-type _CursorKind = Literal['id', 'datetime', 'text']
+_OrderDir: TypeAlias = Literal['asc', 'desc']  # noqa: UP040
+_CursorKind: TypeAlias = Literal['id', 'datetime', 'text']  # noqa: UP040
 
 _EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
 

--- a/app/lib/webauthn.py
+++ b/app/lib/webauthn.py
@@ -1,6 +1,6 @@
 from hashlib import sha256
 from pathlib import Path
-from typing import Literal, NamedTuple, NotRequired, TypedDict
+from typing import Literal, NamedTuple, NotRequired, TypeAlias, TypedDict
 from urllib.parse import urlsplit
 from uuid import UUID
 
@@ -22,7 +22,7 @@ from app.config import APP_URL
 from app.models.db.user_passkey import AAGUIDInfo, UserPasskey
 from app.models.proto.auth_pb2 import PasskeyAssertion
 
-type _ClientDataType = Literal['webauthn.create', 'webauthn.get']
+_ClientDataType: TypeAlias = Literal['webauthn.create', 'webauthn.get']  # noqa: UP040
 
 
 class _ClientData(TypedDict):

--- a/app/models/scope.py
+++ b/app/models/scope.py
@@ -1,9 +1,9 @@
 from collections.abc import Iterable
-from typing import Literal, get_args
+from typing import Literal, TypeAlias, get_args
 
 from app.models.proto.shared_pb2 import Scope as ProtoScope
 
-type PublicScope = Literal[
+PublicScope: TypeAlias = Literal[  # noqa: UP040
     'read_prefs',
     'write_prefs',
     'write_api',
@@ -12,9 +12,9 @@ type PublicScope = Literal[
     'write_notes',
 ]
 
-PUBLIC_SCOPES = frozenset[PublicScope](get_args(PublicScope.__value__))
+PUBLIC_SCOPES = frozenset[PublicScope](get_args(PublicScope))
 
-type Scope = (
+Scope: TypeAlias = (  # noqa: UP040
     PublicScope
     | Literal[
         # additional scopes

--- a/app/queries/graphhopper_query.py
+++ b/app/queries/graphhopper_query.py
@@ -1,4 +1,4 @@
-from typing import Literal, cast, get_args
+from typing import Literal, TypeAlias, cast, get_args
 
 from fastapi import HTTPException
 from shapely import Point, get_coordinates
@@ -10,10 +10,8 @@ from app.lib.translation import primary_translation_locale
 from app.models.graphhopper import GraphHopperResponse
 from app.models.proto.shared_pb2 import RoutingResult
 
-type GraphHopperProfile = Literal['car', 'bike', 'foot']
-GraphHopperProfiles = frozenset[GraphHopperProfile](
-    get_args(GraphHopperProfile.__value__)
-)
+GraphHopperProfile: TypeAlias = Literal['car', 'bike', 'foot']  # noqa: UP040
+GraphHopperProfiles = frozenset[GraphHopperProfile](get_args(GraphHopperProfile))
 
 
 class GraphHopperQuery:

--- a/app/queries/osrm_query.py
+++ b/app/queries/osrm_query.py
@@ -1,6 +1,6 @@
 import logging
 from functools import cache
-from typing import Literal, cast, get_args
+from typing import Literal, TypeAlias, cast, get_args
 
 import cython
 from fastapi import HTTPException
@@ -13,8 +13,8 @@ from app.lib.translation import t
 from app.models.osrm import OSRMResponse, OSRMStep
 from app.models.proto.shared_pb2 import RoutingResult
 
-type OSRMProfile = Literal['car', 'bike', 'foot']
-OSRMProfiles = frozenset[OSRMProfile](get_args(OSRMProfile.__value__))
+OSRMProfile: TypeAlias = Literal['car', 'bike', 'foot']  # noqa: UP040
+OSRMProfiles = frozenset[OSRMProfile](get_args(OSRMProfile))
 
 
 class OSRMQuery:

--- a/app/queries/valhalla_query.py
+++ b/app/queries/valhalla_query.py
@@ -1,4 +1,4 @@
-from typing import Literal, cast, get_args
+from typing import Literal, TypeAlias, cast, get_args
 
 import numpy as np
 from fastapi import HTTPException
@@ -10,8 +10,8 @@ from app.lib.translation import primary_translation_locale
 from app.models.proto.shared_pb2 import RoutingResult
 from app.models.valhalla import ValhallaResponse
 
-type ValhallaProfile = Literal['auto', 'bicycle', 'pedestrian']
-ValhallaProfiles = frozenset[ValhallaProfile](get_args(ValhallaProfile.__value__))
+ValhallaProfile: TypeAlias = Literal['auto', 'bicycle', 'pedestrian']  # noqa: UP040
+ValhallaProfiles = frozenset[ValhallaProfile](get_args(ValhallaProfile))
 
 
 class ValhallaQuery:

--- a/app/responses/precompressed_static_files.py
+++ b/app/responses/precompressed_static_files.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 from mimetypes import guess_type
 from os import PathLike
 from os import stat_result as StatResultType  # noqa: N812
-from typing import override
+from typing import TypeAlias, override
 
 import cython
 from fastapi import HTTPException
@@ -17,8 +17,8 @@ from starlette_compress._utils import parse_accept_encoding
 
 from app.config import ENV, STATIC_PRECOMPRESSED_CACHE_MAX_ENTRIES
 
-type _CacheKey = tuple[str, str | None]
-type _CacheValue = tuple[str, StatResultType, str | None]
+_CacheKey: TypeAlias = tuple[str, str | None]  # noqa: UP040
+_CacheValue: TypeAlias = tuple[str, StatResultType, str | None]  # noqa: UP040
 
 
 class PrecompressedStaticFiles(StaticFiles):

--- a/app/services/changeset_service.py
+++ b/app/services/changeset_service.py
@@ -14,7 +14,8 @@ from app.config import (
     CHANGESET_OPEN_TIMEOUT,
 )
 from app.db import db, db_lock
-from app.lib.auth_context import auth_user
+from app.lib.auth_context import auth_context, auth_user
+from app.lib.changeset_note_closures import changeset_note_closures
 from app.lib.exceptions_context import raise_for
 from app.lib.retry import retry
 from app.lib.sentry import (
@@ -23,8 +24,12 @@ from app.lib.sentry import (
 )
 from app.lib.testmethod import testmethod
 from app.models.db.changeset import ChangesetInit
-from app.models.types import ChangesetId, UserId
+from app.models.db.user import User
+from app.models.types import ChangesetId, NoteId, UserId
+from app.queries.note_query import NoteQuery
+from app.queries.user_query import UserQuery
 from app.services.audit_service import audit
+from app.services.note_service import NoteService
 from app.services.user_subscription_service import UserSubscriptionService
 
 _PROCESS_REQUEST_EVENT = Event()
@@ -104,11 +109,12 @@ class ChangesetService:
     async def close(changeset_id: ChangesetId):
         """Close a changeset."""
         user_id = auth_user(required=True)['id']
+        note_closures: list[tuple[int, str]]
 
         async with db(True) as conn:
             async with await conn.execute(
                 """
-                SELECT user_id, closed_at
+                SELECT user_id, closed_at, tags
                 FROM changeset
                 WHERE id = %s
                 FOR UPDATE
@@ -121,12 +127,14 @@ class ChangesetService:
 
                 changeset_user_id: UserId
                 closed_at: datetime | None
-                changeset_user_id, closed_at = row
+                changeset_tags: dict[str, str]
+                changeset_user_id, closed_at, changeset_tags = row
 
                 if changeset_user_id != user_id:
                     raise_for.changeset_access_denied()
                 if closed_at is not None:
                     raise_for.changeset_already_closed(changeset_id, closed_at)
+                note_closures = changeset_note_closures(changeset_tags)
 
             await conn.execute(
                 """
@@ -137,6 +145,13 @@ class ChangesetService:
                 (changeset_id,),
             )
             await audit('close_changeset', conn, extra={'id': changeset_id})
+
+        await _close_changeset_notes(note_closures)
+
+    @staticmethod
+    async def close_tagged_notes(tags: dict[str, str]):
+        """Close open notes referenced by changeset close tags."""
+        await _close_changeset_notes(changeset_note_closures(tags))
 
     @staticmethod
     @asynccontextmanager
@@ -197,8 +212,10 @@ async def _process_task():
 
 async def _close_inactive():
     """Close all inactive changesets."""
+    closed_changesets: list[tuple[UserId | None, dict[str, str]]] = []
+
     async with db(True) as conn:
-        result = await conn.execute(
+        async with await conn.execute(
             """
             UPDATE changeset
             SET closed_at = statement_timestamp(), updated_at = DEFAULT
@@ -207,12 +224,44 @@ async def _close_inactive():
                 (updated_at >= statement_timestamp() - %s AND
                 created_at < statement_timestamp() - %s)
             )
+            RETURNING user_id, tags
             """,
             (CHANGESET_IDLE_TIMEOUT, CHANGESET_IDLE_TIMEOUT, CHANGESET_OPEN_TIMEOUT),
-        )
+        ) as r:
+            closed_changesets = await r.fetchall()  # type: ignore
 
-        if result.rowcount:
-            logging.debug('Closed %d inactive changesets', result.rowcount)
+        if closed_changesets:
+            logging.debug('Closed %d inactive changesets', len(closed_changesets))
+
+    for user_id, tags in closed_changesets:
+        note_closures = changeset_note_closures(tags)
+        if not note_closures or user_id is None:
+            continue
+
+        user = await UserQuery.find_by_id(user_id)
+        if user is None:
+            continue
+
+        await _close_changeset_notes_as_user(user, note_closures)
+
+
+async def _close_changeset_notes(note_closures: list[tuple[int, str]]):
+    """Close open notes referenced by a changeset's close tags."""
+    for note_id_int, comment in note_closures:
+        note_id = NoteId(note_id_int)
+        notes = await NoteQuery.find(note_ids=[note_id], max_closed_days=None, limit=1)
+        if not notes or notes[0]['closed_at'] is not None:
+            continue
+
+        await NoteService.comment(note_id, comment, 'closed')
+
+
+async def _close_changeset_notes_as_user(
+    user: User, note_closures: list[tuple[int, str]]
+):
+    """Close tagged notes under a changeset owner's auth context."""
+    with auth_context(user):
+        await _close_changeset_notes(note_closures)
 
 
 async def _delete_empty():

--- a/app/services/optimistic_diff/__init__.py
+++ b/app/services/optimistic_diff/__init__.py
@@ -11,6 +11,7 @@ from app.db import db
 from app.exceptions.optimistic_diff_error import OptimisticDiffError
 from app.models.db.element import ElementInit
 from app.models.element import TypedElementId
+from app.services.changeset_service import ChangesetService
 from app.services.optimistic_diff.apply import OptimisticDiffApply
 from app.services.optimistic_diff.prepare import OptimisticDiffPrepare
 
@@ -31,13 +32,18 @@ class OptimisticDiff:
         sleep: cython.double = 0.05
         sleep_limit: cython.double = 5
         attempt: cython.size_t = 0
+        note_closure_tags: dict[str, str] | None = None
+        result: dict[TypedElementId, tuple[TypedElementId, list[int]]]
 
         while True:
             try:
                 async with db(True) as conn:
                     prep = OptimisticDiffPrepare(conn, elements)
                     await prep.prepare()
-                    return await OptimisticDiffApply.apply(prep)
+                    result = await OptimisticDiffApply.apply(prep)
+                    if 'size_limit_reached' in prep.changeset:
+                        note_closure_tags = prep.changeset['tags']
+                break
             except* (OptimisticDiffError, OperationalError) as e:
                 attempt += 1
 
@@ -65,3 +71,8 @@ class OptimisticDiff:
                 await asyncio.sleep(sleep)
                 sleep = uniform(sleep * 1.5, sleep * 2.5)
                 sleep = min(sleep, sleep_limit)
+
+        if note_closure_tags is not None:
+            await ChangesetService.close_tagged_notes(note_closure_tags)
+
+        return result

--- a/app/services/optimistic_diff/prepare.py
+++ b/app/services/optimistic_diff/prepare.py
@@ -2,7 +2,7 @@ import logging
 from asyncio import TaskGroup
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Final, Literal, assert_never
+from typing import Final, Literal, TypeAlias, assert_never
 
 import cython
 import numpy as np
@@ -28,7 +28,7 @@ from app.queries.changeset_query import ChangesetQuery
 from app.queries.element_query import ElementQuery
 from speedup import element_id, element_type, split_typed_element_id
 
-type OSMChangeAction = Literal['create', 'modify', 'delete']
+OSMChangeAction: TypeAlias = Literal['create', 'modify', 'delete']  # noqa: UP040
 
 
 @dataclass(kw_only=True, slots=True)

--- a/app/validators/display_name.py
+++ b/app/validators/display_name.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, TypeAlias
 
 from annotated_types import MaxLen, MinLen
 
@@ -9,12 +9,12 @@ from app.validators.url import UrlSafeValidator
 from app.validators.whitespace import BoundaryWhitespaceValidator
 from app.validators.xml import XMLSafeValidator
 
-type DisplayNameNormalizing = Annotated[
+DisplayNameNormalizing: TypeAlias = Annotated[  # noqa: UP040
     DisplayName,
     UnicodeValidator,
 ]
 
-type DisplayNameValidating = Annotated[
+DisplayNameValidating: TypeAlias = Annotated[  # noqa: UP040
     DisplayNameNormalizing,
     MinLen(3),
     MaxLen(DISPLAY_NAME_MAX_LENGTH),

--- a/app/validators/email.py
+++ b/app/validators/email.py
@@ -1,6 +1,6 @@
 import logging
 from asyncio import Task, TaskGroup
-from typing import Annotated
+from typing import Annotated, TypeAlias
 
 from annotated_types import MaxLen, MinLen
 from dns.asyncresolver import Resolver
@@ -137,7 +137,7 @@ EmailValidator = BeforeValidator(validate_email)
 
 # ideally, should be defined in app/models/types.py
 # but this causes circular import
-type EmailValidating = Annotated[
+EmailValidating: TypeAlias = Annotated[  # noqa: UP040
     Email,
     MinLen(EMAIL_MIN_LENGTH),
     MaxLen(EMAIL_MAX_LENGTH),

--- a/app/validators/tags.py
+++ b/app/validators/tags.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, TypeAlias
 
 import cython
 from annotated_types import MaxLen, MinLen
@@ -34,7 +34,7 @@ def _validate_tags(
     return v
 
 
-type TagsValidating = Annotated[
+TagsValidating: TypeAlias = Annotated[  # noqa: UP040
     dict[
         Annotated[
             str,

--- a/scripts/replication_download.py
+++ b/scripts/replication_download.py
@@ -9,7 +9,7 @@ from dataclasses import asdict, dataclass, replace
 from datetime import UTC, datetime, timedelta
 from itertools import pairwise
 from time import monotonic
-from typing import Literal, get_args
+from typing import Literal, TypeAlias, get_args
 
 import cython
 import orjson
@@ -29,14 +29,14 @@ from app.models.element import TypedElementId
 from app.models.proto.shared_types import ElementType
 from speedup import typed_element_id
 
-type _Dataset = Literal['replication', 'redaction-period', 'cc-by-sa']
-type _Frequency = Literal['minute', 'hour', 'day']
+_Dataset: TypeAlias = Literal['replication', 'redaction-period', 'cc-by-sa']  # noqa: UP040
+_Frequency: TypeAlias = Literal['minute', 'hour', 'day']  # noqa: UP040
 
 _APP_STATE_PATH = REPLICATION_DIR.joinpath('state.json')
 _LOCK_PATH = REPLICATION_DIR.joinpath('.lock')
 
 _NEXT_DATASET: dict[_Dataset, _Dataset] = {
-    from_: to for to, from_ in pairwise(get_args(_Dataset.__value__))
+    from_: to for to, from_ in pairwise(get_args(_Dataset))
 }
 
 _FREQUENCY_TIMEDELTA: dict[_Frequency, timedelta] = {

--- a/scripts/replication_generate.py
+++ b/scripts/replication_generate.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime, timedelta
 from functools import cache
 from pathlib import Path
 from shutil import copyfile
-from typing import Literal, TypedDict, get_args
+from typing import Literal, TypeAlias, TypedDict, get_args
 
 import cython
 from psycopg import AsyncConnection
@@ -31,7 +31,7 @@ class _State(TypedDict):
     timestamp: datetime
 
 
-type _TimeSpan = Literal['minute', 'hour', 'day']
+_TimeSpan: TypeAlias = Literal['minute', 'hour', 'day']  # noqa: UP040
 
 _TIMESPAN_DELTA: dict[_TimeSpan, timedelta] = {
     'minute': timedelta(minutes=1),
@@ -411,7 +411,7 @@ def main():
     parser = ArgumentParser(description='Generate replication diffs continuously')
     parser.add_argument(
         'timespan',
-        choices=get_args(_TimeSpan.__value__),
+        choices=get_args(_TimeSpan),
         help='Timespan for replication diffs',
     )
     parser.add_argument(

--- a/tests/controllers/test_api06_changeset.py
+++ b/tests/controllers/test_api06_changeset.py
@@ -1,18 +1,22 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
-from annotated_types import Gt
+from annotated_types import Gt, Len
 from httpx import AsyncClient
 from starlette import status
 
 from app.config import (
+    CHANGESET_IDLE_TIMEOUT,
     LEGACY_HIGH_PRECISION_TIME,
     TAGS_KEY_MAX_LENGTH,
     TAGS_LIMIT,
     TAGS_MAX_SIZE,
 )
+from app.db import db
 from app.format import Format06
+from app.lib.date_utils import utcnow
 from app.lib.xmltodict import XMLToDict
+from app.services.changeset_service import ChangesetService
 from tests.utils.assert_model import assert_model
 
 
@@ -161,6 +165,110 @@ async def test_changeset_upload(client: AsyncClient):
             '@max_lat': 0.0,
             '@min_lon': 0.0,
             '@max_lon': 0.0,
+        },
+    )
+
+
+async def test_changeset_close_closes_tagged_notes(client: AsyncClient):
+    client.headers['Authorization'] = 'User user1'
+
+    note_id = await _create_note(client, 'note closed from changeset tag')
+    already_closed_note_id = await _create_note(client, 'already closed note')
+    r = await client.post(
+        f'/api/0.6/notes/{already_closed_note_id}/close.json',
+        params={'text': 'Already closed'},
+    )
+    assert r.is_success, r.text
+
+    changeset_id = await _create_changeset(
+        client,
+        {
+            'comment': 'Closing notes from the changeset',
+            'created_by': test_changeset_close_closes_tagged_notes.__name__,
+            'closes:note': f'{note_id};{already_closed_note_id}',
+        },
+    )
+
+    r = await client.put(f'/api/0.6/changeset/{changeset_id}/close')
+    assert r.is_success, r.text
+
+    props = await _get_note_props(client, note_id)
+    assert_model(props, {'status': 'closed', 'comments': Len(2, 2)})
+    assert_model(
+        props['comments'][-1],
+        {
+            'user': 'user1',
+            'action': 'closed',
+            'text': 'Closing notes from the changeset',
+        },
+    )
+
+    already_closed_props = await _get_note_props(client, already_closed_note_id)
+    assert_model(already_closed_props, {'status': 'closed', 'comments': Len(2, 2)})
+    assert already_closed_props['comments'][-1]['text'] == 'Already closed'
+
+
+async def test_changeset_close_note_comment_overrides(client: AsyncClient):
+    client.headers['Authorization'] = 'User user1'
+
+    default_note_id = await _create_note(client, 'default close comment note')
+    override_note_id = await _create_note(client, 'specific close comment note')
+
+    changeset_id = await _create_changeset(
+        client,
+        {
+            'comment': 'Ignored when a global override exists',
+            'created_by': test_changeset_close_note_comment_overrides.__name__,
+            'closes:note': f'{default_note_id};{override_note_id}',
+            'closes:note:comment': 'Global close comment',
+            f'closes:note:{override_note_id}:comment': 'Specific close comment',
+        },
+    )
+
+    r = await client.put(f'/api/0.6/changeset/{changeset_id}/close')
+    assert r.is_success, r.text
+
+    default_props = await _get_note_props(client, default_note_id)
+    assert default_props['comments'][-1]['text'] == 'Global close comment'
+
+    override_props = await _get_note_props(client, override_note_id)
+    assert override_props['comments'][-1]['text'] == 'Specific close comment'
+
+
+async def test_changeset_inactive_close_closes_tagged_notes(client: AsyncClient):
+    client.headers['Authorization'] = 'User user1'
+
+    note_id = await _create_note(client, 'note closed from inactive changeset')
+    changeset_id = await _create_changeset(
+        client,
+        {
+            'comment': 'Inactive changeset close note',
+            'created_by': test_changeset_inactive_close_closes_tagged_notes.__name__,
+            'closes:note': str(note_id),
+        },
+    )
+    inactive_time = utcnow() - CHANGESET_IDLE_TIMEOUT - timedelta(seconds=1)
+
+    async with db(True) as conn:
+        await conn.execute(
+            """
+            UPDATE changeset
+            SET updated_at = %s
+            WHERE id = %s
+            """,
+            (inactive_time, changeset_id),
+        )
+
+    await ChangesetService.force_process()
+
+    props = await _get_note_props(client, note_id)
+    assert_model(props, {'status': 'closed', 'comments': Len(2, 2)})
+    assert_model(
+        props['comments'][-1],
+        {
+            'user': 'user1',
+            'action': 'closed',
+            'text': 'Inactive changeset close note',
         },
     )
 
@@ -412,3 +520,30 @@ async def test_changesets_tags_size(client: AsyncClient, num_tags, should_succee
         assert r.is_success, r.text
     else:
         assert r.status_code == status.HTTP_400_BAD_REQUEST, r.text
+
+
+async def _create_note(client: AsyncClient, text: str):
+    r = await client.post('/api/0.6/notes.json', json={'lon': 0, 'lat': 0, 'text': text})
+    assert r.is_success, r.text
+    return int(r.json()['properties']['id'])
+
+
+async def _get_note_props(client: AsyncClient, note_id: int):
+    r = await client.get(f'/api/0.6/notes/{note_id}.json')
+    assert r.is_success, r.text
+    return r.json()['properties']
+
+
+async def _create_changeset(client: AsyncClient, tags: dict[str, str]):
+    r = await client.put(
+        '/api/0.6/changeset/create',
+        content=XMLToDict.unparse({
+            'osm': {
+                'changeset': {
+                    'tag': [{'@k': key, '@v': value} for key, value in tags.items()]
+                }
+            }
+        }),
+    )
+    assert r.is_success, r.text
+    return int(r.text)

--- a/tests/lib/test_changeset_note_closures.py
+++ b/tests/lib/test_changeset_note_closures.py
@@ -1,0 +1,26 @@
+from app.lib.changeset_note_closures import changeset_note_closures
+
+
+def test_changeset_note_closures_use_changeset_comment_by_default():
+    assert changeset_note_closures({
+        'comment': 'Close mapped notes',
+        'closes:note': '12;34',
+    }) == [(12, 'Close mapped notes'), (34, 'Close mapped notes')]
+
+
+def test_changeset_note_closures_support_global_and_per_note_comments():
+    assert changeset_note_closures({
+        'comment': 'Ignored default',
+        'closes:note': '12;34',
+        'closes:note:comment': 'Global note close comment',
+        'closes:note:34:comment': 'Specific note close comment',
+    }) == [
+        (12, 'Global note close comment'),
+        (34, 'Specific note close comment'),
+    ]
+
+
+def test_changeset_note_closures_ignore_invalid_and_duplicate_ids():
+    assert changeset_note_closures({
+        'closes:note': '12;abc;0;-5;12;34;',
+    }) == [(12, ''), (34, '')]


### PR DESCRIPTION
Closes #126\n/claim #126\n\n## Summary\n- Parse the new `closes:note` tag format, including global and per-note comment overrides.\n- Close referenced open notes when a changeset is closed manually, by inactive timeout, or by upload size-limit auto-close.\n- Skip invalid, duplicate, missing, and already-closed notes without changing their comments.\n\n## Verification\n- `uv run ruff check app/lib/changeset_note_closures.py app/services/changeset_service.py app/services/optimistic_diff/__init__.py tests/lib/test_changeset_note_closures.py tests/controllers/test_api06_changeset.py`\n- `uv run python -m py_compile app/lib/changeset_note_closures.py app/services/changeset_service.py app/services/optimistic_diff/__init__.py tests/lib/test_changeset_note_closures.py tests/controllers/test_api06_changeset.py`\n- Direct parser smoke check for default, override, invalid, and duplicate note-id cases