### PR TITLE
[codex] Support PDF and SVG map exports

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -125,6 +125,8 @@ OSM_REPLICATION_URL = (
 OSM_OLD_REPLICATION_URL = 'https://planet.openstreetmap.org'
 OSRM_URL = 'https://router.project-osrm.org'
 OVERPASS_INTERPRETER_URL = 'https://overpass-api.de/api/interpreter'
+RENDER_EXPORT_TOTP_KEY = SecretStr('')
+RENDER_EXPORT_URL = 'https://render.openstreetmap.org/cgi-bin/export'
 VALHALLA_URL = 'https://valhalla1.openstreetmap.de'
 
 # API and HTTP settings

--- a/app/controllers/web_map.py
+++ b/app/controllers/web_map.py
@@ -1,0 +1,49 @@
+import base64
+import hmac
+import time
+from hashlib import sha1
+from typing import Annotated, Literal
+from urllib.parse import urlencode
+
+from app.config import RENDER_EXPORT_TOTP_KEY, RENDER_EXPORT_URL
+from app.lib.geo_utils import parse_bbox
+from fastapi import APIRouter, Query
+from pydantic import PositiveInt
+from starlette import status
+from starlette.responses import RedirectResponse
+
+router = APIRouter(prefix='/api/web/map')
+
+
+@router.get('/export')
+async def export_map(
+    bbox: Annotated[str, Query(min_length=1)],
+    scale: Annotated[PositiveInt, Query()],
+    format: Annotated[Literal['svg', 'pdf'], Query()],
+):
+    bounds = parse_bbox(bbox).bounds
+    params = {
+        'bbox': ','.join(str(v) for v in bounds),
+        'scale': str(scale),
+        'format': format,
+        'token': _render_export_totp(),
+    }
+    return RedirectResponse(
+        f'{RENDER_EXPORT_URL}?{urlencode(params)}',
+        status.HTTP_303_SEE_OTHER,
+    )
+
+
+def _render_export_totp():
+    secret = RENDER_EXPORT_TOTP_KEY.get_secret_value()
+    if not secret:
+        return ''
+
+    normalized = secret.replace(' ', '').upper()
+    normalized += '=' * (-len(normalized) % 8)
+    key = base64.b32decode(normalized)
+    counter = int(time.time() // 3600)
+    digest = hmac.new(key, counter.to_bytes(8, 'big'), sha1).digest()
+    offset = digest[-1] & 0x0F
+    code = int.from_bytes(digest[offset : offset + 4], 'big') & 0x7FFFFFFF
+    return f'{code % 1_000_000:06d}'

--- a/app/views/index/sidebar/share.tsx
+++ b/app/views/index/sidebar/share.tsx
@@ -32,6 +32,8 @@ const SHARE_FORMATS = [
   { mimeType: "image/jpeg", suffix: ".jpg", label: "JPEG" },
   { mimeType: "image/png", suffix: ".png", label: "PNG" },
   { mimeType: "image/webp", suffix: ".webp", label: "WebP" },
+  { mimeType: "image/svg+xml", suffix: ".svg", label: "SVG" },
+  { mimeType: "application/pdf", suffix: ".pdf", label: "PDF" },
 ] as const
 
 let urlMarker: Marker | null = null

--- a/app/views/lib/map/export-image.ts
+++ b/app/views/lib/map/export-image.ts
@@ -5,7 +5,7 @@ import type {
   LngLatBounds,
   Map as MaplibreMap,
 } from "maplibre-gl"
-import { boundsIntersect, boundsIntersection } from "./bounds"
+import { boundsIntersect, boundsIntersection, boundsToString } from "./bounds"
 import { loadMapImage } from "./image"
 import {
   addMapLayer,
@@ -35,9 +35,105 @@ layersConfig.set(LAYER_ID, {
 
 // https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob#quality
 const IMAGE_QUALITY = 0.98
+const SVG_MIME_TYPE = "image/svg+xml"
+const PDF_MIME_TYPE = "application/pdf"
+const RENDER_EXPORT_FORMATS = new Map([
+  [SVG_MIME_TYPE, "svg"],
+  [PDF_MIME_TYPE, "pdf"],
+])
+const EARTH_RADIUS = 6378137
+const PRINT_METERS_PER_PIXEL = 1 / (92 * 39.3701)
+const STANDARD_PIXEL_SIZE = 0.00028
+const MAX_RENDER_AREA = 4_000_000 * STANDARD_PIXEL_SIZE ** 2
+const MAX_MERCATOR_LATITUDE = 85.05112878
 
 export const exportMapImage = async (
   mimeType: string,
+  map: MaplibreMap,
+  filterBounds: LngLatBounds | null,
+  markerLngLat: LngLat | null,
+  attribution: boolean,
+) => {
+  const renderFormat = RENDER_EXPORT_FORMATS.get(mimeType)
+  if (renderFormat) return await exportRenderedMap(renderFormat, map, filterBounds)
+
+  const exportCanvas = await renderMapCanvas(
+    map,
+    filterBounds,
+    markerLngLat,
+    attribution,
+  )
+
+  return await exportCanvasToBlob(exportCanvas, mimeType)
+}
+
+const exportRenderedMap = async (
+  format: string,
+  map: MaplibreMap,
+  filterBounds: LngLatBounds | null,
+) => {
+  const mapBounds = map.getBounds()
+  const exportBounds =
+    filterBounds && boundsIntersect(mapBounds, filterBounds)
+      ? boundsIntersection(mapBounds, filterBounds)
+      : mapBounds
+  const params = new URLSearchParams({
+    bbox: boundsToString(exportBounds, 7),
+    scale: getRenderScale(map, exportBounds).toString(),
+    format,
+  })
+  const response = await fetch(`/api/web/map/export?${params}`)
+  if (!response.ok) {
+    throw new Error((await response.text()) || "Failed to export the map image")
+  }
+  return await response.blob()
+}
+
+const getRenderScale = (map: MaplibreMap, exportBounds: LngLatBounds) => {
+  const scale = getCurrentMapScale(map)
+  const minScale = getMinRenderScale(exportBounds)
+  return scale < minScale ? roundScale(minScale) : scale
+}
+
+const getCurrentMapScale = (map: MaplibreMap) => {
+  const bounds = map.getBounds().adjustAntiMeridian()
+  const centerLat = bounds.getCenter().lat
+  const halfWorldMeters =
+    EARTH_RADIUS * Math.PI * Math.cos((centerLat * Math.PI) / 180)
+  const meters = (halfWorldMeters * (bounds.getEast() - bounds.getWest())) / 180
+  const pixelsPerMeter = map.getCanvas().clientWidth / meters
+  const scale = Math.round(1 / (pixelsPerMeter * PRINT_METERS_PER_PIXEL))
+  return Number.isFinite(scale) ? Math.max(1, scale) : 1
+}
+
+const getMinRenderScale = (bounds: LngLatBounds) => {
+  const adjusted = bounds.adjustAntiMeridian()
+  const southWest = projectMercator(adjusted.getSouthWest())
+  const northEast = projectMercator(adjusted.getNorthEast())
+  const area = Math.abs(northEast.x - southWest.x) * Math.abs(northEast.y - southWest.y)
+  const scale = Math.floor(Math.sqrt(area / MAX_RENDER_AREA))
+  return Number.isFinite(scale) ? Math.max(1, scale) : 1
+}
+
+const projectMercator = (lngLat: LngLat) => {
+  const lat = Math.max(
+    -MAX_MERCATOR_LATITUDE,
+    Math.min(MAX_MERCATOR_LATITUDE, lngLat.lat),
+  )
+  const lonRad = (lngLat.lng * Math.PI) / 180
+  const latRad = (lat * Math.PI) / 180
+  return {
+    x: EARTH_RADIUS * lonRad,
+    y: EARTH_RADIUS * Math.log(Math.tan(Math.PI / 4 + latRad / 2)),
+  }
+}
+
+const roundScale = (scale: number) => {
+  const precision = 5 * 10 ** (Math.floor(Math.LOG10E * Math.log(scale)) - 2)
+  return precision * Math.ceil(scale / precision)
+}
+
+const renderMapCanvas = async (
   map: MaplibreMap,
   filterBounds: LngLatBounds | null,
   markerLngLat: LngLat | null,
@@ -83,7 +179,6 @@ export const exportMapImage = async (
   console.debug(
     "ExportImage: Exporting",
     [sourceCanvas.width, sourceCanvas.height],
-    mimeType,
   )
   let exportCanvas = document.createElement("canvas")
   exportCanvas.width = sourceCanvas.width
@@ -140,7 +235,13 @@ export const exportMapImage = async (
     ctx.fillText(attributionText, xPos + padding, yPos + padding, textWidth)
   }
 
-  // Export the canvas to an image
+  return exportCanvas
+}
+
+const exportCanvasToBlob = (
+  exportCanvas: HTMLCanvasElement,
+  mimeType: string,
+) => {
   return new Promise<Blob>((resolve, reject) => {
     exportCanvas.toBlob(
       (blob) => {


### PR DESCRIPTION
## Summary

Fixes #36.

- add SVG and PDF to the share sidebar export format selector
- keep JPEG/PNG/WebP on the existing canvas export path
- route SVG/PDF exports through `/api/web/map/export`, which redirects to `render.openstreetmap.org` with bbox, scale, format, and an optional `RENDER_EXPORT_TOTP_KEY` token
- compute print scale from the current map view and raise it for large selected regions to avoid oversized render requests

## Validation

- `python -m py_compile app\controllers\web_map.py app\config.py`
- `npx -y oxlint --disable-nested-config ...export-image.ts ...share.tsx`
- `npx -y -p ruff ruff check ...web_map.py --config ...pyproject.toml`
- `git diff --cached --check`

`npx -y -p typescript tsc --noEmit --project tsconfig.json` could not complete in this environment because `node_modules` is absent and the required type packages are missing. Installing dependencies with npm is blocked by the repo's Bun-specific `vite` override (`EOVERRIDE`), and `bun`/`nix` are not installed here.