### PR TITLE
feat: reject repeated null island edits

### DIFF
--- a/app/controllers/diary.py
+++ b/app/controllers/diary.py
@@ -69,8 +69,11 @@ async def details(
 
     profile = diary['user']  # type: ignore
 
+    page = DetailsPage()
+    _build_entry(page.entry, diary)
+
     return await render_proto_page(
-        DetailsPage(entry=_build_entry(diary)),
+        page,
         title_prefix=(
             f'{t("diary_entries.index.user_title", user=profile["display_name"])}'
             f' | {diary["title"]}'

--- a/app/controllers/diary.py
+++ b/app/controllers/diary.py
@@ -2,6 +2,13 @@ from asyncio import TaskGroup
 from typing import Annotated
 
 import cython
+from app.models.proto.diary_pb2 import (
+    ComposePage,
+    DetailsPage,
+    IndexPage,
+    UserCommentsPage,
+)
+from app.models.proto.shared_pb2 import LonLat
 from fastapi import APIRouter, Path, Query, Response
 from feedgen.feed import FeedGenerator
 from pydantic import SecretStr
@@ -18,13 +25,6 @@ from app.lib.user_token_struct_utils import UserTokenStructUtils
 from app.middlewares.request_context_middleware import get_request
 from app.models.db.diary import diaries_resolve_rich_text
 from app.models.db.user import User, user_proto
-from app.models.proto.diary_pb2 import (
-    ComposePage,
-    DetailsPage,
-    IndexPage,
-    UserCommentsPage,
-)
-from app.models.proto.shared_pb2 import LonLat
 from app.models.types import DiaryId, LocaleCode, UserId
 from app.queries.diary_comment_query import DiaryCommentQuery
 from app.queries.diary_query import DiaryQuery

--- a/app/exceptions/diff_mixin.py
+++ b/app/exceptions/diff_mixin.py
@@ -21,3 +21,7 @@ class DiffExceptionsMixin:
     @abstractmethod
     def diff_update_bad_version(self, element: 'ElementInit') -> NoReturn:
         raise NotImplementedError
+
+    @abstractmethod
+    def diff_null_island(self, count: int) -> NoReturn:
+        raise NotImplementedError

--- a/app/exceptions/note_mixin.py
+++ b/app/exceptions/note_mixin.py
@@ -24,5 +24,9 @@ class NoteExceptionsMixin:
         raise NotImplementedError
 
     @abstractmethod
+    def note_null_island(self) -> NoReturn:
+        raise NotImplementedError
+
+    @abstractmethod
     def notes_query_area_too_big(self) -> NoReturn:
         raise NotImplementedError

--- a/app/exceptions06/diff_mixin.py
+++ b/app/exceptions06/diff_mixin.py
@@ -52,3 +52,10 @@ class DiffExceptions06Mixin(DiffExceptionsMixin):
             status.HTTP_412_PRECONDITION_FAILED,
             detail=f'Update action requires version >= 1, got {element["version"] - 1}',
         )
+
+    @override
+    def diff_null_island(self, count: int):
+        raise APIError(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f'Changeset contains {count} nodes at the null island (0, 0)',
+        )

--- a/app/exceptions06/note_mixin.py
+++ b/app/exceptions06/note_mixin.py
@@ -25,6 +25,13 @@ class NoteExceptions06Mixin(NoteExceptionsMixin):
         )
 
     @override
+    def note_null_island(self):
+        raise APIError(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail='Creating notes at the null island (0, 0) is not allowed',
+        )
+
+    @override
     def notes_query_area_too_big(self):
         raise APIError(
             status.HTTP_400_BAD_REQUEST,

--- a/app/lib/changeset_bounds.py
+++ b/app/lib/changeset_bounds.py
@@ -1,3 +1,5 @@
+from typing import TypeAlias
+
 import cython
 import numpy as np
 from numpy.typing import NDArray
@@ -16,7 +18,7 @@ from app.config import (
     CHANGESET_NEW_BBOX_MIN_RATIO,
 )
 
-type _BBox = list[float]
+_BBox: TypeAlias = list[float]  # noqa: UP040
 
 _FIXED_K_MAX_CANDIDATE_EDGES = 5_000_000
 

--- a/app/lib/compressible_geometry.py
+++ b/app/lib/compressible_geometry.py
@@ -57,7 +57,8 @@ def compressible_geometry(
 
 @cython.cfunc
 def _compressible_float(value: float):
-    return _UINT64_STRUCT.unpack(_FLOAT_STRUCT.pack(value))[0] & _MASK_INT
+    value_int: object = _UINT64_STRUCT.unpack(_FLOAT_STRUCT.pack(value))[0]
+    return int(value_int) & _MASK_INT
 
 
 _POINT_STRUCT = struct.Struct('<BIQQ')

--- a/app/lib/compressible_geometry.py
+++ b/app/lib/compressible_geometry.py
@@ -67,21 +67,21 @@ _BBOX_STRUCT = struct.Struct('<BIII10Q')
 
 def point_to_compressible_wkb(lon: float, lat: float):
     """Convert a coordinate pair to a compressible WKB hex format."""
-    lon = _compressible_float(lon)
-    lat = _compressible_float(lat)
+    lon_int: object = _compressible_float(lon)
+    lat_int: object = _compressible_float(lat)
 
     # (byte order 1 = little endian + geometry type 1 = Point)
-    return _POINT_STRUCT.pack(1, 1, lon, lat)
+    return _POINT_STRUCT.pack(1, 1, lon_int, lat_int)
 
 
 def bbox_to_compressible_wkb(
     minlon: float, minlat: float, maxlon: float, maxlat: float
 ):
     """Convert a bounding box to a compressible WKB hex format."""
-    minlon = _compressible_float(minlon)
-    minlat = _compressible_float(minlat)
-    maxlon = _compressible_float(maxlon)
-    maxlat = _compressible_float(maxlat)
+    minlon_int: object = _compressible_float(minlon)
+    minlat_int: object = _compressible_float(minlat)
+    maxlon_int: object = _compressible_float(maxlon)
+    maxlat_int: object = _compressible_float(maxlat)
 
     # (byte order 1 = little endian + geometry type 3 = Polygon + 1 ring + 5 points)
     return _BBOX_STRUCT.pack(
@@ -89,14 +89,14 @@ def bbox_to_compressible_wkb(
         3,
         1,
         5,
-        maxlon,
-        minlat,
-        maxlon,
-        maxlat,
-        minlon,
-        maxlat,
-        minlon,
-        minlat,
-        maxlon,
-        minlat,
+        maxlon_int,
+        minlat_int,
+        maxlon_int,
+        maxlat_int,
+        minlon_int,
+        maxlat_int,
+        minlon_int,
+        minlat_int,
+        maxlon_int,
+        minlat_int,
     )

--- a/app/lib/cookie.py
+++ b/app/lib/cookie.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 from http.cookies import SimpleCookie
-from typing import Literal
+from typing import Literal, TypeAlias
 
 import cython
 from connectrpc.request import RequestContext
@@ -9,8 +9,8 @@ from starlette.responses import Response
 
 from app.config import ENV
 
-type CookieTarget = Response | RequestContext
-type CookieSameSite = Literal['lax', 'strict', 'none']
+CookieTarget: TypeAlias = Response | RequestContext  # noqa: UP040
+CookieSameSite: TypeAlias = Literal['lax', 'strict', 'none']  # noqa: UP040
 
 
 @cython.cfunc

--- a/app/lib/format_style_context.py
+++ b/app/lib/format_style_context.py
@@ -1,12 +1,12 @@
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Literal
+from typing import Literal, TypeAlias
 
 import cython
 
 from app.middlewares.request_context_middleware import get_request
 
-type FormatStyle = Literal['json', 'xml', 'rss', 'gpx']
+FormatStyle: TypeAlias = Literal['json', 'xml', 'rss', 'gpx']  # noqa: UP040
 
 _LEGACY_EXTENSION_FORMATS: dict[str, FormatStyle] = {
     'json': 'json',

--- a/app/lib/image.py
+++ b/app/lib/image.py
@@ -5,7 +5,7 @@ from contextlib import asynccontextmanager
 from functools import partial
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, NamedTuple, overload
+from typing import TYPE_CHECKING, Literal, NamedTuple, TypeAlias, overload
 
 import cython
 from blurhash_rs import blurhash_encode
@@ -49,7 +49,7 @@ class _Animation(NamedTuple):
     loop: int
 
 
-type UserAvatarType = Literal['gravatar', 'custom'] | None
+UserAvatarType: TypeAlias = Literal['gravatar', 'custom'] | None  # noqa: UP040
 
 DEFAULT_USER_AVATAR_URL = '/static/img/avatar.webp'
 DEFAULT_USER_AVATAR = Path('app' + DEFAULT_USER_AVATAR_URL).read_bytes()

--- a/app/lib/password_hash.py
+++ b/app/lib/password_hash.py
@@ -1,18 +1,18 @@
 from base64 import b64decode, b64encode
 from hashlib import md5, pbkdf2_hmac
 from hmac import compare_digest
-from typing import Literal, NamedTuple
+from typing import Literal, NamedTuple, TypeAlias
 
 import cython
+from app.models.proto.auth_pb2 import TransmitUserPassword
+from app.models.proto.server_pb2 import UserPassword
 from argon2 import PasswordHasher, Type
 from argon2.exceptions import VerifyMismatchError
 
 from app.config import SECRET_32
-from app.models.proto.auth_pb2 import TransmitUserPassword
-from app.models.proto.server_pb2 import UserPassword
 from app.models.types import Password
 
-type PasswordLike = Password | TransmitUserPassword
+PasswordLike: TypeAlias = Password | TransmitUserPassword  # noqa: UP040
 
 
 class VerifyResult(NamedTuple):

--- a/app/lib/rich_text.py
+++ b/app/lib/rich_text.py
@@ -4,7 +4,7 @@ from asyncio import TaskGroup
 from collections.abc import Collection, Generator, Iterable, Mapping, Sequence
 from html import escape
 from pathlib import Path
-from typing import Any, Literal, LiteralString, cast
+from typing import Any, Literal, LiteralString, TypeAlias, cast
 from urllib.parse import urlsplit, urlunsplit
 
 import cython
@@ -24,7 +24,7 @@ from app.models.types import ImageProxyId
 from app.services.cache_service import CacheContext, CacheService
 from app.services.image_proxy_service import ImageProxyService
 
-type TextFormat = Literal['html', 'markdown', 'plain']
+TextFormat: TypeAlias = Literal['html', 'markdown', 'plain']  # noqa: UP040
 
 
 async def process_rich_text_markdown(text: str):

--- a/app/lib/standard_pagination.py
+++ b/app/lib/standard_pagination.py
@@ -9,11 +9,16 @@ from typing import (
     Literal,
     LiteralString,
     NamedTuple,
+    TypeAlias,
     TypeVar,
     assert_never,
 )
 
 import cython
+from app.models.proto.shared_pb2 import (
+    StandardPaginationRequest,
+    StandardPaginationState,
+)
 from fastapi import Body
 from protovalidate import collect_violations
 from psycopg import AsyncConnection
@@ -28,10 +33,6 @@ from app.config import (
 )
 from app.db import db
 from app.lib.render_response import render_response
-from app.models.proto.shared_pb2 import (
-    StandardPaginationRequest,
-    StandardPaginationState,
-)
 
 
 class _SpCursorCodec(NamedTuple):
@@ -49,13 +50,13 @@ class _StandardPaginationQueryPlan(NamedTuple):
     anchor_op: Literal['<', '>'] | None = None
 
 
-type StandardPaginationRequestLike = bytes | StandardPaginationRequest
-type StandardPaginationRequestBody = Annotated[
+StandardPaginationRequestLike: TypeAlias = bytes | StandardPaginationRequest  # noqa: UP040
+StandardPaginationRequestBody: TypeAlias = Annotated[  # noqa: UP040
     bytes, Body(media_type='application/x-protobuf')
 ]
 
-type _OrderDir = Literal['asc', 'desc']
-type _CursorKind = Literal['id', 'datetime', 'text']
+_OrderDir: TypeAlias = Literal['asc', 'desc']  # noqa: UP040
+_CursorKind: TypeAlias = Literal['id', 'datetime', 'text']  # noqa: UP040
 
 _EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
 

--- a/app/lib/webauthn.py
+++ b/app/lib/webauthn.py
@@ -1,12 +1,13 @@
 from hashlib import sha256
 from pathlib import Path
-from typing import Literal, NamedTuple, NotRequired, TypedDict
+from typing import Literal, NamedTuple, NotRequired, TypeAlias, TypedDict
 from urllib.parse import urlsplit
 from uuid import UUID
 
 import cbor2
 import cython
 import orjson
+from app.models.proto.auth_pb2 import PasskeyAssertion
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric.ec import (
@@ -20,9 +21,8 @@ from starlette.exceptions import HTTPException
 
 from app.config import APP_URL
 from app.models.db.user_passkey import AAGUIDInfo, UserPasskey
-from app.models.proto.auth_pb2 import PasskeyAssertion
 
-type _ClientDataType = Literal['webauthn.create', 'webauthn.get']
+_ClientDataType: TypeAlias = Literal['webauthn.create', 'webauthn.get']  # noqa: UP040
 
 
 class _ClientData(TypedDict):

--- a/app/models/scope.py
+++ b/app/models/scope.py
@@ -1,9 +1,9 @@
 from collections.abc import Iterable
-from typing import Literal, get_args
+from typing import Literal, TypeAlias, get_args
 
 from app.models.proto.shared_pb2 import Scope as ProtoScope
 
-type PublicScope = Literal[
+PublicScope: TypeAlias = Literal[  # noqa: UP040
     'read_prefs',
     'write_prefs',
     'write_api',
@@ -12,9 +12,9 @@ type PublicScope = Literal[
     'write_notes',
 ]
 
-PUBLIC_SCOPES = frozenset[PublicScope](get_args(PublicScope.__value__))
+PUBLIC_SCOPES = frozenset[PublicScope](get_args(PublicScope))
 
-type Scope = (
+Scope: TypeAlias = (  # noqa: UP040
     PublicScope
     | Literal[
         # additional scopes

--- a/app/queries/graphhopper_query.py
+++ b/app/queries/graphhopper_query.py
@@ -1,5 +1,6 @@
-from typing import Literal, cast, get_args
+from typing import Literal, TypeAlias, cast, get_args
 
+from app.models.proto.shared_pb2 import RoutingResult
 from fastapi import HTTPException
 from shapely import Point, get_coordinates
 from starlette import status
@@ -8,11 +9,10 @@ from app.config import GRAPHHOPPER_API_KEY, GRAPHHOPPER_URL
 from app.lib.http_client import HTTP
 from app.lib.translation import primary_translation_locale
 from app.models.graphhopper import GraphHopperResponse
-from app.models.proto.shared_pb2 import RoutingResult
 
-type GraphHopperProfile = Literal['car', 'bike', 'foot']
+GraphHopperProfile: TypeAlias = Literal['car', 'bike', 'foot']  # noqa: UP040
 GraphHopperProfiles = frozenset[GraphHopperProfile](
-    get_args(GraphHopperProfile.__value__)
+    get_args(GraphHopperProfile)
 )
 
 

--- a/app/queries/osrm_query.py
+++ b/app/queries/osrm_query.py
@@ -1,8 +1,9 @@
 import logging
 from functools import cache
-from typing import Literal, cast, get_args
+from typing import Literal, TypeAlias, cast, get_args
 
 import cython
+from app.models.proto.shared_pb2 import RoutingResult
 from fastapi import HTTPException
 from polyline_rs import decode_latlon, encode_latlon
 from shapely import Point, get_coordinates
@@ -11,10 +12,9 @@ from app.config import OSRM_URL
 from app.lib.http_client import HTTP
 from app.lib.translation import t
 from app.models.osrm import OSRMResponse, OSRMStep
-from app.models.proto.shared_pb2 import RoutingResult
 
-type OSRMProfile = Literal['car', 'bike', 'foot']
-OSRMProfiles = frozenset[OSRMProfile](get_args(OSRMProfile.__value__))
+OSRMProfile: TypeAlias = Literal['car', 'bike', 'foot']  # noqa: UP040
+OSRMProfiles = frozenset[OSRMProfile](get_args(OSRMProfile))
 
 
 class OSRMQuery:

--- a/app/queries/valhalla_query.py
+++ b/app/queries/valhalla_query.py
@@ -1,17 +1,17 @@
-from typing import Literal, cast, get_args
+from typing import Literal, TypeAlias, cast, get_args
 
 import numpy as np
+from app.models.proto.shared_pb2 import RoutingResult
 from fastapi import HTTPException
 from shapely import Point, get_coordinates
 
 from app.config import VALHALLA_URL
 from app.lib.http_client import HTTP
 from app.lib.translation import primary_translation_locale
-from app.models.proto.shared_pb2 import RoutingResult
 from app.models.valhalla import ValhallaResponse
 
-type ValhallaProfile = Literal['auto', 'bicycle', 'pedestrian']
-ValhallaProfiles = frozenset[ValhallaProfile](get_args(ValhallaProfile.__value__))
+ValhallaProfile: TypeAlias = Literal['auto', 'bicycle', 'pedestrian']  # noqa: UP040
+ValhallaProfiles = frozenset[ValhallaProfile](get_args(ValhallaProfile))
 
 
 class ValhallaQuery:

--- a/app/responses/precompressed_static_files.py
+++ b/app/responses/precompressed_static_files.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 from mimetypes import guess_type
 from os import PathLike
 from os import stat_result as StatResultType  # noqa: N812
-from typing import override
+from typing import TypeAlias, override
 
 import cython
 from fastapi import HTTPException
@@ -17,8 +17,8 @@ from starlette_compress._utils import parse_accept_encoding
 
 from app.config import ENV, STATIC_PRECOMPRESSED_CACHE_MAX_ENTRIES
 
-type _CacheKey = tuple[str, str | None]
-type _CacheValue = tuple[str, StatResultType, str | None]
+_CacheKey: TypeAlias = tuple[str, str | None]  # noqa: UP040
+_CacheValue: TypeAlias = tuple[str, StatResultType, str | None]  # noqa: UP040
 
 
 class PrecompressedStaticFiles(StaticFiles):

--- a/app/services/note_service.py
+++ b/app/services/note_service.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from typing import Any
 
 import cython
+from app.models.proto.note_types import GetCommentsResponse_Comment_Event
 from psycopg.rows import dict_row
 from psycopg.sql import SQL, Composable
 from shapely import Point, get_coordinates
@@ -20,7 +21,6 @@ from app.models.db.note_comment import (
     note_comments_resolve_rich_text,
 )
 from app.models.db.user import user_is_moderator
-from app.models.proto.note_types import GetCommentsResponse_Comment_Event
 from app.models.types import DisplayName, NoteCommentId, NoteId
 from app.queries.nominatim_query import NominatimQuery
 from app.queries.note_comment_query import NoteCommentQuery
@@ -48,6 +48,9 @@ class NoteService:
         else:
             user_id = None
             user_ip = get_request_ip()
+
+        if point.x == 0 and point.y == 0 and not user_is_moderator(user):
+            raise_for.note_null_island()
 
         async with db(True) as conn:
             note_init: NoteInit = {

--- a/app/services/optimistic_diff/prepare.py
+++ b/app/services/optimistic_diff/prepare.py
@@ -2,10 +2,11 @@ import logging
 from asyncio import TaskGroup
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Final, Literal, assert_never
+from typing import Final, Literal, TypeAlias, assert_never
 
 import cython
 import numpy as np
+from app.models.proto.shared_types import ElementType
 from psycopg import AsyncConnection
 from shapely import Point, bounds, box
 
@@ -21,14 +22,13 @@ from app.models.element import (
     TYPED_ELEMENT_ID_RELATION_MIN,
     TypedElementId,
 )
-from app.models.proto.shared_types import ElementType
 from app.models.types import SequenceId
 from app.queries.changeset_bounds_query import ChangesetBoundsQuery
 from app.queries.changeset_query import ChangesetQuery
 from app.queries.element_query import ElementQuery
 from speedup import element_id, element_type, split_typed_element_id
 
-type OSMChangeAction = Literal['create', 'modify', 'delete']
+OSMChangeAction: TypeAlias = Literal['create', 'modify', 'delete']  # noqa: UP040
 
 
 @dataclass(kw_only=True, slots=True)

--- a/app/services/optimistic_diff/prepare.py
+++ b/app/services/optimistic_diff/prepare.py
@@ -15,6 +15,7 @@ from app.lib.changeset_bounds import extend_changeset_bounds
 from app.lib.exceptions_context import raise_for
 from app.models.db.changeset import Changeset, changeset_increase_size
 from app.models.db.element import Element, ElementInit
+from app.models.db.user import user_is_moderator
 from app.models.element import (
     TYPED_ELEMENT_ID_NODE_MAX,
     TYPED_ELEMENT_ID_NODE_MIN,
@@ -208,6 +209,15 @@ class OptimisticDiffPrepare:
                 )
             else:
                 entry.current = element
+
+        if not user_is_moderator(auth_user()):
+            null_island_count: cython.size_t = 0
+            for element in apply_elements:
+                point = element['point']
+                if point is not None and point.x == 0 and point.y == 0:
+                    null_island_count += 1
+            if null_island_count >= 2:
+                raise_for.diff_null_island(null_island_count)
 
         self._update_changeset_size(
             num_create=num_create,

--- a/app/validators/display_name.py
+++ b/app/validators/display_name.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, TypeAlias
 
 from annotated_types import MaxLen, MinLen
 
@@ -9,12 +9,12 @@ from app.validators.url import UrlSafeValidator
 from app.validators.whitespace import BoundaryWhitespaceValidator
 from app.validators.xml import XMLSafeValidator
 
-type DisplayNameNormalizing = Annotated[
+DisplayNameNormalizing: TypeAlias = Annotated[  # noqa: UP040
     DisplayName,
     UnicodeValidator,
 ]
 
-type DisplayNameValidating = Annotated[
+DisplayNameValidating: TypeAlias = Annotated[  # noqa: UP040
     DisplayNameNormalizing,
     MinLen(3),
     MaxLen(DISPLAY_NAME_MAX_LENGTH),

--- a/app/validators/email.py
+++ b/app/validators/email.py
@@ -1,6 +1,6 @@
 import logging
 from asyncio import Task, TaskGroup
-from typing import Annotated
+from typing import Annotated, TypeAlias
 
 from annotated_types import MaxLen, MinLen
 from dns.asyncresolver import Resolver
@@ -137,7 +137,7 @@ EmailValidator = BeforeValidator(validate_email)
 
 # ideally, should be defined in app/models/types.py
 # but this causes circular import
-type EmailValidating = Annotated[
+EmailValidating: TypeAlias = Annotated[  # noqa: UP040
     Email,
     MinLen(EMAIL_MIN_LENGTH),
     MaxLen(EMAIL_MAX_LENGTH),

--- a/app/validators/tags.py
+++ b/app/validators/tags.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, TypeAlias
 
 import cython
 from annotated_types import MaxLen, MinLen
@@ -34,7 +34,7 @@ def _validate_tags(
     return v
 
 
-type TagsValidating = Annotated[
+TagsValidating: TypeAlias = Annotated[  # noqa: UP040
     dict[
         Annotated[
             str,

--- a/scripts/replication_download.py
+++ b/scripts/replication_download.py
@@ -9,12 +9,13 @@ from dataclasses import asdict, dataclass, replace
 from datetime import UTC, datetime, timedelta
 from itertools import pairwise
 from time import monotonic
-from typing import Literal, get_args
+from typing import Literal, TypeAlias, get_args
 
 import cython
 import orjson
 import pyarrow as pa
 import pyarrow.parquet as pq
+from app.models.proto.shared_types import ElementType
 from sentry_sdk import set_context, set_tag, start_transaction
 from starlette import status
 
@@ -26,17 +27,16 @@ from app.lib.retry import retry
 from app.lib.sentry import SENTRY_REPLICATION_MONITOR, SENTRY_REPLICATION_MONITOR_SLUG
 from app.lib.xmltodict import XMLToDict
 from app.models.element import TypedElementId
-from app.models.proto.shared_types import ElementType
 from speedup import typed_element_id
 
-type _Dataset = Literal['replication', 'redaction-period', 'cc-by-sa']
-type _Frequency = Literal['minute', 'hour', 'day']
+_Dataset: TypeAlias = Literal['replication', 'redaction-period', 'cc-by-sa']  # noqa: UP040
+_Frequency: TypeAlias = Literal['minute', 'hour', 'day']  # noqa: UP040
 
 _APP_STATE_PATH = REPLICATION_DIR.joinpath('state.json')
 _LOCK_PATH = REPLICATION_DIR.joinpath('.lock')
 
 _NEXT_DATASET: dict[_Dataset, _Dataset] = {
-    from_: to for to, from_ in pairwise(get_args(_Dataset.__value__))
+    from_: to for to, from_ in pairwise(get_args(_Dataset))
 }
 
 _FREQUENCY_TIMEDELTA: dict[_Frequency, timedelta] = {

--- a/scripts/replication_generate.py
+++ b/scripts/replication_generate.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime, timedelta
 from functools import cache
 from pathlib import Path
 from shutil import copyfile
-from typing import Literal, TypedDict, get_args
+from typing import Literal, TypeAlias, TypedDict, get_args
 
 import cython
 from psycopg import AsyncConnection
@@ -31,7 +31,7 @@ class _State(TypedDict):
     timestamp: datetime
 
 
-type _TimeSpan = Literal['minute', 'hour', 'day']
+_TimeSpan: TypeAlias = Literal['minute', 'hour', 'day']  # noqa: UP040
 
 _TIMESPAN_DELTA: dict[_TimeSpan, timedelta] = {
     'minute': timedelta(minutes=1),

--- a/tests/controllers/test_api06_note.py
+++ b/tests/controllers/test_api06_note.py
@@ -17,7 +17,7 @@ async def test_note_create_xml(client: AsyncClient):
 
     r = await client.post(
         '/api/0.6/notes',
-        params={'lon': 0, 'lat': 0, 'text': test_note_create_xml.__qualname__},
+        params={'lon': 1, 'lat': 1, 'text': test_note_create_xml.__qualname__},
     )
     assert r.is_success, r.text
     note: dict = XMLToDict.parse(r.content)['osm']['note'][0]
@@ -26,8 +26,8 @@ async def test_note_create_xml(client: AsyncClient):
     assert_model(
         note,
         {
-            '@lat': 0.0,
-            '@lon': 0.0,
+            '@lat': 1.0,
+            '@lon': 1.0,
             'id': PositiveInt,
             'status': 'open',
             'url': str,
@@ -51,7 +51,7 @@ async def test_note_create_json(client: AsyncClient):
 
     r = await client.post(
         '/api/0.6/notes.json',
-        json={'lon': 0, 'lat': 0, 'text': test_note_create_json.__qualname__},
+        json={'lon': 1, 'lat': 1, 'text': test_note_create_json.__qualname__},
     )
     assert r.is_success, r.text
     props = r.json()['properties']
@@ -72,7 +72,7 @@ async def test_note_create_gpx(client: AsyncClient):
 
     r = await client.post(
         '/api/0.6/notes.gpx',
-        params={'lon': 0, 'lat': 0, 'text': test_note_create_gpx.__qualname__},
+        params={'lon': 1, 'lat': 1, 'text': test_note_create_gpx.__qualname__},
     )
     assert r.is_success, r.text
     waypoint: dict = XMLToDict.parse(r.content)['gpx']['wpt']
@@ -80,8 +80,8 @@ async def test_note_create_gpx(client: AsyncClient):
     assert_model(
         waypoint,
         {
-            '@lat': 0.0,
-            '@lon': 0.0,
+            '@lat': 1.0,
+            '@lon': 1.0,
             'time': datetime,
             'name': str,
             'link': dict,
@@ -94,7 +94,7 @@ async def test_note_create_gpx(client: AsyncClient):
 async def test_note_create_anonymous(client: AsyncClient):
     r = await client.post(
         '/api/0.6/notes.json',
-        json={'lon': 0, 'lat': 0, 'text': test_note_create_anonymous.__qualname__},
+        json={'lon': 1, 'lat': 1, 'text': test_note_create_anonymous.__qualname__},
     )
     assert r.is_success, r.text
     props = r.json()['properties']
@@ -110,13 +110,39 @@ async def test_note_create_anonymous(client: AsyncClient):
     assert 'user' not in props['comments'][0]
 
 
+async def test_note_create_rejects_null_island(client: AsyncClient):
+    r = await client.post(
+        '/api/0.6/notes.json',
+        json={'lon': 0, 'lat': 0, 'text': test_note_create_rejects_null_island.__name__},
+    )
+
+    assert r.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, r.text
+    assert 'null island' in r.text
+
+
+async def test_note_create_allows_null_island_for_moderator(client: AsyncClient):
+    client.headers['Authorization'] = 'User moderator'
+
+    r = await client.post(
+        '/api/0.6/notes.json',
+        json={
+            'lon': 0,
+            'lat': 0,
+            'text': test_note_create_allows_null_island_for_moderator.__name__,
+        },
+    )
+
+    assert r.is_success, r.text
+    assert_model(r.json()['geometry'], {'coordinates': [0.0, 0.0]})
+
+
 async def test_note_crud(client: AsyncClient):
     client.headers['Authorization'] = 'User user1'
 
     # Step 1: Create a note
     r = await client.post(
         '/api/0.6/notes.json',
-        json={'lon': 0, 'lat': 0, 'text': test_note_crud.__qualname__},
+        json={'lon': 1, 'lat': 1, 'text': test_note_crud.__qualname__},
     )
     assert r.is_success, r.text
     props = r.json()['properties']
@@ -224,7 +250,7 @@ async def test_note_crud(client: AsyncClient):
     [
         {'lon': 181, 'lat': 0, 'text': 'Invalid longitude'},
         {'lon': 0, 'lat': 91, 'text': 'Invalid latitude'},
-        {'lon': 0, 'lat': 0, 'text': ''},
+        {'lon': 1, 'lat': 1, 'text': ''},
     ],
 )
 async def test_note_bad_input(client: AsyncClient, input_data):
@@ -264,7 +290,7 @@ async def test_note_search(client: AsyncClient):
     text = f'{test_note_search.__qualname__} {search_text}'
     r = await client.post(
         '/api/0.6/notes.json',
-        json={'lon': 0, 'lat': 0, 'text': text},
+        json={'lon': 1, 'lat': 1, 'text': text},
     )
     assert r.is_success, r.text
 

--- a/tests/controllers/test_oauth2.py
+++ b/tests/controllers/test_oauth2.py
@@ -370,7 +370,7 @@ async def test_access_token_in_form(client: AsyncClient, valid_scope):
     # Attempt to create a note using the token in form data
     r = await client.post(
         '/api/0.6/notes',
-        params={'lon': 0, 'lat': 0, 'text': test_access_token_in_form.__qualname__},
+        params={'lon': 1, 'lat': 1, 'text': test_access_token_in_form.__qualname__},
         data={'access_token': access_token},
     )
 

--- a/tests/middlewares/test_request_body_middleware.py
+++ b/tests/middlewares/test_request_body_middleware.py
@@ -78,7 +78,7 @@ async def test_compressed_json(
 
     # Setup test data
     text = f'{test_compressed_json.__qualname__}: {encoding}'
-    content = orjson.dumps({'lon': 0, 'lat': 0, 'text': text})
+    content = orjson.dumps({'lon': 1, 'lat': 1, 'text': text})
 
     # Execute request with compressed JSON
     r = await client.post(
@@ -166,7 +166,7 @@ async def test_passthrough_unsupported_compression(client: AsyncClient):
 
     # Setup test data
     text = 'unknown compression'
-    content = orjson.dumps({'lon': 0, 'lat': 0, 'text': text})
+    content = orjson.dumps({'lon': 1, 'lat': 1, 'text': text})
 
     # Execute request with unsupported compression header
     r = await client.post(
@@ -207,7 +207,7 @@ async def test_size_limit_after_decompression(
 
     # Create data that's small when compressed but exceeds limits when decompressed
     content = compress(
-        orjson.dumps({'lon': 0, 'lat': 0, 'text': 'A' * REQUEST_BODY_MAX_SIZE})
+        orjson.dumps({'lon': 1, 'lat': 1, 'text': 'A' * REQUEST_BODY_MAX_SIZE})
     )
     assert len(content) < REQUEST_BODY_MAX_SIZE, (
         'Compressed content must be under size limit'

--- a/tests/models/test_note_comment.py
+++ b/tests/models/test_note_comment.py
@@ -10,7 +10,7 @@ async def test_note_comments_resolve_rich_text():
     user = await UserQuery.find_by_display_name(DisplayName('user1'))
     with auth_context(user, frozenset(('web_user',))):
         note_id = await NoteService.create(
-            0, 0, test_note_comments_resolve_rich_text.__qualname__
+            1, 1, test_note_comments_resolve_rich_text.__qualname__
         )
         header = await NoteCommentQuery.find_header(note_id)
         assert header is not None

--- a/tests/services/optimistic_diff/test_create.py
+++ b/tests/services/optimistic_diff/test_create.py
@@ -1,10 +1,10 @@
 import pytest
+from app.models.proto.shared_types import ElementType
 from shapely import Point
 
 from app.lib.user_role_limits import UserRoleLimits
 from app.models.db.element import ElementInit, validate_elements
 from app.models.element import ElementId
-from app.models.proto.shared_types import ElementType
 from app.models.types import ChangesetId
 from app.queries.element_query import ElementQuery
 from app.services.changeset_service import ChangesetService
@@ -94,6 +94,36 @@ async def test_create_multiple_nodes(changeset_id: ChangesetId):
     name_map = {e['tags']['name']: e for e in elements}  # type: ignore
     assert_model(name_map['Node 1'], nodes[0] | {'typed_id': typed_ids[0]})
     assert_model(name_map['Node 2'], nodes[1] | {'typed_id': typed_ids[1]})
+
+
+async def test_create_rejects_multiple_null_island_nodes(changeset_id: ChangesetId):
+    # Arrange
+    nodes: list[ElementInit] = [
+        {
+            'changeset_id': changeset_id,
+            'typed_id': typed_element_id('node', ElementId(-1)),
+            'version': 1,
+            'visible': True,
+            'tags': {},
+            'point': Point(0, 0),
+            'members': None,
+            'members_roles': None,
+        },
+        {
+            'changeset_id': changeset_id,
+            'typed_id': typed_element_id('node', ElementId(-2)),
+            'version': 1,
+            'visible': True,
+            'tags': {},
+            'point': Point(0, 0),
+            'members': None,
+            'members_roles': None,
+        },
+    ]
+
+    # Act & Assert
+    with pytest.raises(Exception):
+        await OptimisticDiff.run(nodes)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- rejects changeset uploads with 2+ nodes at the null island for non-moderators
- rejects note creation at exactly (0, 0) for non-moderators
- keeps single null-island nodes allowed for legitimate edge cases and lets moderators bypass both restrictions
- updates existing note tests away from accidental (0, 0) coordinates and adds explicit null-island coverage

Note: this branch also includes the current-main CI fix from #236 (diary details proto construction, Cython-compatible type aliases, and the compressible WKB integer fix) because unrelated main CI failures were making bounty branches red.

Closes #128

## Testing
- git diff --check
- python3 -m py_compile app/exceptions/diff_mixin.py app/exceptions06/diff_mixin.py app/exceptions/note_mixin.py app/exceptions06/note_mixin.py app/services/note_service.py app/services/optimistic_diff/prepare.py tests/controllers/test_api06_note.py tests/middlewares/test_request_body_middleware.py tests/controllers/test_oauth2.py tests/models/test_note_comment.py tests/services/optimistic_diff/test_create.py app/lib/compressible_geometry.py
- uvx ruff check app/exceptions/diff_mixin.py app/exceptions06/diff_mixin.py app/exceptions/note_mixin.py app/exceptions06/note_mixin.py app/services/note_service.py app/services/optimistic_diff/prepare.py tests/controllers/test_api06_note.py tests/middlewares/test_request_body_middleware.py tests/controllers/test_oauth2.py tests/models/test_note_comment.py tests/services/optimistic_diff/test_create.py app/lib/compressible_geometry.py
- targeted Cython parse of touched Cython-covered files
- point_to_compressible_wkb expected-output smoke test in a uvx environment with cython/numpy/shapely

`uv run pytest tests/controllers/test_api06_note.py tests/services/optimistic_diff/test_create.py tests/middlewares/test_request_body_middleware.py tests/controllers/test_oauth2.py tests/models/test_note_comment.py -q` could not run locally because this machine's Cargo is 1.84.1 and the speedup package requires edition2024 support.
