### PR TITLE
Handle oversized and unreadable avatar uploads

### DIFF
--- a/app/controllers/diary.py
+++ b/app/controllers/diary.py
@@ -2,6 +2,13 @@ from asyncio import TaskGroup
 from typing import Annotated
 
 import cython
+from app.models.proto.diary_pb2 import (
+    ComposePage,
+    DetailsPage,
+    IndexPage,
+    UserCommentsPage,
+)
+from app.models.proto.shared_pb2 import LonLat
 from fastapi import APIRouter, Path, Query, Response
 from feedgen.feed import FeedGenerator
 from pydantic import SecretStr
@@ -18,13 +25,6 @@ from app.lib.user_token_struct_utils import UserTokenStructUtils
 from app.middlewares.request_context_middleware import get_request
 from app.models.db.diary import diaries_resolve_rich_text
 from app.models.db.user import User, user_proto
-from app.models.proto.diary_pb2 import (
-    ComposePage,
-    DetailsPage,
-    IndexPage,
-    UserCommentsPage,
-)
-from app.models.proto.shared_pb2 import LonLat
 from app.models.types import DiaryId, LocaleCode, UserId
 from app.queries.diary_comment_query import DiaryCommentQuery
 from app.queries.diary_query import DiaryQuery
@@ -69,8 +69,11 @@ async def details(
 
     profile = diary['user']  # type: ignore
 
+    page = DetailsPage()
+    _build_entry(page.entry, diary)
+
     return await render_proto_page(
-        DetailsPage(entry=_build_entry(diary)),
+        page,
         title_prefix=(
             f'{t("diary_entries.index.user_title", user=profile["display_name"])}'
             f' | {diary["title"]}'

--- a/app/exceptions/image_mixin.py
+++ b/app/exceptions/image_mixin.py
@@ -10,6 +10,12 @@ class ImageExceptionsMixin:
     def image_too_big(self):
         raise APIError(status.HTTP_413_CONTENT_TOO_LARGE, detail='Image is too large')
 
+    def image_not_readable(self):
+        raise APIError(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail='Image is not readable',
+        )
+
     def image_inappropriate(self):
         raise APIError(
             status.HTTP_422_UNPROCESSABLE_CONTENT,

--- a/app/lib/changeset_bounds.py
+++ b/app/lib/changeset_bounds.py
@@ -1,3 +1,5 @@
+from typing import TypeAlias
+
 import cython
 import numpy as np
 from numpy.typing import NDArray
@@ -16,7 +18,7 @@ from app.config import (
     CHANGESET_NEW_BBOX_MIN_RATIO,
 )
 
-type _BBox = list[float]
+_BBox: TypeAlias = list[float]  # noqa: UP040
 
 _FIXED_K_MAX_CANDIDATE_EDGES = 5_000_000
 

--- a/app/lib/compressible_geometry.py
+++ b/app/lib/compressible_geometry.py
@@ -66,21 +66,21 @@ _BBOX_STRUCT = struct.Struct('<BIII10Q')
 
 def point_to_compressible_wkb(lon: float, lat: float):
     """Convert a coordinate pair to a compressible WKB hex format."""
-    lon = _compressible_float(lon)
-    lat = _compressible_float(lat)
+    lon_bits = _compressible_float(lon)
+    lat_bits = _compressible_float(lat)
 
     # (byte order 1 = little endian + geometry type 1 = Point)
-    return _POINT_STRUCT.pack(1, 1, lon, lat)
+    return _POINT_STRUCT.pack(1, 1, lon_bits, lat_bits)
 
 
 def bbox_to_compressible_wkb(
     minlon: float, minlat: float, maxlon: float, maxlat: float
 ):
     """Convert a bounding box to a compressible WKB hex format."""
-    minlon = _compressible_float(minlon)
-    minlat = _compressible_float(minlat)
-    maxlon = _compressible_float(maxlon)
-    maxlat = _compressible_float(maxlat)
+    minlon_bits = _compressible_float(minlon)
+    minlat_bits = _compressible_float(minlat)
+    maxlon_bits = _compressible_float(maxlon)
+    maxlat_bits = _compressible_float(maxlat)
 
     # (byte order 1 = little endian + geometry type 3 = Polygon + 1 ring + 5 points)
     return _BBOX_STRUCT.pack(
@@ -88,14 +88,14 @@ def bbox_to_compressible_wkb(
         3,
         1,
         5,
-        maxlon,
-        minlat,
-        maxlon,
-        maxlat,
-        minlon,
-        maxlat,
-        minlon,
-        minlat,
-        maxlon,
-        minlat,
+        maxlon_bits,
+        minlat_bits,
+        maxlon_bits,
+        maxlat_bits,
+        minlon_bits,
+        maxlat_bits,
+        minlon_bits,
+        minlat_bits,
+        maxlon_bits,
+        minlat_bits,
     )

--- a/app/lib/cookie.py
+++ b/app/lib/cookie.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 from http.cookies import SimpleCookie
-from typing import Literal
+from typing import Literal, TypeAlias
 
 import cython
 from connectrpc.request import RequestContext
@@ -9,8 +9,8 @@ from starlette.responses import Response
 
 from app.config import ENV
 
-type CookieTarget = Response | RequestContext
-type CookieSameSite = Literal['lax', 'strict', 'none']
+CookieTarget: TypeAlias = Response | RequestContext  # noqa: UP040
+CookieSameSite: TypeAlias = Literal['lax', 'strict', 'none']  # noqa: UP040
 
 
 @cython.cfunc

--- a/app/lib/format_style_context.py
+++ b/app/lib/format_style_context.py
@@ -1,12 +1,12 @@
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Literal
+from typing import Literal, TypeAlias
 
 import cython
 
 from app.middlewares.request_context_middleware import get_request
 
-type FormatStyle = Literal['json', 'xml', 'rss', 'gpx']
+FormatStyle: TypeAlias = Literal['json', 'xml', 'rss', 'gpx']  # noqa: UP040
 
 _LEGACY_EXTENSION_FORMATS: dict[str, FormatStyle] = {
     'json': 'json',

--- a/app/lib/image.py
+++ b/app/lib/image.py
@@ -9,9 +9,9 @@ from typing import TYPE_CHECKING, Literal, NamedTuple, overload
 
 import cython
 from blurhash_rs import blurhash_encode
-from PIL import ImageOps, ImageSequence
+from PIL import ImageOps, ImageSequence, UnidentifiedImageError
+from PIL.Image import DecompressionBombError, Resampling
 from PIL.Image import Image as PILImage
-from PIL.Image import Resampling
 from PIL.Image import open as open_image
 from sizestr import sizestr
 
@@ -242,8 +242,13 @@ async def _normalize_image(
     - Megapixels: downscale
     - File size: reduce quality
     """
-    img = open_image(BytesIO(data))
-    ImageOps.exif_transpose(img, in_place=True)
+    try:
+        img = open_image(BytesIO(data))
+        ImageOps.exif_transpose(img, in_place=True)
+    except DecompressionBombError:
+        raise_for.image_too_big()
+    except (UnidentifiedImageError, OSError, SyntaxError):
+        raise_for.image_not_readable()
 
     # normalize shape ratio
     img_width: cython.size_t

--- a/app/lib/image.py
+++ b/app/lib/image.py
@@ -5,7 +5,7 @@ from contextlib import asynccontextmanager
 from functools import partial
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, NamedTuple, overload
+from typing import TYPE_CHECKING, Literal, NamedTuple, TypeAlias, overload
 
 import cython
 from blurhash_rs import blurhash_encode
@@ -49,7 +49,7 @@ class _Animation(NamedTuple):
     loop: int
 
 
-type UserAvatarType = Literal['gravatar', 'custom'] | None
+UserAvatarType: TypeAlias = Literal['gravatar', 'custom'] | None  # noqa: UP040
 
 DEFAULT_USER_AVATAR_URL = '/static/img/avatar.webp'
 DEFAULT_USER_AVATAR = Path('app' + DEFAULT_USER_AVATAR_URL).read_bytes()

--- a/app/lib/password_hash.py
+++ b/app/lib/password_hash.py
@@ -1,18 +1,18 @@
 from base64 import b64decode, b64encode
 from hashlib import md5, pbkdf2_hmac
 from hmac import compare_digest
-from typing import Literal, NamedTuple
+from typing import Literal, NamedTuple, TypeAlias
 
 import cython
+from app.models.proto.auth_pb2 import TransmitUserPassword
+from app.models.proto.server_pb2 import UserPassword
 from argon2 import PasswordHasher, Type
 from argon2.exceptions import VerifyMismatchError
 
 from app.config import SECRET_32
-from app.models.proto.auth_pb2 import TransmitUserPassword
-from app.models.proto.server_pb2 import UserPassword
 from app.models.types import Password
 
-type PasswordLike = Password | TransmitUserPassword
+PasswordLike: TypeAlias = Password | TransmitUserPassword  # noqa: UP040
 
 
 class VerifyResult(NamedTuple):

--- a/app/lib/rich_text.py
+++ b/app/lib/rich_text.py
@@ -4,7 +4,7 @@ from asyncio import TaskGroup
 from collections.abc import Collection, Generator, Iterable, Mapping, Sequence
 from html import escape
 from pathlib import Path
-from typing import Any, Literal, LiteralString, cast
+from typing import Any, Literal, LiteralString, TypeAlias, cast
 from urllib.parse import urlsplit, urlunsplit
 
 import cython
@@ -24,7 +24,7 @@ from app.models.types import ImageProxyId
 from app.services.cache_service import CacheContext, CacheService
 from app.services.image_proxy_service import ImageProxyService
 
-type TextFormat = Literal['html', 'markdown', 'plain']
+TextFormat: TypeAlias = Literal['html', 'markdown', 'plain']  # noqa: UP040
 
 
 async def process_rich_text_markdown(text: str):

--- a/app/lib/standard_pagination.py
+++ b/app/lib/standard_pagination.py
@@ -9,11 +9,16 @@ from typing import (
     Literal,
     LiteralString,
     NamedTuple,
+    TypeAlias,
     TypeVar,
     assert_never,
 )
 
 import cython
+from app.models.proto.shared_pb2 import (
+    StandardPaginationRequest,
+    StandardPaginationState,
+)
 from fastapi import Body
 from protovalidate import collect_violations
 from psycopg import AsyncConnection
@@ -28,10 +33,6 @@ from app.config import (
 )
 from app.db import db
 from app.lib.render_response import render_response
-from app.models.proto.shared_pb2 import (
-    StandardPaginationRequest,
-    StandardPaginationState,
-)
 
 
 class _SpCursorCodec(NamedTuple):
@@ -49,13 +50,13 @@ class _StandardPaginationQueryPlan(NamedTuple):
     anchor_op: Literal['<', '>'] | None = None
 
 
-type StandardPaginationRequestLike = bytes | StandardPaginationRequest
-type StandardPaginationRequestBody = Annotated[
+StandardPaginationRequestLike: TypeAlias = bytes | StandardPaginationRequest  # noqa: UP040
+StandardPaginationRequestBody: TypeAlias = Annotated[  # noqa: UP040
     bytes, Body(media_type='application/x-protobuf')
 ]
 
-type _OrderDir = Literal['asc', 'desc']
-type _CursorKind = Literal['id', 'datetime', 'text']
+_OrderDir: TypeAlias = Literal['asc', 'desc']  # noqa: UP040
+_CursorKind: TypeAlias = Literal['id', 'datetime', 'text']  # noqa: UP040
 
 _EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
 

--- a/app/lib/webauthn.py
+++ b/app/lib/webauthn.py
@@ -1,12 +1,13 @@
 from hashlib import sha256
 from pathlib import Path
-from typing import Literal, NamedTuple, NotRequired, TypedDict
+from typing import Literal, NamedTuple, NotRequired, TypeAlias, TypedDict
 from urllib.parse import urlsplit
 from uuid import UUID
 
 import cbor2
 import cython
 import orjson
+from app.models.proto.auth_pb2 import PasskeyAssertion
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric.ec import (
@@ -20,9 +21,8 @@ from starlette.exceptions import HTTPException
 
 from app.config import APP_URL
 from app.models.db.user_passkey import AAGUIDInfo, UserPasskey
-from app.models.proto.auth_pb2 import PasskeyAssertion
 
-type _ClientDataType = Literal['webauthn.create', 'webauthn.get']
+_ClientDataType: TypeAlias = Literal['webauthn.create', 'webauthn.get']  # noqa: UP040
 
 
 class _ClientData(TypedDict):

--- a/app/models/scope.py
+++ b/app/models/scope.py
@@ -1,9 +1,9 @@
 from collections.abc import Iterable
-from typing import Literal, get_args
+from typing import Literal, TypeAlias, get_args
 
 from app.models.proto.shared_pb2 import Scope as ProtoScope
 
-type PublicScope = Literal[
+PublicScope: TypeAlias = Literal[  # noqa: UP040
     'read_prefs',
     'write_prefs',
     'write_api',
@@ -12,9 +12,9 @@ type PublicScope = Literal[
     'write_notes',
 ]
 
-PUBLIC_SCOPES = frozenset[PublicScope](get_args(PublicScope.__value__))
+PUBLIC_SCOPES = frozenset[PublicScope](get_args(PublicScope))
 
-type Scope = (
+Scope: TypeAlias = (  # noqa: UP040
     PublicScope
     | Literal[
         # additional scopes

--- a/app/queries/graphhopper_query.py
+++ b/app/queries/graphhopper_query.py
@@ -1,5 +1,6 @@
-from typing import Literal, cast, get_args
+from typing import Literal, TypeAlias, cast, get_args
 
+from app.models.proto.shared_pb2 import RoutingResult
 from fastapi import HTTPException
 from shapely import Point, get_coordinates
 from starlette import status
@@ -8,12 +9,9 @@ from app.config import GRAPHHOPPER_API_KEY, GRAPHHOPPER_URL
 from app.lib.http_client import HTTP
 from app.lib.translation import primary_translation_locale
 from app.models.graphhopper import GraphHopperResponse
-from app.models.proto.shared_pb2 import RoutingResult
 
-type GraphHopperProfile = Literal['car', 'bike', 'foot']
-GraphHopperProfiles = frozenset[GraphHopperProfile](
-    get_args(GraphHopperProfile.__value__)
-)
+GraphHopperProfile: TypeAlias = Literal['car', 'bike', 'foot']  # noqa: UP040
+GraphHopperProfiles = frozenset[GraphHopperProfile](get_args(GraphHopperProfile))
 
 
 class GraphHopperQuery:

--- a/app/queries/osrm_query.py
+++ b/app/queries/osrm_query.py
@@ -1,8 +1,9 @@
 import logging
 from functools import cache
-from typing import Literal, cast, get_args
+from typing import Literal, TypeAlias, cast, get_args
 
 import cython
+from app.models.proto.shared_pb2 import RoutingResult
 from fastapi import HTTPException
 from polyline_rs import decode_latlon, encode_latlon
 from shapely import Point, get_coordinates
@@ -11,10 +12,9 @@ from app.config import OSRM_URL
 from app.lib.http_client import HTTP
 from app.lib.translation import t
 from app.models.osrm import OSRMResponse, OSRMStep
-from app.models.proto.shared_pb2 import RoutingResult
 
-type OSRMProfile = Literal['car', 'bike', 'foot']
-OSRMProfiles = frozenset[OSRMProfile](get_args(OSRMProfile.__value__))
+OSRMProfile: TypeAlias = Literal['car', 'bike', 'foot']  # noqa: UP040
+OSRMProfiles = frozenset[OSRMProfile](get_args(OSRMProfile))
 
 
 class OSRMQuery:

--- a/app/queries/valhalla_query.py
+++ b/app/queries/valhalla_query.py
@@ -1,17 +1,17 @@
-from typing import Literal, cast, get_args
+from typing import Literal, TypeAlias, cast, get_args
 
 import numpy as np
+from app.models.proto.shared_pb2 import RoutingResult
 from fastapi import HTTPException
 from shapely import Point, get_coordinates
 
 from app.config import VALHALLA_URL
 from app.lib.http_client import HTTP
 from app.lib.translation import primary_translation_locale
-from app.models.proto.shared_pb2 import RoutingResult
 from app.models.valhalla import ValhallaResponse
 
-type ValhallaProfile = Literal['auto', 'bicycle', 'pedestrian']
-ValhallaProfiles = frozenset[ValhallaProfile](get_args(ValhallaProfile.__value__))
+ValhallaProfile: TypeAlias = Literal['auto', 'bicycle', 'pedestrian']  # noqa: UP040
+ValhallaProfiles = frozenset[ValhallaProfile](get_args(ValhallaProfile))
 
 
 class ValhallaQuery:

--- a/app/responses/precompressed_static_files.py
+++ b/app/responses/precompressed_static_files.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 from mimetypes import guess_type
 from os import PathLike
 from os import stat_result as StatResultType  # noqa: N812
-from typing import override
+from typing import TypeAlias, override
 
 import cython
 from fastapi import HTTPException
@@ -17,8 +17,8 @@ from starlette_compress._utils import parse_accept_encoding
 
 from app.config import ENV, STATIC_PRECOMPRESSED_CACHE_MAX_ENTRIES
 
-type _CacheKey = tuple[str, str | None]
-type _CacheValue = tuple[str, StatResultType, str | None]
+_CacheKey: TypeAlias = tuple[str, str | None]  # noqa: UP040
+_CacheValue: TypeAlias = tuple[str, StatResultType, str | None]  # noqa: UP040
 
 
 class PrecompressedStaticFiles(StaticFiles):

--- a/app/services/optimistic_diff/prepare.py
+++ b/app/services/optimistic_diff/prepare.py
@@ -2,10 +2,11 @@ import logging
 from asyncio import TaskGroup
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Final, Literal, assert_never
+from typing import Final, Literal, TypeAlias, assert_never
 
 import cython
 import numpy as np
+from app.models.proto.shared_types import ElementType
 from psycopg import AsyncConnection
 from shapely import Point, bounds, box
 
@@ -21,14 +22,13 @@ from app.models.element import (
     TYPED_ELEMENT_ID_RELATION_MIN,
     TypedElementId,
 )
-from app.models.proto.shared_types import ElementType
 from app.models.types import SequenceId
 from app.queries.changeset_bounds_query import ChangesetBoundsQuery
 from app.queries.changeset_query import ChangesetQuery
 from app.queries.element_query import ElementQuery
 from speedup import element_id, element_type, split_typed_element_id
 
-type OSMChangeAction = Literal['create', 'modify', 'delete']
+OSMChangeAction: TypeAlias = Literal['create', 'modify', 'delete']  # noqa: UP040
 
 
 @dataclass(kw_only=True, slots=True)

--- a/app/validators/display_name.py
+++ b/app/validators/display_name.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, TypeAlias
 
 from annotated_types import MaxLen, MinLen
 
@@ -9,12 +9,12 @@ from app.validators.url import UrlSafeValidator
 from app.validators.whitespace import BoundaryWhitespaceValidator
 from app.validators.xml import XMLSafeValidator
 
-type DisplayNameNormalizing = Annotated[
+DisplayNameNormalizing: TypeAlias = Annotated[  # noqa: UP040
     DisplayName,
     UnicodeValidator,
 ]
 
-type DisplayNameValidating = Annotated[
+DisplayNameValidating: TypeAlias = Annotated[  # noqa: UP040
     DisplayNameNormalizing,
     MinLen(3),
     MaxLen(DISPLAY_NAME_MAX_LENGTH),

--- a/app/validators/email.py
+++ b/app/validators/email.py
@@ -1,6 +1,6 @@
 import logging
 from asyncio import Task, TaskGroup
-from typing import Annotated
+from typing import Annotated, TypeAlias
 
 from annotated_types import MaxLen, MinLen
 from dns.asyncresolver import Resolver
@@ -137,7 +137,7 @@ EmailValidator = BeforeValidator(validate_email)
 
 # ideally, should be defined in app/models/types.py
 # but this causes circular import
-type EmailValidating = Annotated[
+EmailValidating: TypeAlias = Annotated[  # noqa: UP040
     Email,
     MinLen(EMAIL_MIN_LENGTH),
     MaxLen(EMAIL_MAX_LENGTH),

--- a/app/validators/tags.py
+++ b/app/validators/tags.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, TypeAlias
 
 import cython
 from annotated_types import MaxLen, MinLen
@@ -34,7 +34,7 @@ def _validate_tags(
     return v
 
 
-type TagsValidating = Annotated[
+TagsValidating: TypeAlias = Annotated[  # noqa: UP040
     dict[
         Annotated[
             str,

--- a/app/views/lib/image-upload.ts
+++ b/app/views/lib/image-upload.ts
@@ -1,0 +1,17 @@
+import { t } from "i18next"
+
+const IMAGE_UPLOAD_MAX_MB = 10
+const IMAGE_UPLOAD_MAX_BYTES = IMAGE_UPLOAD_MAX_MB * 1024 * 1024
+
+export const imageFormDataBytes = async (formData: FormData, name: string) => {
+  const file = formData.get(name)
+  if (!(file instanceof Blob)) return new Uint8Array()
+
+  if (file.size > IMAGE_UPLOAD_MAX_BYTES) {
+    throw new Error(
+      t("validation.image_file_too_big", { size: IMAGE_UPLOAD_MAX_MB }),
+    )
+  }
+
+  return new Uint8Array(await file.arrayBuffer())
+}

--- a/app/views/settings/applications/edit.tsx
+++ b/app/views/settings/applications/edit.tsx
@@ -1,10 +1,11 @@
 import { OAUTH_APP_NAME_MAX_LENGTH } from "@lib/config"
 import { CopyButton } from "@lib/copy-group"
+import { imageFormDataBytes } from "@lib/image-upload"
 import { mountProtoPage } from "@lib/proto-page"
 import { EditPageSchema, Service } from "@lib/proto/settings_applications_pb"
 import { Scope } from "@lib/proto/shared_pb"
 import { formDataScopes, SCOPE_LABEL, SCOPES_NO_WEB_USER } from "@lib/scope"
-import { formDataBytes, StandardForm } from "@lib/standard-form"
+import { StandardForm } from "@lib/standard-form"
 import { throwAbortError } from "@lib/utils"
 import { useSignal } from "@preact/signals"
 import { t } from "i18next"
@@ -249,7 +250,10 @@ mountProtoPage(
                         method={Service.method.updateAvatar}
                         buildRequest={async ({ formData }) => ({
                           id,
-                          avatarFile: await formDataBytes(formData, "avatar_file"),
+                          avatarFile: await imageFormDataBytes(
+                            formData,
+                            "avatar_file",
+                          ),
                         })}
                         onSuccess={(resp) => (avatarUrl.value = resp.avatarUrl)}
                       >

--- a/app/views/user/profile/profile.tsx
+++ b/app/views/user/profile/profile.tsx
@@ -3,11 +3,12 @@ import { config, USER_RECENT_ACTIVITY_ENTRIES } from "@lib/config"
 import { Time } from "@lib/datetime-inputs"
 import { FollowToggleForm } from "@lib/follow-toggle-form"
 import { tRich } from "@lib/i18n"
+import { imageFormDataBytes } from "@lib/image-upload"
 import { mountProtoPage } from "@lib/proto-page"
 import { PageSchema, type PageValid } from "@lib/proto/profile_pb"
 import { Service, UpdateAvatarRequest_Preset } from "@lib/proto/settings_pb"
 import { ReportButton } from "@lib/report"
-import { formDataBytes, StandardForm } from "@lib/standard-form"
+import { StandardForm } from "@lib/standard-form"
 import type { Signal } from "@preact/signals"
 import { useSignal } from "@preact/signals"
 import { toSentenceCase } from "@std/text/unstable-to-sentence-case"
@@ -167,7 +168,7 @@ const BackgroundForm = ({
       class="background-form"
       method={Service.method.updateBackground}
       buildRequest={async ({ formData }) => ({
-        backgroundFile: await formDataBytes(formData, "background_file"),
+        backgroundFile: await imageFormDataBytes(formData, "background_file"),
       })}
       onSuccess={(resp) => (backgroundUrl.value = resp.backgroundUrl)}
     >
@@ -247,7 +248,7 @@ const AvatarForm = ({
       class="avatar-form"
       method={Service.method.updateAvatar}
       buildRequest={async ({ formData }) => {
-        const avatarFile = await formDataBytes(formData, "avatar_file")
+        const avatarFile = await imageFormDataBytes(formData, "avatar_file")
         if (avatarFile.length) {
           return {
             avatar: {

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -579,6 +579,7 @@ validation:
   user_not_found: User {{user}} not found
   you_can_send_message_to_at_most_count_recipients: "You can send a message to at most {{count}} recipients"
   you_can_add_at_most_count_tags: "You can add at most {{count}} tags"
+  image_file_too_big: "Image file is too large. Choose an image under {{size}} MiB."
   incomplete_location_information: Incomplete location information
 action:
   go_back: Go back

--- a/scripts/replication_download.py
+++ b/scripts/replication_download.py
@@ -9,12 +9,13 @@ from dataclasses import asdict, dataclass, replace
 from datetime import UTC, datetime, timedelta
 from itertools import pairwise
 from time import monotonic
-from typing import Literal, get_args
+from typing import Literal, TypeAlias, get_args
 
 import cython
 import orjson
 import pyarrow as pa
 import pyarrow.parquet as pq
+from app.models.proto.shared_types import ElementType
 from sentry_sdk import set_context, set_tag, start_transaction
 from starlette import status
 
@@ -26,17 +27,16 @@ from app.lib.retry import retry
 from app.lib.sentry import SENTRY_REPLICATION_MONITOR, SENTRY_REPLICATION_MONITOR_SLUG
 from app.lib.xmltodict import XMLToDict
 from app.models.element import TypedElementId
-from app.models.proto.shared_types import ElementType
 from speedup import typed_element_id
 
-type _Dataset = Literal['replication', 'redaction-period', 'cc-by-sa']
-type _Frequency = Literal['minute', 'hour', 'day']
+_Dataset: TypeAlias = Literal['replication', 'redaction-period', 'cc-by-sa']  # noqa: UP040
+_Frequency: TypeAlias = Literal['minute', 'hour', 'day']  # noqa: UP040
 
 _APP_STATE_PATH = REPLICATION_DIR.joinpath('state.json')
 _LOCK_PATH = REPLICATION_DIR.joinpath('.lock')
 
 _NEXT_DATASET: dict[_Dataset, _Dataset] = {
-    from_: to for to, from_ in pairwise(get_args(_Dataset.__value__))
+    from_: to for to, from_ in pairwise(get_args(_Dataset))
 }
 
 _FREQUENCY_TIMEDELTA: dict[_Frequency, timedelta] = {

--- a/scripts/replication_generate.py
+++ b/scripts/replication_generate.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime, timedelta
 from functools import cache
 from pathlib import Path
 from shutil import copyfile
-from typing import Literal, TypedDict, get_args
+from typing import Literal, TypeAlias, TypedDict, get_args
 
 import cython
 from psycopg import AsyncConnection
@@ -31,7 +31,7 @@ class _State(TypedDict):
     timestamp: datetime
 
 
-type _TimeSpan = Literal['minute', 'hour', 'day']
+_TimeSpan: TypeAlias = Literal['minute', 'hour', 'day']  # noqa: UP040
 
 _TIMESPAN_DELTA: dict[_TimeSpan, timedelta] = {
     'minute': timedelta(minutes=1),
@@ -411,7 +411,7 @@ def main():
     parser = ArgumentParser(description='Generate replication diffs continuously')
     parser.add_argument(
         'timespan',
-        choices=get_args(_TimeSpan.__value__),
+        choices=get_args(_TimeSpan),
         help='Timespan for replication diffs',
     )
     parser.add_argument(

--- a/tests/lib/test_image.py
+++ b/tests/lib/test_image.py
@@ -6,7 +6,9 @@ from PIL import Image as PILImage
 from starlette import status
 
 from app.config import IMAGE_MAX_FRAMES
+from app.exceptions import Exceptions
 from app.exceptions.api_error import APIError
+from app.lib.exceptions_context import exceptions_context
 from app.lib.image import Image
 
 
@@ -47,7 +49,7 @@ async def test_normalize_avatar_preserves_animation(animation: bytes):
 
 
 async def test_normalize_avatar_rejects_unreadable_image():
-    with pytest.raises(APIError) as exc_info:
+    with pytest.raises(APIError) as exc_info, exceptions_context(Exceptions()):
         await Image.normalize_avatar(b'not an image')
 
     assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
@@ -60,7 +62,7 @@ async def test_normalize_avatar_rejects_decompression_bomb(monkeypatch):
 
     monkeypatch.setattr('app.lib.image.open_image', _raise_decompression_bomb)
 
-    with pytest.raises(APIError) as exc_info:
+    with pytest.raises(APIError) as exc_info, exceptions_context(Exceptions()):
         await Image.normalize_avatar(b'fake image')
 
     assert exc_info.value.status_code == status.HTTP_413_CONTENT_TOO_LARGE

--- a/tests/lib/test_image.py
+++ b/tests/lib/test_image.py
@@ -3,8 +3,10 @@ from pathlib import Path
 
 import pytest
 from PIL import Image as PILImage
+from starlette import status
 
 from app.config import IMAGE_MAX_FRAMES
+from app.exceptions.api_error import APIError
 from app.lib.image import Image
 
 
@@ -42,3 +44,24 @@ async def test_normalize_avatar_preserves_animation(animation: bytes):
     assert len(normalized[0]) < len(animation)
     assert result.is_animated  # type: ignore
     assert 1 < result.n_frames <= IMAGE_MAX_FRAMES  # type: ignore
+
+
+async def test_normalize_avatar_rejects_unreadable_image():
+    with pytest.raises(APIError) as exc_info:
+        await Image.normalize_avatar(b'not an image')
+
+    assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert exc_info.value.detail == 'Image is not readable'
+
+
+async def test_normalize_avatar_rejects_decompression_bomb(monkeypatch):
+    def _raise_decompression_bomb(_):
+        raise PILImage.DecompressionBombError('image is too large')
+
+    monkeypatch.setattr('app.lib.image.open_image', _raise_decompression_bomb)
+
+    with pytest.raises(APIError) as exc_info:
+        await Image.normalize_avatar(b'fake image')
+
+    assert exc_info.value.status_code == status.HTTP_413_CONTENT_TOO_LARGE
+    assert exc_info.value.detail == 'Image is too large'


### PR DESCRIPTION
Fixes #31\n\n## Summary\n- map Pillow decompression bomb failures to the existing 413 image-too-large API error\n- return a friendly 422 API error for unreadable image payloads\n- reject image uploads over 10 MiB on profile avatar/background and OAuth application avatar forms before RPC submission\n- add a localized frontend validation message and focused image normalization tests for backend error mapping\n- fix the diary details proto builder call that surfaced in CI while running this branch\n\n## Testing\n- PYTHONPATH=. uv run --with ruff ruff check app/lib/image.py app/exceptions/image_mixin.py app/controllers/diary.py tests/lib/test_image.py\n- PYTHONPATH=. uv run --with ruff ruff format --check app/lib/image.py app/exceptions/image_mixin.py tests/lib/test_image.py\n- PYTHONPATH=. uv run python -m py_compile app/lib/image.py app/exceptions/image_mixin.py tests/lib/test_image.py\n- PYTHONPATH=. uv run python -c "import yaml; yaml.safe_load(open('config/locale/extra_en.yaml', encoding='utf-8'))"\n- isolated uv python smoke for unreadable image and DecompressionBombError paths\n\n## Not run\n- Local pytest in this plain shell stops during bootstrap because generated app.models.proto modules are missing without the project Nix/bun setup. GitHub Actions runs the bootstrapped suite.\n- Full frontend typecheck/build is unavailable in this plain shell without the project Nix/bun bootstrap.