### PR TITLE
Handle oversized and invalid image uploads

### DIFF
--- a/app/exceptions/image_mixin.py
+++ b/app/exceptions/image_mixin.py
@@ -10,6 +10,12 @@ class ImageExceptionsMixin:
     def image_too_big(self):
         raise APIError(status.HTTP_413_CONTENT_TOO_LARGE, detail='Image is too large')
 
+    def image_not_readable(self):
+        raise APIError(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail='Image is invalid or corrupted',
+        )
+
     def image_inappropriate(self):
         raise APIError(
             status.HTTP_422_UNPROCESSABLE_CONTENT,

--- a/app/lib/image.py
+++ b/app/lib/image.py
@@ -9,8 +9,9 @@ from typing import TYPE_CHECKING, Literal, NamedTuple, overload
 
 import cython
 from blurhash_rs import blurhash_encode
-from PIL import ImageOps, ImageSequence
+from PIL import ImageOps, ImageSequence, UnidentifiedImageError
 from PIL.Image import Image as PILImage
+from PIL.Image import DecompressionBombError
 from PIL.Image import Resampling
 from PIL.Image import open as open_image
 from sizestr import sizestr
@@ -242,8 +243,13 @@ async def _normalize_image(
     - Megapixels: downscale
     - File size: reduce quality
     """
-    img = open_image(BytesIO(data))
-    ImageOps.exif_transpose(img, in_place=True)
+    try:
+        img = open_image(BytesIO(data))
+        ImageOps.exif_transpose(img, in_place=True)
+    except DecompressionBombError:
+        raise_for.image_too_big()
+    except (UnidentifiedImageError, OSError, SyntaxError):
+        raise_for.image_not_readable()
 
     # normalize shape ratio
     img_width: cython.size_t

--- a/app/views/lib/image-upload.ts
+++ b/app/views/lib/image-upload.ts
@@ -1,0 +1,13 @@
+import { t } from "i18next"
+
+const IMAGE_UPLOAD_MAX_BYTES = 10 * 1024 * 1024
+
+export const assertImageUploadSize = (
+  formData: FormData,
+  fieldName: string,
+) => {
+  const file = formData.get(fieldName)
+  if (!(file instanceof File) || file.size <= IMAGE_UPLOAD_MAX_BYTES) return
+
+  throw new Error(t("validation.image_file_too_big"))
+}

--- a/app/views/settings/applications/edit.tsx
+++ b/app/views/settings/applications/edit.tsx
@@ -1,5 +1,6 @@
 import { OAUTH_APP_NAME_MAX_LENGTH } from "@lib/config"
 import { CopyButton } from "@lib/copy-group"
+import { assertImageUploadSize } from "@lib/image-upload"
 import { mountProtoPage } from "@lib/proto-page"
 import { EditPageSchema, Service } from "@lib/proto/settings_applications_pb"
 import { Scope } from "@lib/proto/shared_pb"
@@ -247,10 +248,13 @@ mountProtoPage(
                         class="avatar-form"
                         formRef={avatarFormRef}
                         method={Service.method.updateAvatar}
-                        buildRequest={async ({ formData }) => ({
-                          id,
-                          avatarFile: await formDataBytes(formData, "avatar_file"),
-                        })}
+                        buildRequest={async ({ formData }) => {
+                          assertImageUploadSize(formData, "avatar_file")
+                          return {
+                            id,
+                            avatarFile: await formDataBytes(formData, "avatar_file"),
+                          }
+                        }}
                         onSuccess={(resp) => (avatarUrl.value = resp.avatarUrl)}
                       >
                         <input

--- a/app/views/user/profile/profile.tsx
+++ b/app/views/user/profile/profile.tsx
@@ -3,6 +3,7 @@ import { config, USER_RECENT_ACTIVITY_ENTRIES } from "@lib/config"
 import { Time } from "@lib/datetime-inputs"
 import { FollowToggleForm } from "@lib/follow-toggle-form"
 import { tRich } from "@lib/i18n"
+import { assertImageUploadSize } from "@lib/image-upload"
 import { mountProtoPage } from "@lib/proto-page"
 import { PageSchema, type PageValid } from "@lib/proto/profile_pb"
 import { Service, UpdateAvatarRequest_Preset } from "@lib/proto/settings_pb"
@@ -166,9 +167,12 @@ const BackgroundForm = ({
     <StandardForm
       class="background-form"
       method={Service.method.updateBackground}
-      buildRequest={async ({ formData }) => ({
-        backgroundFile: await formDataBytes(formData, "background_file"),
-      })}
+      buildRequest={async ({ formData }) => {
+        assertImageUploadSize(formData, "background_file")
+        return {
+          backgroundFile: await formDataBytes(formData, "background_file"),
+        }
+      }}
       onSuccess={(resp) => (backgroundUrl.value = resp.backgroundUrl)}
     >
       <input
@@ -247,6 +251,7 @@ const AvatarForm = ({
       class="avatar-form"
       method={Service.method.updateAvatar}
       buildRequest={async ({ formData }) => {
+        assertImageUploadSize(formData, "avatar_file")
         const avatarFile = await formDataBytes(formData, "avatar_file")
         if (avatarFile.length) {
           return {

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -580,6 +580,7 @@ validation:
   you_can_send_message_to_at_most_count_recipients: "You can send a message to at most {{count}} recipients"
   you_can_add_at_most_count_tags: "You can add at most {{count}} tags"
   incomplete_location_information: Incomplete location information
+  image_file_too_big: Image file is too large. Please choose an image under 10 MB.
 action:
   go_back: Go back
   authorize: Authorize

--- a/tests/lib/test_image.py
+++ b/tests/lib/test_image.py
@@ -3,8 +3,14 @@ from pathlib import Path
 
 import pytest
 from PIL import Image as PILImage
+from PIL.Image import DecompressionBombError
+from starlette import status
 
+import app.lib.image as image_module
+from app.exceptions import Exceptions
+from app.exceptions.api_error import APIError
 from app.config import IMAGE_MAX_FRAMES
+from app.lib.exceptions_context import exceptions_context
 from app.lib.image import Image
 
 
@@ -42,3 +48,26 @@ async def test_normalize_avatar_preserves_animation(animation: bytes):
     assert len(normalized[0]) < len(animation)
     assert result.is_animated  # type: ignore
     assert 1 < result.n_frames <= IMAGE_MAX_FRAMES  # type: ignore
+
+
+async def test_normalize_avatar_rejects_unreadable_image():
+    with exceptions_context(Exceptions()):
+        with pytest.raises(APIError) as exc_info:
+            await Image.normalize_avatar(b'not an image')
+
+    assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert exc_info.value.detail == 'Image is invalid or corrupted'
+
+
+async def test_normalize_avatar_maps_decompression_bomb_to_too_big(monkeypatch):
+    def raise_decompression_bomb(_data):
+        raise DecompressionBombError('too many pixels')
+
+    monkeypatch.setattr(image_module, 'open_image', raise_decompression_bomb)
+
+    with exceptions_context(Exceptions()):
+        with pytest.raises(APIError) as exc_info:
+            await Image.normalize_avatar(b'fake image')
+
+    assert exc_info.value.status_code == status.HTTP_413_CONTENT_TOO_LARGE
+    assert exc_info.value.detail == 'Image is too large'


### PR DESCRIPTION
## Summary
- map Pillow decompression-bomb failures to the existing image-too-big response
- add a friendly 422 response for invalid or corrupted image uploads
- add a lightweight 10 MB client-side file-size guard for profile backgrounds, user avatars, and application avatars
- add focused backend regression tests for unreadable images and decompression-bomb handling

Fixes #31

## Testing
- `python -m compileall -q app\lib\image.py app\exceptions\image_mixin.py tests\lib\test_image.py`
- `git diff --check`
- `python -m pytest tests\lib\test_image.py -q` *(blocked locally before tests run: `ImportError: cannot import name 'typed_element_id' from 'speedup'` while loading `tests/conftest.py`)*