### PR TITLE
[codex] Add direct tag edit frontend scaffold

### DIFF
--- a/app/views/index/element.tsx
+++ b/app/views/index/element.tsx
@@ -1,7 +1,7 @@
 import { SidebarContent, SidebarHeader, useSidebar } from "@index/_action-sidebar"
 import { defineRoute } from "@index/router"
 import { pathParam } from "@lib/codecs"
-import { API_URL } from "@lib/config"
+import { API_URL, isLoggedIn } from "@lib/config"
 import { Time } from "@lib/datetime-inputs"
 import { type FocusLayerPaint, focusObjects } from "@lib/map/layers/focus-layer"
 import { convertRenderElementsData } from "@lib/map/render-objects"
@@ -359,7 +359,11 @@ const ElementSidebar = ({
                 />
               )}
 
-              <Tags tags={d.tags} />
+              <Tags
+                tags={d.tags}
+                editable={isLoggedIn && d.visible && !d.nextVersion}
+                editAction={`${API_URL}/api/0.7/${getElementTypeSlug(d.ref.type)}/${d.ref.id}/tags`}
+              />
 
               {hasRelations && (
                 <div class="elements mt-3">

--- a/app/views/lib/tags.scss
+++ b/app/views/lib/tags.scss
@@ -6,6 +6,33 @@
   overflow: hidden;
   border: 1px solid $table-border-color;
 
+  .tags-header {
+    @extend .bg-body-tertiary;
+
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.25rem 0.55rem;
+    border-bottom: 1px solid $table-border-color;
+
+    h4 {
+      margin: 0;
+    }
+
+    .btn {
+      padding-block: 0;
+    }
+  }
+
+  .tag-edit-form {
+    padding: 0.55rem;
+
+    textarea {
+      resize: vertical;
+      white-space: pre;
+    }
+  }
+
   table {
     margin-bottom: unset;
     vertical-align: middle;

--- a/app/views/lib/tags.tsx
+++ b/app/views/lib/tags.tsx
@@ -2,6 +2,7 @@ import { useDisposeEffect } from "@lib/dispose-scope"
 import { useSignal } from "@preact/signals"
 import { memoize } from "@std/cache/memoize"
 import { union } from "@std/collections/union"
+import { t } from "i18next"
 import { primaryLanguage } from "./config"
 import { getWikiData } from "./tags.macro" with { type: "macro" }
 
@@ -354,33 +355,130 @@ const computeDiffRows = (
   return [...rows, ...deleted]
 }
 
+const serializeTags = (tags: Record<string, string>) =>
+  Object.keys(tags)
+    .sort((a, b) => a.localeCompare(b))
+    .map((key) => `${key}=${tags[key]}`)
+    .join("\n")
+
+const getSerializedTagsFromDataset = (
+  container: HTMLElement | null,
+  fallback: string,
+) => {
+  const rawTags = container?.dataset.tags
+  if (!rawTags) return fallback
+
+  try {
+    const parsed = JSON.parse(rawTags) as unknown
+    if (!parsed || Array.isArray(parsed) || typeof parsed !== "object") return fallback
+
+    const tags: Record<string, string> = {}
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof value === "string") tags[key] = value
+    }
+    return serializeTags(tags)
+  } catch {
+    return fallback
+  }
+}
+
 export const Tags = ({
   tags,
   tagsOld,
   diff = false,
+  editable = false,
+  editAction,
 }: {
   tags: Record<string, string>
   tagsOld?: Record<string, string>
   diff?: boolean
+  editable?: boolean
+  editAction?: string
 }) => {
   const rows = computeDiffRows(tags, tagsOld, diff)
-  if (!rows.length) return null
+  const isEditing = useSignal(false)
+  const editText = useSignal("")
+  const serializedTags = serializeTags(tags)
+  if (!rows.length && !editable) return null
 
   return (
-    <div class="tags">
-      <table class="table table-sm">
-        <tbody dir="auto">
-          {rows.map((row) => (
-            <TagRow
-              key={row.key}
-              tagKey={row.key}
-              value={row.value}
-              oldValue={row.oldValue}
-              status={row.status}
+    <div
+      class="tags"
+      data-tags={JSON.stringify(tags)}
+    >
+      {editable && (
+        <div class="tags-header">
+          <h4>{t("browse.tag_details.tags")}</h4>
+          {!isEditing.value && (
+            <button
+              class="btn btn-link btn-sm"
+              type="button"
+              onClick={(event) => {
+                editText.value = getSerializedTagsFromDataset(
+                  event.currentTarget.closest<HTMLElement>(".tags"),
+                  serializedTags,
+                )
+                isEditing.value = true
+              }}
+            >
+              {t("element.edit_text")}
+            </button>
+          )}
+        </div>
+      )}
+      {!isEditing.value && rows.length > 0 && (
+        <table class="table table-sm">
+          <tbody dir="auto">
+            {rows.map((row) => (
+              <TagRow
+                key={row.key}
+                tagKey={row.key}
+                value={row.value}
+                oldValue={row.oldValue}
+                status={row.status}
+              />
+            ))}
+          </tbody>
+        </table>
+      )}
+      {isEditing.value && (
+        <form
+          class="tag-edit-form"
+          method="post"
+          action={editAction}
+        >
+          <textarea
+            class="form-control font-monospace"
+            name="tags"
+            rows={Math.max(4, Math.min(12, rows.length + 1))}
+            defaultValue={editText.value}
+          />
+          <label class="form-label mt-2 mb-1">
+            {t("element.changeset_comment")}
+            <input
+              class="form-control"
+              name="comment"
+              type="text"
+              required
             />
-          ))}
-        </tbody>
-      </table>
+          </label>
+          <div class="d-flex gap-2 mt-2">
+            <button
+              class="btn btn-primary btn-sm"
+              type="submit"
+            >
+              {t("action.submit")}
+            </button>
+            <button
+              class="btn btn-outline-secondary btn-sm"
+              type="button"
+              onClick={() => (isEditing.value = false)}
+            >
+              {t("action.discard")}
+            </button>
+          </div>
+        </form>
+      )}
     </div>
   )
 }

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -49,6 +49,8 @@ changesets_history:
 element:
   tags_diff_mode: Tags diff mode
   highlight_changed_tags_between_versions: Highlight changed tags between versions
+  edit_text: Edit text
+  changeset_comment: Changeset comment
 note:
   title: Note
   count_one: "note"
@@ -616,6 +618,7 @@ action:
   send: Send
   send_a_message: Send a message
   submit: Submit
+  discard: Discard
   continue: Continue
   view_all: View all
   view_more: View more


### PR DESCRIPTION
## Summary
- Adds a logged-in/latest-element direct tag edit toggle beside the Tags heading.
- Stores the raw tag dictionary in one JSON data attribute and fills a textarea as key=value lines when editing starts.
- Adds the required changeset comment input plus Discard/Submit actions, leaving API 0.7 backend handling for the later backend work called out in #90.

Fixes #90

## Validation
- `bunx oxfmt --write app/views/lib/tags.tsx app/views/index/element.tsx config/locale/extra_en.yaml`
- `bunx prettier --write app/views/lib/tags.scss`
- `git diff --check`
- `bunx oxlint app/views/lib/tags.tsx app/views/index/element.tsx`
- `bunx prettier --check app/views/lib/tags.scss`

Fuller checks attempted but blocked by local/generated environment gaps:
- `bunx oxlint --type-aware --type-check ...` fails because `oxlint-tsgolint` is not available in this checkout.
- `bunx vite build` initially fails until ignored web protobuf files are generated, then fails on missing generated locale/browser assets and `python` executable path expected by macros.
- `bunx tsc --noEmit --pretty false` fails in `node_modules/.bun/@jsr+zod__zod...`, unrelated to this patch.
