### PR TITLE
feat: launch edit walkthrough from help query

### DIFF
--- a/app/controllers/diary.py
+++ b/app/controllers/diary.py
@@ -69,8 +69,11 @@ async def details(
 
     profile = diary['user']  # type: ignore
 
+    page = DetailsPage()
+    _build_entry(page.entry, diary)
+
     return await render_proto_page(
-        DetailsPage(entry=_build_entry(diary)),
+        page,
         title_prefix=(
             f'{t("diary_entries.index.user_title", user=profile["display_name"])}'
             f' | {diary["title"]}'

--- a/app/controllers/diary.py
+++ b/app/controllers/diary.py
@@ -2,6 +2,13 @@ from asyncio import TaskGroup
 from typing import Annotated
 
 import cython
+from app.models.proto.diary_pb2 import (
+    ComposePage,
+    DetailsPage,
+    IndexPage,
+    UserCommentsPage,
+)
+from app.models.proto.shared_pb2 import LonLat
 from fastapi import APIRouter, Path, Query, Response
 from feedgen.feed import FeedGenerator
 from pydantic import SecretStr
@@ -18,13 +25,6 @@ from app.lib.user_token_struct_utils import UserTokenStructUtils
 from app.middlewares.request_context_middleware import get_request
 from app.models.db.diary import diaries_resolve_rich_text
 from app.models.db.user import User, user_proto
-from app.models.proto.diary_pb2 import (
-    ComposePage,
-    DetailsPage,
-    IndexPage,
-    UserCommentsPage,
-)
-from app.models.proto.shared_pb2 import LonLat
 from app.models.types import DiaryId, LocaleCode, UserId
 from app.queries.diary_comment_query import DiaryCommentQuery
 from app.queries.diary_query import DiaryQuery

--- a/app/lib/changeset_bounds.py
+++ b/app/lib/changeset_bounds.py
@@ -1,3 +1,5 @@
+from typing import TypeAlias
+
 import cython
 import numpy as np
 from numpy.typing import NDArray
@@ -16,7 +18,7 @@ from app.config import (
     CHANGESET_NEW_BBOX_MIN_RATIO,
 )
 
-type _BBox = list[float]
+_BBox: TypeAlias = list[float]  # noqa: UP040
 
 _FIXED_K_MAX_CANDIDATE_EDGES = 5_000_000
 

--- a/app/lib/compressible_geometry.py
+++ b/app/lib/compressible_geometry.py
@@ -57,7 +57,8 @@ def compressible_geometry(
 
 @cython.cfunc
 def _compressible_float(value: float):
-    return _UINT64_STRUCT.unpack(_FLOAT_STRUCT.pack(value))[0] & _MASK_INT
+    value_int: object = _UINT64_STRUCT.unpack(_FLOAT_STRUCT.pack(value))[0]
+    return int(value_int) & _MASK_INT
 
 
 _POINT_STRUCT = struct.Struct('<BIQQ')

--- a/app/lib/compressible_geometry.py
+++ b/app/lib/compressible_geometry.py
@@ -67,21 +67,21 @@ _BBOX_STRUCT = struct.Struct('<BIII10Q')
 
 def point_to_compressible_wkb(lon: float, lat: float):
     """Convert a coordinate pair to a compressible WKB hex format."""
-    lon = _compressible_float(lon)
-    lat = _compressible_float(lat)
+    lon_int: object = _compressible_float(lon)
+    lat_int: object = _compressible_float(lat)
 
     # (byte order 1 = little endian + geometry type 1 = Point)
-    return _POINT_STRUCT.pack(1, 1, lon, lat)
+    return _POINT_STRUCT.pack(1, 1, lon_int, lat_int)
 
 
 def bbox_to_compressible_wkb(
     minlon: float, minlat: float, maxlon: float, maxlat: float
 ):
     """Convert a bounding box to a compressible WKB hex format."""
-    minlon = _compressible_float(minlon)
-    minlat = _compressible_float(minlat)
-    maxlon = _compressible_float(maxlon)
-    maxlat = _compressible_float(maxlat)
+    minlon_int: object = _compressible_float(minlon)
+    minlat_int: object = _compressible_float(minlat)
+    maxlon_int: object = _compressible_float(maxlon)
+    maxlat_int: object = _compressible_float(maxlat)
 
     # (byte order 1 = little endian + geometry type 3 = Polygon + 1 ring + 5 points)
     return _BBOX_STRUCT.pack(
@@ -89,14 +89,14 @@ def bbox_to_compressible_wkb(
         3,
         1,
         5,
-        maxlon,
-        minlat,
-        maxlon,
-        maxlat,
-        minlon,
-        maxlat,
-        minlon,
-        minlat,
-        maxlon,
-        minlat,
+        maxlon_int,
+        minlat_int,
+        maxlon_int,
+        maxlat_int,
+        minlon_int,
+        maxlat_int,
+        minlon_int,
+        minlat_int,
+        maxlon_int,
+        minlat_int,
     )

--- a/app/lib/cookie.py
+++ b/app/lib/cookie.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 from http.cookies import SimpleCookie
-from typing import Literal
+from typing import Literal, TypeAlias
 
 import cython
 from connectrpc.request import RequestContext
@@ -9,8 +9,8 @@ from starlette.responses import Response
 
 from app.config import ENV
 
-type CookieTarget = Response | RequestContext
-type CookieSameSite = Literal['lax', 'strict', 'none']
+CookieTarget: TypeAlias = Response | RequestContext  # noqa: UP040
+CookieSameSite: TypeAlias = Literal['lax', 'strict', 'none']  # noqa: UP040
 
 
 @cython.cfunc

--- a/app/lib/format_style_context.py
+++ b/app/lib/format_style_context.py
@@ -1,12 +1,12 @@
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Literal
+from typing import Literal, TypeAlias
 
 import cython
 
 from app.middlewares.request_context_middleware import get_request
 
-type FormatStyle = Literal['json', 'xml', 'rss', 'gpx']
+FormatStyle: TypeAlias = Literal['json', 'xml', 'rss', 'gpx']  # noqa: UP040
 
 _LEGACY_EXTENSION_FORMATS: dict[str, FormatStyle] = {
     'json': 'json',

--- a/app/lib/image.py
+++ b/app/lib/image.py
@@ -5,7 +5,7 @@ from contextlib import asynccontextmanager
 from functools import partial
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, NamedTuple, overload
+from typing import TYPE_CHECKING, Literal, NamedTuple, TypeAlias, overload
 
 import cython
 from blurhash_rs import blurhash_encode
@@ -49,7 +49,7 @@ class _Animation(NamedTuple):
     loop: int
 
 
-type UserAvatarType = Literal['gravatar', 'custom'] | None
+UserAvatarType: TypeAlias = Literal['gravatar', 'custom'] | None  # noqa: UP040
 
 DEFAULT_USER_AVATAR_URL = '/static/img/avatar.webp'
 DEFAULT_USER_AVATAR = Path('app' + DEFAULT_USER_AVATAR_URL).read_bytes()

--- a/app/lib/password_hash.py
+++ b/app/lib/password_hash.py
@@ -1,18 +1,18 @@
 from base64 import b64decode, b64encode
 from hashlib import md5, pbkdf2_hmac
 from hmac import compare_digest
-from typing import Literal, NamedTuple
+from typing import Literal, NamedTuple, TypeAlias
 
 import cython
+from app.models.proto.auth_pb2 import TransmitUserPassword
+from app.models.proto.server_pb2 import UserPassword
 from argon2 import PasswordHasher, Type
 from argon2.exceptions import VerifyMismatchError
 
 from app.config import SECRET_32
-from app.models.proto.auth_pb2 import TransmitUserPassword
-from app.models.proto.server_pb2 import UserPassword
 from app.models.types import Password
 
-type PasswordLike = Password | TransmitUserPassword
+PasswordLike: TypeAlias = Password | TransmitUserPassword  # noqa: UP040
 
 
 class VerifyResult(NamedTuple):

--- a/app/lib/rich_text.py
+++ b/app/lib/rich_text.py
@@ -4,7 +4,7 @@ from asyncio import TaskGroup
 from collections.abc import Collection, Generator, Iterable, Mapping, Sequence
 from html import escape
 from pathlib import Path
-from typing import Any, Literal, LiteralString, cast
+from typing import Any, Literal, LiteralString, TypeAlias, cast
 from urllib.parse import urlsplit, urlunsplit
 
 import cython
@@ -24,7 +24,7 @@ from app.models.types import ImageProxyId
 from app.services.cache_service import CacheContext, CacheService
 from app.services.image_proxy_service import ImageProxyService
 
-type TextFormat = Literal['html', 'markdown', 'plain']
+TextFormat: TypeAlias = Literal['html', 'markdown', 'plain']  # noqa: UP040
 
 
 async def process_rich_text_markdown(text: str):

--- a/app/lib/standard_pagination.py
+++ b/app/lib/standard_pagination.py
@@ -9,11 +9,16 @@ from typing import (
     Literal,
     LiteralString,
     NamedTuple,
+    TypeAlias,
     TypeVar,
     assert_never,
 )
 
 import cython
+from app.models.proto.shared_pb2 import (
+    StandardPaginationRequest,
+    StandardPaginationState,
+)
 from fastapi import Body
 from protovalidate import collect_violations
 from psycopg import AsyncConnection
@@ -28,10 +33,6 @@ from app.config import (
 )
 from app.db import db
 from app.lib.render_response import render_response
-from app.models.proto.shared_pb2 import (
-    StandardPaginationRequest,
-    StandardPaginationState,
-)
 
 
 class _SpCursorCodec(NamedTuple):
@@ -49,13 +50,13 @@ class _StandardPaginationQueryPlan(NamedTuple):
     anchor_op: Literal['<', '>'] | None = None
 
 
-type StandardPaginationRequestLike = bytes | StandardPaginationRequest
-type StandardPaginationRequestBody = Annotated[
+StandardPaginationRequestLike: TypeAlias = bytes | StandardPaginationRequest  # noqa: UP040
+StandardPaginationRequestBody: TypeAlias = Annotated[  # noqa: UP040
     bytes, Body(media_type='application/x-protobuf')
 ]
 
-type _OrderDir = Literal['asc', 'desc']
-type _CursorKind = Literal['id', 'datetime', 'text']
+_OrderDir: TypeAlias = Literal['asc', 'desc']  # noqa: UP040
+_CursorKind: TypeAlias = Literal['id', 'datetime', 'text']  # noqa: UP040
 
 _EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
 

--- a/app/lib/webauthn.py
+++ b/app/lib/webauthn.py
@@ -1,12 +1,13 @@
 from hashlib import sha256
 from pathlib import Path
-from typing import Literal, NamedTuple, NotRequired, TypedDict
+from typing import Literal, NamedTuple, NotRequired, TypeAlias, TypedDict
 from urllib.parse import urlsplit
 from uuid import UUID
 
 import cbor2
 import cython
 import orjson
+from app.models.proto.auth_pb2 import PasskeyAssertion
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric.ec import (
@@ -20,9 +21,8 @@ from starlette.exceptions import HTTPException
 
 from app.config import APP_URL
 from app.models.db.user_passkey import AAGUIDInfo, UserPasskey
-from app.models.proto.auth_pb2 import PasskeyAssertion
 
-type _ClientDataType = Literal['webauthn.create', 'webauthn.get']
+_ClientDataType: TypeAlias = Literal['webauthn.create', 'webauthn.get']  # noqa: UP040
 
 
 class _ClientData(TypedDict):

--- a/app/models/scope.py
+++ b/app/models/scope.py
@@ -1,9 +1,9 @@
 from collections.abc import Iterable
-from typing import Literal, get_args
+from typing import Literal, TypeAlias, get_args
 
 from app.models.proto.shared_pb2 import Scope as ProtoScope
 
-type PublicScope = Literal[
+PublicScope: TypeAlias = Literal[  # noqa: UP040
     'read_prefs',
     'write_prefs',
     'write_api',
@@ -12,9 +12,9 @@ type PublicScope = Literal[
     'write_notes',
 ]
 
-PUBLIC_SCOPES = frozenset[PublicScope](get_args(PublicScope.__value__))
+PUBLIC_SCOPES = frozenset[PublicScope](get_args(PublicScope))
 
-type Scope = (
+Scope: TypeAlias = (  # noqa: UP040
     PublicScope
     | Literal[
         # additional scopes

--- a/app/queries/graphhopper_query.py
+++ b/app/queries/graphhopper_query.py
@@ -1,5 +1,6 @@
-from typing import Literal, cast, get_args
+from typing import Literal, TypeAlias, cast, get_args
 
+from app.models.proto.shared_pb2 import RoutingResult
 from fastapi import HTTPException
 from shapely import Point, get_coordinates
 from starlette import status
@@ -8,11 +9,10 @@ from app.config import GRAPHHOPPER_API_KEY, GRAPHHOPPER_URL
 from app.lib.http_client import HTTP
 from app.lib.translation import primary_translation_locale
 from app.models.graphhopper import GraphHopperResponse
-from app.models.proto.shared_pb2 import RoutingResult
 
-type GraphHopperProfile = Literal['car', 'bike', 'foot']
+GraphHopperProfile: TypeAlias = Literal['car', 'bike', 'foot']  # noqa: UP040
 GraphHopperProfiles = frozenset[GraphHopperProfile](
-    get_args(GraphHopperProfile.__value__)
+    get_args(GraphHopperProfile)
 )
 
 

--- a/app/queries/osrm_query.py
+++ b/app/queries/osrm_query.py
@@ -1,8 +1,9 @@
 import logging
 from functools import cache
-from typing import Literal, cast, get_args
+from typing import Literal, TypeAlias, cast, get_args
 
 import cython
+from app.models.proto.shared_pb2 import RoutingResult
 from fastapi import HTTPException
 from polyline_rs import decode_latlon, encode_latlon
 from shapely import Point, get_coordinates
@@ -11,10 +12,9 @@ from app.config import OSRM_URL
 from app.lib.http_client import HTTP
 from app.lib.translation import t
 from app.models.osrm import OSRMResponse, OSRMStep
-from app.models.proto.shared_pb2 import RoutingResult
 
-type OSRMProfile = Literal['car', 'bike', 'foot']
-OSRMProfiles = frozenset[OSRMProfile](get_args(OSRMProfile.__value__))
+OSRMProfile: TypeAlias = Literal['car', 'bike', 'foot']  # noqa: UP040
+OSRMProfiles = frozenset[OSRMProfile](get_args(OSRMProfile))
 
 
 class OSRMQuery:

--- a/app/queries/valhalla_query.py
+++ b/app/queries/valhalla_query.py
@@ -1,17 +1,17 @@
-from typing import Literal, cast, get_args
+from typing import Literal, TypeAlias, cast, get_args
 
 import numpy as np
+from app.models.proto.shared_pb2 import RoutingResult
 from fastapi import HTTPException
 from shapely import Point, get_coordinates
 
 from app.config import VALHALLA_URL
 from app.lib.http_client import HTTP
 from app.lib.translation import primary_translation_locale
-from app.models.proto.shared_pb2 import RoutingResult
 from app.models.valhalla import ValhallaResponse
 
-type ValhallaProfile = Literal['auto', 'bicycle', 'pedestrian']
-ValhallaProfiles = frozenset[ValhallaProfile](get_args(ValhallaProfile.__value__))
+ValhallaProfile: TypeAlias = Literal['auto', 'bicycle', 'pedestrian']  # noqa: UP040
+ValhallaProfiles = frozenset[ValhallaProfile](get_args(ValhallaProfile))
 
 
 class ValhallaQuery:

--- a/app/responses/precompressed_static_files.py
+++ b/app/responses/precompressed_static_files.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 from mimetypes import guess_type
 from os import PathLike
 from os import stat_result as StatResultType  # noqa: N812
-from typing import override
+from typing import TypeAlias, override
 
 import cython
 from fastapi import HTTPException
@@ -17,8 +17,8 @@ from starlette_compress._utils import parse_accept_encoding
 
 from app.config import ENV, STATIC_PRECOMPRESSED_CACHE_MAX_ENTRIES
 
-type _CacheKey = tuple[str, str | None]
-type _CacheValue = tuple[str, StatResultType, str | None]
+_CacheKey: TypeAlias = tuple[str, str | None]  # noqa: UP040
+_CacheValue: TypeAlias = tuple[str, StatResultType, str | None]  # noqa: UP040
 
 
 class PrecompressedStaticFiles(StaticFiles):

--- a/app/services/optimistic_diff/prepare.py
+++ b/app/services/optimistic_diff/prepare.py
@@ -2,10 +2,11 @@ import logging
 from asyncio import TaskGroup
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Final, Literal, assert_never
+from typing import Final, Literal, TypeAlias, assert_never
 
 import cython
 import numpy as np
+from app.models.proto.shared_types import ElementType
 from psycopg import AsyncConnection
 from shapely import Point, bounds, box
 
@@ -21,14 +22,13 @@ from app.models.element import (
     TYPED_ELEMENT_ID_RELATION_MIN,
     TypedElementId,
 )
-from app.models.proto.shared_types import ElementType
 from app.models.types import SequenceId
 from app.queries.changeset_bounds_query import ChangesetBoundsQuery
 from app.queries.changeset_query import ChangesetQuery
 from app.queries.element_query import ElementQuery
 from speedup import element_id, element_type, split_typed_element_id
 
-type OSMChangeAction = Literal['create', 'modify', 'delete']
+OSMChangeAction: TypeAlias = Literal['create', 'modify', 'delete']  # noqa: UP040
 
 
 @dataclass(kw_only=True, slots=True)

--- a/app/validators/display_name.py
+++ b/app/validators/display_name.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, TypeAlias
 
 from annotated_types import MaxLen, MinLen
 
@@ -9,12 +9,12 @@ from app.validators.url import UrlSafeValidator
 from app.validators.whitespace import BoundaryWhitespaceValidator
 from app.validators.xml import XMLSafeValidator
 
-type DisplayNameNormalizing = Annotated[
+DisplayNameNormalizing: TypeAlias = Annotated[  # noqa: UP040
     DisplayName,
     UnicodeValidator,
 ]
 
-type DisplayNameValidating = Annotated[
+DisplayNameValidating: TypeAlias = Annotated[  # noqa: UP040
     DisplayNameNormalizing,
     MinLen(3),
     MaxLen(DISPLAY_NAME_MAX_LENGTH),

--- a/app/validators/email.py
+++ b/app/validators/email.py
@@ -1,6 +1,6 @@
 import logging
 from asyncio import Task, TaskGroup
-from typing import Annotated
+from typing import Annotated, TypeAlias
 
 from annotated_types import MaxLen, MinLen
 from dns.asyncresolver import Resolver
@@ -137,7 +137,7 @@ EmailValidator = BeforeValidator(validate_email)
 
 # ideally, should be defined in app/models/types.py
 # but this causes circular import
-type EmailValidating = Annotated[
+EmailValidating: TypeAlias = Annotated[  # noqa: UP040
     Email,
     MinLen(EMAIL_MIN_LENGTH),
     MaxLen(EMAIL_MAX_LENGTH),

--- a/app/validators/tags.py
+++ b/app/validators/tags.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, TypeAlias
 
 import cython
 from annotated_types import MaxLen, MinLen
@@ -34,7 +34,7 @@ def _validate_tags(
     return v
 
 
-type TagsValidating = Annotated[
+TagsValidating: TypeAlias = Annotated[  # noqa: UP040
     dict[
         Annotated[
             str,

--- a/app/views/lib/map/main-map.tsx
+++ b/app/views/lib/map/main-map.tsx
@@ -16,6 +16,7 @@ import type { RightSidebarKind } from "@index/sidebar/_toggle-button"
 import { LayersSidebarControl } from "@index/sidebar/layers"
 import { LegendSidebarControl } from "@index/sidebar/legend"
 import { ShareSidebarControl } from "@index/sidebar/share"
+import { isLoggedIn } from "@lib/config"
 import { globeProjectionStorage, mapStateStorage } from "@lib/local-storage"
 import { wrapIdleCallbackStatic } from "@lib/utils"
 import { effect, signal } from "@preact/signals"
@@ -123,6 +124,12 @@ export const initMainMap = (
   onMapStateChange: (state: MapState) => void,
   onInitError?: (ctx: MapInitErrorContext) => void,
 ) => {
+  const searchParams = new URLSearchParams(window.location.search)
+  if (searchParams.get("edit_help") === "1" && isLoggedIn) {
+    window.location.replace("/edit#walkthrough=true")
+    return
+  }
+
   const map = createMainMap(container, onMapStateChange, onInitError)
   if (!map) return
 

--- a/scripts/replication_download.py
+++ b/scripts/replication_download.py
@@ -9,12 +9,13 @@ from dataclasses import asdict, dataclass, replace
 from datetime import UTC, datetime, timedelta
 from itertools import pairwise
 from time import monotonic
-from typing import Literal, get_args
+from typing import Literal, TypeAlias, get_args
 
 import cython
 import orjson
 import pyarrow as pa
 import pyarrow.parquet as pq
+from app.models.proto.shared_types import ElementType
 from sentry_sdk import set_context, set_tag, start_transaction
 from starlette import status
 
@@ -26,17 +27,16 @@ from app.lib.retry import retry
 from app.lib.sentry import SENTRY_REPLICATION_MONITOR, SENTRY_REPLICATION_MONITOR_SLUG
 from app.lib.xmltodict import XMLToDict
 from app.models.element import TypedElementId
-from app.models.proto.shared_types import ElementType
 from speedup import typed_element_id
 
-type _Dataset = Literal['replication', 'redaction-period', 'cc-by-sa']
-type _Frequency = Literal['minute', 'hour', 'day']
+_Dataset: TypeAlias = Literal['replication', 'redaction-period', 'cc-by-sa']  # noqa: UP040
+_Frequency: TypeAlias = Literal['minute', 'hour', 'day']  # noqa: UP040
 
 _APP_STATE_PATH = REPLICATION_DIR.joinpath('state.json')
 _LOCK_PATH = REPLICATION_DIR.joinpath('.lock')
 
 _NEXT_DATASET: dict[_Dataset, _Dataset] = {
-    from_: to for to, from_ in pairwise(get_args(_Dataset.__value__))
+    from_: to for to, from_ in pairwise(get_args(_Dataset))
 }
 
 _FREQUENCY_TIMEDELTA: dict[_Frequency, timedelta] = {

--- a/scripts/replication_generate.py
+++ b/scripts/replication_generate.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime, timedelta
 from functools import cache
 from pathlib import Path
 from shutil import copyfile
-from typing import Literal, TypedDict, get_args
+from typing import Literal, TypeAlias, TypedDict, get_args
 
 import cython
 from psycopg import AsyncConnection
@@ -31,7 +31,7 @@ class _State(TypedDict):
     timestamp: datetime
 
 
-type _TimeSpan = Literal['minute', 'hour', 'day']
+_TimeSpan: TypeAlias = Literal['minute', 'hour', 'day']  # noqa: UP040
 
 _TIMESPAN_DELTA: dict[_TimeSpan, timedelta] = {
     'minute': timedelta(minutes=1),


### PR DESCRIPTION
## Summary
- redirects logged-in visits to /?edit_help=1 into the iD editor walkthrough
- uses location.replace() so the stale query-param URL is not kept in browser history
- leaves anonymous visitors on the regular main-map flow

This covers #28 against current main, where #212 is currently conflicting after the map entry file moved to TSX.

Note: this branch also includes the current-main CI fix from #236 (diary details proto construction, Cython-compatible type aliases, and the compressible WKB integer fix) because unrelated main CI failures were making bounty branches red.

Closes #28

## Testing
- git diff --check
- python3 -m py_compile app/controllers/diary.py app/lib/webauthn.py app/lib/format_style_context.py app/lib/changeset_bounds.py app/lib/password_hash.py app/lib/rich_text.py app/lib/image.py app/lib/cookie.py app/lib/standard_pagination.py app/responses/precompressed_static_files.py app/services/optimistic_diff/prepare.py app/queries/graphhopper_query.py app/queries/osrm_query.py app/queries/valhalla_query.py app/validators/display_name.py app/validators/tags.py app/validators/email.py app/models/scope.py scripts/replication_download.py scripts/replication_generate.py app/lib/compressible_geometry.py
- uvx ruff check app/controllers/diary.py app/lib/webauthn.py app/lib/format_style_context.py app/lib/changeset_bounds.py app/lib/password_hash.py app/lib/rich_text.py app/lib/image.py app/lib/cookie.py app/lib/standard_pagination.py app/responses/precompressed_static_files.py app/services/optimistic_diff/prepare.py app/queries/graphhopper_query.py app/queries/osrm_query.py app/queries/valhalla_query.py app/validators/display_name.py app/validators/tags.py app/validators/email.py app/models/scope.py scripts/replication_download.py scripts/replication_generate.py app/lib/compressible_geometry.py
- targeted Cython parse of the changed Cython-covered files
- broader Cython parse of existing files covered by shellscripts/cython-build.sh, plus existing extra scripts
- point_to_compressible_wkb expected-output smoke test in a uvx environment with cython/numpy/shapely
- tsc -p tsconfig.json --noEmit --pretty false --skipLibCheck could not run fully in this fresh clone because Node/Bun dependencies were not installed (@types/bootstrap, @types/bun, @types/geojson, typed-query-selector/strict missing).