### PR TITLE
Add built-in GPS trace tiles

### DIFF
--- a/app/controllers/gps_tile.py
+++ b/app/controllers/gps_tile.py
@@ -1,0 +1,116 @@
+from asyncio import TaskGroup
+from io import BytesIO
+from math import asinh, atan, pi, radians, sinh, tan
+
+from fastapi import APIRouter, HTTPException, Response
+from PIL import Image, ImageDraw
+from shapely import MultiLineString, box, get_coordinates
+from starlette import status
+
+from app.queries.trace_query import TraceQuery
+
+router = APIRouter()
+
+_TILE_SIZE = 256
+_MAX_ZOOM = 23
+_TRACE_COLOR = (0, 102, 255, 190)
+
+
+@router.get('/gps/lines/{z:int}/{x:int}/{y:int}')
+@router.get('/gps/lines/{z:int}/{x:int}/{y:int}.png')
+@router.get('/lines/{z:int}/{x:int}/{y:int}')
+@router.get('/lines/{z:int}/{x:int}/{y:int}.png')
+async def gps_trace_tile(z: int, x: int, y: int):
+    """Render public GPX traces into an anonymous transparent raster tile."""
+    _validate_tile(z, x, y)
+    geometry = _tile_geometry(z, x, y)
+
+    async with TaskGroup() as tg:
+        identifiable_t = tg.create_task(
+            TraceQuery.find_by_geom(
+                geometry,
+                identifiable_trackable=True,
+                limit=5000,
+            )
+        )
+        anonymous_t = tg.create_task(
+            TraceQuery.find_by_geom(
+                geometry,
+                identifiable_trackable=False,
+                limit=5000,
+            )
+        )
+
+    image = Image.new('RGBA', (_TILE_SIZE, _TILE_SIZE), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(image)
+
+    for trace in (*identifiable_t.result(), *anonymous_t.result()):
+        _draw_segments(draw, trace['segments'], z=z, x=x, y=y)
+
+    buffer = BytesIO()
+    image.save(buffer, format='PNG', optimize=True)
+    return Response(
+        buffer.getvalue(),
+        media_type='image/png',
+        headers={'Cache-Control': 'public, max-age=3600'},
+    )
+
+
+def _validate_tile(z: int, x: int, y: int):
+    if z < 0 or z > _MAX_ZOOM:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+
+    tiles = 1 << z
+    if x < 0 or x >= tiles or y < 0 or y >= tiles:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+
+
+def _tile_geometry(z: int, x: int, y: int):
+    return box(
+        _tile_x_to_lon(x, z),
+        _tile_y_to_lat(y + 1, z),
+        _tile_x_to_lon(x + 1, z),
+        _tile_y_to_lat(y, z),
+    )
+
+
+def _tile_x_to_lon(x: int, z: int):
+    return x / (1 << z) * 360 - 180
+
+
+def _tile_y_to_lat(y: int, z: int):
+    return atan(sinh(pi * (1 - 2 * y / (1 << z)))) * 180 / pi
+
+
+def _draw_segments(
+    draw: ImageDraw.ImageDraw,
+    segments: MultiLineString,
+    *,
+    z: int,
+    x: int,
+    y: int,
+):
+    for line in segments.geoms:
+        coords = get_coordinates(line)
+        if len(coords) == 0:
+            continue
+
+        points = [
+            _lonlat_to_tile_pixel(float(lon), float(lat), z=z, x=x, y=y)
+            for lon, lat in coords[:, :2]
+        ]
+        if len(points) == 1:
+            px, py = points[0]
+            draw.ellipse((px - 1, py - 1, px + 1, py + 1), fill=_TRACE_COLOR)
+        else:
+            draw.line(points, fill=_TRACE_COLOR, width=2, joint='curve')
+
+
+def _lonlat_to_tile_pixel(lon: float, lat: float, *, z: int, x: int, y: int):
+    scale = 1 << z
+    world_x = (lon + 180) / 360 * scale
+    world_y = (1 - asinh(tan(radians(lat))) / pi) / 2 * scale
+    return (
+        (world_x - x) * _TILE_SIZE,
+        (world_y - y) * _TILE_SIZE,
+    )

--- a/app/views/lib/map/layers/layers.ts
+++ b/app/views/lib/map/layers/layers.ts
@@ -240,7 +240,7 @@ layersConfig.set(GPS_LAYER_ID, {
   specification: {
     type: "raster",
     // This layer has no zoom limits
-    tiles: ["https://gps.tile.openstreetmap.org/lines/{z}/{x}/{y}.png"],
+    tiles: ["/gps/lines/{z}/{x}/{y}.png"],
     tileSize: 256,
   },
   layerCode: GPS_LAYER_CODE,

--- a/tests/controllers/test_api06_gpx.py
+++ b/tests/controllers/test_api06_gpx.py
@@ -1,8 +1,10 @@
 from datetime import UTC, datetime
-from math import isclose
+from io import BytesIO
+from math import asinh, floor, isclose, pi, radians, tan
 
 import pytest
 from httpx import AsyncClient
+from PIL import Image
 from starlette import status
 
 from app.lib.xmltodict import XMLToDict
@@ -307,3 +309,39 @@ async def test_trackpoints_visibility(client: AsyncClient, gpx: dict):
         },
     )
     assert isclose(trkpt['ele'], 190.8, abs_tol=0.01)
+
+
+async def test_gps_trace_tile_renders_uploaded_trace(client: AsyncClient, gpx: dict):
+    client.headers['Authorization'] = 'User user1'
+
+    file = XMLToDict.unparse(gpx, binary=True)
+    r = await client.post(
+        '/api/0.6/gpx/create',
+        data={
+            'visibility': 'identifiable',
+            'description': test_gps_trace_tile_renders_uploaded_trace.__qualname__,
+        },
+        files={
+            'file': (
+                test_gps_trace_tile_renders_uploaded_trace.__qualname__ + '.gpx',
+                file,
+            ),
+        },
+    )
+    assert r.is_success, r.text
+
+    z, x, y = _tile_for_lonlat(20.8726996, 51.8583922, 14)
+    r = await client.get(f'/gps/lines/{z}/{x}/{y}.png')
+    assert r.is_success, r.text
+    assert r.headers['Content-Type'] == 'image/png'
+
+    image = Image.open(BytesIO(r.content)).convert('RGBA')
+    assert image.size == (256, 256)
+    assert image.getchannel('A').getbbox() is not None
+
+
+def _tile_for_lonlat(lon: float, lat: float, z: int):
+    tiles = 1 << z
+    x = floor((lon + 180) / 360 * tiles)
+    y = floor((1 - asinh(tan(radians(lat))) / pi) / 2 * tiles)
+    return z, x, y


### PR DESCRIPTION
Closes #108.

This adds a built-in transparent PNG GPS trace tile renderer so OSM-NG can serve `/gps/lines/{z}/{x}/{y}.png` locally instead of depending on `gps.tile.openstreetmap.org`.

What changed:
- Adds `/gps/lines/{z}/{x}/{y}` and `/gps/lines/{z}/{x}/{y}.png` tile endpoints, plus `/lines/...` aliases for tile-subdomain compatibility.
- Reuses the existing trace geometry query and renders identifiable/anonymous trace segments into 256px transparent PNG tiles.
- Switches the GPS map layer to the local tile endpoint.
- Adds a controller regression test that uploads a GPX trace, requests the matching tile, and verifies a non-empty PNG is returned.

Verification:
- `python -m compileall app\controllers\gps_tile.py tests\controllers\test_api06_gpx.py`
- `python -m ruff check app\controllers\gps_tile.py tests\controllers\test_api06_gpx.py`

I could not run the full pytest target on this Windows workstation because importing `app.main` fails before test startup on `from time import tzset`; the project appears to expect Linux for tests/CI.