### PR TITLE
Add hybrid aerial base layer

### DIFF
--- a/app/views/index/sidebar/layers.tsx
+++ b/app/views/index/sidebar/layers.tsx
@@ -24,6 +24,7 @@ import {
   DATA_LAYER_ID,
   GPS_LAYER_ID,
   HOT_LAYER_ID,
+  HYBRID_LAYER_ID,
   hasMapLayer,
   type LayerId,
   LIBERTY_LAYER_ID,
@@ -49,6 +50,7 @@ const BASE_LAYERS = new Set([
   TRANSPORTMAP_LAYER_ID,
   TRACESTRACKTOPO_LAYER_ID,
   LIBERTY_LAYER_ID,
+  HYBRID_LAYER_ID,
   HOT_LAYER_ID,
 ])
 
@@ -63,6 +65,7 @@ const OVERLAY_LAYERS = new Set([
 // Avoids "Too many active WebGL context even after destroyed".
 const LAYER_THUMBNAILS = new Map<LayerId, string>([
   [AERIAL_LAYER_ID, "/static/img/layer/aerial.webp"],
+  [HYBRID_LAYER_ID, "/static/img/layer/aerial.webp"],
 ])
 
 type Minimap =
@@ -385,6 +388,12 @@ export const LayersSidebar = ({ close }: { close: () => void }) => {
                 {layerId === LIBERTY_LAYER_ID && (
                   <>
                     {t("map.layers.liberty")}
+                    <span class="vector">{t("map.layers.vector")}</span>
+                  </>
+                )}
+                {layerId === HYBRID_LAYER_ID && (
+                  <>
+                    {t("map.layers.hybrid_aerial")}
                     <span class="vector">{t("map.layers.vector")}</span>
                   </>
                 )}

--- a/app/views/lib/map/layers/layers.ts
+++ b/app/views/lib/map/layers/layers.ts
@@ -26,6 +26,7 @@ export const DEFAULT_LAYER_ID = STANDARD_LAYER_ID
 export const DEFAULT_LAYER_CODE = "" as LayerCode
 
 export const LIBERTY_LAYER_ID = "liberty" as LayerId
+export const HYBRID_LAYER_ID = "hybrid" as LayerId
 export const CYCLOSM_LAYER_ID = "cyclosm" as LayerId
 export const CYCLEMAP_LAYER_ID = "cyclemap" as LayerId
 export const TRANSPORTMAP_LAYER_ID = "transportmap" as LayerId
@@ -33,6 +34,7 @@ export const TRACESTRACKTOPO_LAYER_ID = "tracestracktopo" as LayerId
 export const HOT_LAYER_ID = "hot" as LayerId
 
 const LIBERTY_LAYER_CODE = "L" as LayerCode
+const HYBRID_LAYER_CODE = "I" as LayerCode
 const CYCLOSM_LAYER_CODE = "Y" as LayerCode
 const CYCLEMAP_LAYER_CODE = "C" as LayerCode
 const TRANSPORTMAP_LAYER_CODE = "T" as LayerCode
@@ -92,6 +94,74 @@ const hotosmCredit = t("javascripts.map.hotosm_credit", {
 // https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/0
 const aerialEsriCredit =
   "Esri, Maxar, Earthstar Geographics, and the GIS User Community"
+const aerialEsriSource = {
+  type: "raster",
+  maxzoom: 23,
+  tiles: [
+    "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+  ],
+  tileSize: 256,
+  attribution: aerialEsriCredit,
+} satisfies SourceSpecification
+
+const libertyVectorStyle = libertyStyle as unknown as StyleSpecification
+const hybridAerialSourceId = "aerial"
+const hybridFeatureSourceLayers = new Set([
+  "aerodrome_label",
+  "aeroway",
+  "boundary",
+  "building",
+  "place",
+  "poi",
+  "transportation",
+  "transportation_name",
+  "water_name",
+  "waterway",
+])
+const hybridFillLayerIds = new Set(["building"])
+
+const shouldIncludeHybridLayer = (layer: LayerSpecification) => {
+  const sourceLayer =
+    "source-layer" in layer && typeof layer["source-layer"] === "string"
+      ? layer["source-layer"]
+      : undefined
+  if (!sourceLayer || !hybridFeatureSourceLayers.has(sourceLayer)) return false
+
+  return layer.type !== "fill" || hybridFillLayerIds.has(layer.id)
+}
+
+const cloneStylePart = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T
+const libertyOpenMapTilesSource = libertyVectorStyle.sources.openmaptiles as Extract<
+  SourceSpecification,
+  { attribution?: string }
+>
+
+const hybridStyle: StyleSpecification = {
+  ...cloneStylePart(libertyVectorStyle),
+  sources: {
+    [hybridAerialSourceId]: cloneStylePart(aerialEsriSource),
+    openmaptiles: {
+      ...cloneStylePart(libertyOpenMapTilesSource),
+      attribution: `${copyright}. ${terms}`,
+    },
+  },
+  layers: [
+    {
+      id: hybridAerialSourceId,
+      type: "raster",
+      source: hybridAerialSourceId,
+    },
+    ...libertyVectorStyle.layers.filter(shouldIncludeHybridLayer).map((layer) => {
+      const next = cloneStylePart(layer)
+      if (next.id === "building") {
+        next.paint = { ...next.paint, "fill-opacity": 0.55 }
+      } else if (next.id === "building-3d") {
+        next.paint = { ...next.paint, "fill-extrusion-opacity": 0.55 }
+      }
+      return next
+    }),
+  ],
+}
 
 export const emptyFeatureCollection: FeatureCollection = {
   type: "FeatureCollection",
@@ -133,10 +203,16 @@ layersConfig.set(STANDARD_LAYER_ID, {
 
 layersConfig.set(LIBERTY_LAYER_ID, {
   specification: { type: "vector" },
-  // @ts-expect-error
-  vectorStyle: libertyStyle,
+  vectorStyle: libertyVectorStyle,
   isBaseLayer: true,
   layerCode: LIBERTY_LAYER_CODE,
+})
+
+layersConfig.set(HYBRID_LAYER_ID, {
+  specification: { type: "vector" },
+  vectorStyle: hybridStyle,
+  isBaseLayer: true,
+  layerCode: HYBRID_LAYER_CODE,
 })
 
 layersConfig.set(CYCLOSM_LAYER_ID, {
@@ -217,15 +293,7 @@ layersConfig.set(HOT_LAYER_ID, {
 
 // Overlay layers
 layersConfig.set(AERIAL_LAYER_ID, {
-  specification: {
-    type: "raster",
-    maxzoom: 23,
-    tiles: [
-      "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
-    ],
-    tileSize: 256,
-    attribution: aerialEsriCredit,
-  },
+  specification: aerialEsriSource,
   layerOptions: {
     paint: {
       // @ts-expect-error loaded from storage

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -9,6 +9,7 @@ map:
   zoom_out_to_see_the_world_in_3d: Zoom out to see the world in 3D
   layers:
     esri_world_imagery: Esri World Imagery
+    hybrid_aerial: Hybrid Aerial
     liberty: Liberty
     vector: Vector
   overlays:


### PR DESCRIPTION
## Summary
- add a Hybrid Aerial base layer that uses Esri imagery as the raster background
- overlay selected Liberty vector features for roads, buildings, POIs, boundaries, and labels
- expose the new layer in the map layer sidebar

Closes #182

## Testing
- bunx oxfmt --check app/views/lib/map/layers/layers.ts app/views/index/sidebar/layers.tsx
- bunx prettier --check config/locale/extra_en.yaml
- git diff --check

Additional local checks:
- bunx tsc -p tsconfig.json --noEmit currently reaches only existing third-party @jsr/zod source type errors in node_modules
- vite build transforms the app modules successfully, then fails in the current rolldown-vite legacy polyfill plugin with PluginContext.emitFile type prebuilt-chunk