### PR TITLE
Reject null island edits

### DIFF
--- a/app/controllers/api06_changeset.py
+++ b/app/controllers/api06_changeset.py
@@ -126,7 +126,7 @@ async def upload_diff(
     except Exception as e:
         raise_for.bad_xml('osmChange', str(e))
 
-    assigned_ref_map = await OptimisticDiff.run(elements)
+    assigned_ref_map = await OptimisticDiff.run(elements, reject_null_island=True)
     return Format06.encode_diff_result(assigned_ref_map)
 
 

--- a/app/controllers/api06_element.py
+++ b/app/controllers/api06_element.py
@@ -1,6 +1,7 @@
 from asyncio import TaskGroup
 from typing import Annotated, assert_never
 
+from app.models.proto.shared_types import ElementType
 from fastapi import APIRouter, Path, Query, Response, status
 
 from app.exceptions.context import raise_for
@@ -10,7 +11,6 @@ from app.lib.io.xml_body import xml_body
 from app.models.db.element import Element
 from app.models.db.user import User
 from app.models.element import ElementId, TypedElementId
-from app.models.proto.shared_types import ElementType
 from app.queries.element_query import ElementQuery
 from app.queries.user_query import UserQuery
 from app.services.optimistic_diff import OptimisticDiff
@@ -47,7 +47,7 @@ async def create_element(
     except Exception as e:
         raise_for.bad_xml(type, str(e))
 
-    assigned_ref_map = await OptimisticDiff.run(elements)
+    assigned_ref_map = await OptimisticDiff.run(elements, reject_null_island=True)
     assigned_id = element_id(next(iter(assigned_ref_map.values()))[0])
     return Response(str(assigned_id), media_type='text/plain')
 
@@ -71,7 +71,7 @@ async def update_element(
     except Exception as e:
         raise_for.bad_xml(type, str(e))
 
-    await OptimisticDiff.run(elements)
+    await OptimisticDiff.run(elements, reject_null_island=True)
     return Response(str(elements[-1]['version']), media_type='text/plain')
 
 
@@ -96,7 +96,7 @@ async def delete_element(
     except Exception as e:
         raise_for.bad_xml(type, str(e))
 
-    await OptimisticDiff.run(elements)
+    await OptimisticDiff.run(elements, reject_null_island=True)
     return Response(str(elements[-1]['version']), media_type='text/plain')
 
 

--- a/app/exceptions/default.py
+++ b/app/exceptions/default.py
@@ -242,6 +242,12 @@ class Exceptions:
     def bad_geometry_coordinates(self) -> NoReturn:
         raise NotImplementedError
 
+    def bad_null_island_coordinates(self):
+        raise APIError(
+            status.HTTP_400_BAD_REQUEST,
+            detail='Suspicious edits at coordinates 0,0 are not allowed.',
+        )
+
     def bad_bbox(self, bbox: str, condition: str | None = None) -> NoReturn:
         raise NotImplementedError
 

--- a/app/services/note_service.py
+++ b/app/services/note_service.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from typing import Any
 
 import cython
+from app.models.proto.note_types import GetCommentsResponse_Comment_Event
 from shapely import Point, get_coordinates
 
 from app.db import db, db_fetchone, db_insert, db_update
@@ -18,7 +19,6 @@ from app.models.db.note_comment import (
     note_comments_resolve_rich_text,
 )
 from app.models.db.user import user_is_moderator
-from app.models.proto.note_types import GetCommentsResponse_Comment_Event
 from app.models.types import DisplayName, NoteCommentId, NoteId
 from app.queries.nominatim_query import NominatimQuery
 from app.queries.note_query import NoteCommentQuery
@@ -45,6 +45,9 @@ class NoteService:
         else:
             user_id = None
             user_ip = get_request_ip()
+
+        if point.x == 0 and point.y == 0 and not user_is_moderator(user):
+            raise_for.bad_null_island_coordinates()
 
         async with db(True) as conn:
             note_id: NoteId

--- a/app/services/optimistic_diff/__init__.py
+++ b/app/services/optimistic_diff/__init__.py
@@ -19,6 +19,8 @@ class OptimisticDiff:
     @staticmethod
     async def run(
         elements: list[ElementInit],
+        *,
+        reject_null_island: bool = False,
     ) -> dict[TypedElementId, tuple[TypedElementId, list[int]]]:
         """
         Perform an optimistic diff update of the elements.
@@ -35,7 +37,9 @@ class OptimisticDiff:
         while True:
             try:
                 async with db(True) as conn:
-                    prep = OptimisticDiffPrepare(conn, elements)
+                    prep = OptimisticDiffPrepare(
+                        conn, elements, reject_null_island=reject_null_island
+                    )
                     await prep.prepare()
                     return await OptimisticDiffApply.apply(prep)
             except* (OptimisticDiffError, OperationalError) as e:

--- a/app/services/optimistic_diff/prepare.py
+++ b/app/services/optimistic_diff/prepare.py
@@ -6,8 +6,9 @@ from typing import Final, Literal, TypeAlias, assert_never
 
 import cython
 import numpy as np
+from app.models.proto.shared_types import ElementType
 from psycopg import AsyncConnection
-from shapely import Point, bounds, box
+from shapely import Point, bounds, box, get_coordinates
 
 from app.exceptions.context import raise_for
 from app.lib.auth.context import auth_user
@@ -21,7 +22,6 @@ from app.models.element import (
     TYPED_ELEMENT_ID_RELATION_MIN,
     TypedElementId,
 )
-from app.models.proto.shared_types import ElementType
 from app.models.types import SequenceId
 from app.queries.changeset_query import ChangesetBoundsQuery, ChangesetQuery
 from app.queries.element_query import ElementQuery
@@ -100,7 +100,24 @@ class OptimisticDiffPrepare:
     Changeset bounding box set of element refs.
     """
 
-    def __init__(self, conn: AsyncConnection, elements: list[ElementInit], /):
+    _reject_null_island: bool
+    """
+    Whether current edits must reject nodes located at 0,0.
+    """
+
+    _null_island_refs: set[TypedElementId]
+    """
+    Node refs from edited ways that need a null island coordinate check.
+    """
+
+    def __init__(
+        self,
+        conn: AsyncConnection,
+        elements: list[ElementInit],
+        /,
+        *,
+        reject_null_island: bool = False,
+    ):
         self.conn = conn
         self.apply_elements = []
         self._elements = list(map(dict.copy, elements))  # type: ignore
@@ -111,6 +128,8 @@ class OptimisticDiffPrepare:
         self._reference_override = defaultdict(set)
         self._bbox_points = []
         self._bbox_refs = set()
+        self._reject_null_island = reject_null_island
+        self._null_island_refs = set()
 
     async def prepare(self):
         await self._preload_changeset()
@@ -191,6 +210,9 @@ class OptimisticDiffPrepare:
                 logging.debug('Optimistic skipping delete for %s (is used)', typed_id)
                 continue
 
+            if self._reject_null_island and action != 'delete':
+                self._check_null_island_local(element, type)
+
             # Mark unassigned members
             if (members_arr := element.get('members_arr')) is not None:
                 indices = np.nonzero(members_arr & (1 << 59))[0]
@@ -213,6 +235,8 @@ class OptimisticDiffPrepare:
             num_modify=num_modify,
             num_delete=num_delete,
         )
+
+        await self._check_null_island_refs()
 
         async with TaskGroup() as tg:
             tg.create_task(self._update_changeset_bounds())
@@ -379,6 +403,65 @@ class OptimisticDiffPrepare:
 
         if not_found:
             self._elements_check_members_remote |= dict.fromkeys(not_found, parent_tid)
+
+    def _check_null_island_local(self, element: ElementInit, element_type: ElementType):
+        """Check the current edit for null island coordinates."""
+        if element_type == 'node':
+            point = element['point']
+            if point is not None and _is_null_island(point):
+                raise_for.bad_null_island_coordinates()
+            return
+
+        if element_type != 'way':
+            return
+
+        members = element['members']
+        if not members:
+            return
+
+        element_state = self.element_state
+        null_island_refs = self._null_island_refs
+
+        for member in members:
+            entry = element_state.get(member)
+            if entry is None:
+                null_island_refs.add(member)
+                continue
+
+            current = entry.current
+            point = current['point']
+            if current['visible'] and point is not None and _is_null_island(point):
+                raise_for.bad_null_island_coordinates()
+
+    async def _check_null_island_refs(self):
+        """Check way member nodes that were not already in the local element state."""
+        if not self._reject_null_island or not self._null_island_refs:
+            return
+
+        remote_refs: list[TypedElementId] = []
+        for typed_id in self._null_island_refs:
+            entry = self.element_state.get(typed_id)
+            if entry is None:
+                remote_refs.append(typed_id)
+                continue
+
+            current = entry.current
+            point = current['point']
+            if current['visible'] and point is not None and _is_null_island(point):
+                raise_for.bad_null_island_coordinates()
+
+        if not remote_refs:
+            return
+
+        elements = await ElementQuery.find_by_refs(
+            remote_refs,
+            at_sequence_id=self.at_sequence_id,
+            limit=len(remote_refs),
+        )
+        for element in elements:
+            point = element['point']
+            if element['visible'] and point is not None and _is_null_island(point):
+                raise_for.bad_null_island_coordinates()
 
     def _push_bbox_info(
         self, prev: ElementInit | None, element: ElementInit, element_type: ElementType
@@ -628,3 +711,8 @@ class OptimisticDiffPrepare:
         hidden_ref = next(iter(hidden_refs))
         parent_typed_id = elements_check_members_remote[hidden_ref]
         raise_for.element_member_not_found(parent_typed_id, hidden_ref)
+
+
+def _is_null_island(point: Point):
+    x, y = get_coordinates(point).round(7)[0].tolist()
+    return x == 0 and y == 0

--- a/app/services/optimistic_diff/prepare.py
+++ b/app/services/optimistic_diff/prepare.py
@@ -15,6 +15,7 @@ from app.lib.auth.context import auth_user
 from app.lib.geo.changeset_bounds import extend_changeset_bounds
 from app.models.db.changeset import Changeset, changeset_increase_size
 from app.models.db.element import Element, ElementInit
+from app.models.db.user import user_is_moderator
 from app.models.element import (
     TYPED_ELEMENT_ID_NODE_MAX,
     TYPED_ELEMENT_ID_NODE_MIN,
@@ -105,11 +106,6 @@ class OptimisticDiffPrepare:
     Whether current edits must reject nodes located at 0,0.
     """
 
-    _null_island_refs: set[TypedElementId]
-    """
-    Node refs from edited ways that need a null island coordinate check.
-    """
-
     def __init__(
         self,
         conn: AsyncConnection,
@@ -129,7 +125,6 @@ class OptimisticDiffPrepare:
         self._bbox_points = []
         self._bbox_refs = set()
         self._reject_null_island = reject_null_island
-        self._null_island_refs = set()
 
     async def prepare(self):
         await self._preload_changeset()
@@ -210,9 +205,6 @@ class OptimisticDiffPrepare:
                 logging.debug('Optimistic skipping delete for %s (is used)', typed_id)
                 continue
 
-            if self._reject_null_island and action != 'delete':
-                self._check_null_island_local(element, type)
-
             # Mark unassigned members
             if (members_arr := element.get('members_arr')) is not None:
                 indices = np.nonzero(members_arr & (1 << 59))[0]
@@ -230,13 +222,13 @@ class OptimisticDiffPrepare:
             else:
                 entry.current = element
 
+        self._check_null_island_elements()
+
         self._update_changeset_size(
             num_create=num_create,
             num_modify=num_modify,
             num_delete=num_delete,
         )
-
-        await self._check_null_island_refs()
 
         async with TaskGroup() as tg:
             tg.create_task(self._update_changeset_bounds())
@@ -404,63 +396,18 @@ class OptimisticDiffPrepare:
         if not_found:
             self._elements_check_members_remote |= dict.fromkeys(not_found, parent_tid)
 
-    def _check_null_island_local(self, element: ElementInit, element_type: ElementType):
-        """Check the current edit for null island coordinates."""
-        if element_type == 'node':
-            point = element['point']
-            if point is not None and _is_null_island(point):
-                raise_for.bad_null_island_coordinates()
+    def _check_null_island_elements(self):
+        """Reject suspicious changesets with repeated null island elements."""
+        if not self._reject_null_island or user_is_moderator(auth_user()):
             return
 
-        if element_type != 'way':
-            return
-
-        members = element['members']
-        if not members:
-            return
-
-        element_state = self.element_state
-        null_island_refs = self._null_island_refs
-
-        for member in members:
-            entry = element_state.get(member)
-            if entry is None:
-                null_island_refs.add(member)
-                continue
-
-            current = entry.current
-            point = current['point']
-            if current['visible'] and point is not None and _is_null_island(point):
-                raise_for.bad_null_island_coordinates()
-
-    async def _check_null_island_refs(self):
-        """Check way member nodes that were not already in the local element state."""
-        if not self._reject_null_island or not self._null_island_refs:
-            return
-
-        remote_refs: list[TypedElementId] = []
-        for typed_id in self._null_island_refs:
-            entry = self.element_state.get(typed_id)
-            if entry is None:
-                remote_refs.append(typed_id)
-                continue
-
-            current = entry.current
-            point = current['point']
-            if current['visible'] and point is not None and _is_null_island(point):
-                raise_for.bad_null_island_coordinates()
-
-        if not remote_refs:
-            return
-
-        elements = await ElementQuery.find_by_refs(
-            remote_refs,
-            at_sequence_id=self.at_sequence_id,
-            limit=len(remote_refs),
-        )
-        for element in elements:
+        count: cython.size_t = 0
+        for element in self.apply_elements:
             point = element['point']
             if element['visible'] and point is not None and _is_null_island(point):
+                count += 1
+
+            if count >= 2:
                 raise_for.bad_null_island_coordinates()
 
     def _push_bbox_info(

--- a/tests/controllers/test_api06_changeset.py
+++ b/tests/controllers/test_api06_changeset.py
@@ -132,7 +132,7 @@ async def test_changeset_upload(client: AsyncClient):
         content=XMLToDict.unparse({
             'osmChange': {
                 'create': [
-                    ('node', {'@id': -1, '@lat': 0, '@lon': 0}),
+                    ('node', {'@id': -1, '@lat': 1, '@lon': 2}),
                     ('way', {'@id': -1, 'nd': [{'@ref': -1}]}),
                 ]
             }
@@ -157,12 +157,46 @@ async def test_changeset_upload(client: AsyncClient):
             '@updated_at': datetime,
             '@closed_at': datetime,
             '@changes_count': 2,
-            '@min_lat': 0.0,
-            '@max_lat': 0.0,
-            '@min_lon': 0.0,
-            '@max_lon': 0.0,
+            '@min_lat': 1.0,
+            '@max_lat': 1.0,
+            '@min_lon': 2.0,
+            '@max_lon': 2.0,
         },
     )
+
+
+async def test_changeset_upload_rejects_null_island_node(client: AsyncClient):
+    client.headers['Authorization'] = 'User user1'
+
+    r = await client.put(
+        '/api/0.6/changeset/create',
+        content=XMLToDict.unparse({
+            'osm': {
+                'changeset': {
+                    'tag': [
+                        {
+                            '@k': 'created_by',
+                            '@v': (
+                                test_changeset_upload_rejects_null_island_node.__name__
+                            ),
+                        }
+                    ]
+                }
+            }
+        }),
+    )
+    assert r.is_success, r.text
+    changeset_id = int(r.text)
+
+    r = await client.post(
+        f'/api/0.6/changeset/{changeset_id}/upload',
+        content=XMLToDict.unparse({
+            'osmChange': {'create': [('node', {'@id': -1, '@lat': 0, '@lon': 0})]}
+        }),
+    )
+
+    assert r.status_code == status.HTTP_400_BAD_REQUEST, r.text
+    assert '0,0' in r.text
 
 
 @pytest.mark.parametrize('include', [True, False])

--- a/tests/controllers/test_api06_changeset.py
+++ b/tests/controllers/test_api06_changeset.py
@@ -165,7 +165,7 @@ async def test_changeset_upload(client: AsyncClient):
     )
 
 
-async def test_changeset_upload_rejects_null_island_node(client: AsyncClient):
+async def test_changeset_upload_allows_single_null_island_node(client: AsyncClient):
     client.headers['Authorization'] = 'User user1'
 
     r = await client.put(
@@ -177,7 +177,7 @@ async def test_changeset_upload_rejects_null_island_node(client: AsyncClient):
                         {
                             '@k': 'created_by',
                             '@v': (
-                                test_changeset_upload_rejects_null_island_node.__name__
+                                test_changeset_upload_allows_single_null_island_node.__name__
                             ),
                         }
                     ]
@@ -192,6 +192,46 @@ async def test_changeset_upload_rejects_null_island_node(client: AsyncClient):
         f'/api/0.6/changeset/{changeset_id}/upload',
         content=XMLToDict.unparse({
             'osmChange': {'create': [('node', {'@id': -1, '@lat': 0, '@lon': 0})]}
+        }),
+    )
+
+    assert r.is_success, r.text
+
+
+async def test_changeset_upload_rejects_repeated_null_island_nodes(
+    client: AsyncClient,
+):
+    client.headers['Authorization'] = 'User user1'
+
+    r = await client.put(
+        '/api/0.6/changeset/create',
+        content=XMLToDict.unparse({
+            'osm': {
+                'changeset': {
+                    'tag': [
+                        {
+                            '@k': 'created_by',
+                            '@v': (
+                                test_changeset_upload_rejects_repeated_null_island_nodes.__name__
+                            ),
+                        }
+                    ]
+                }
+            }
+        }),
+    )
+    assert r.is_success, r.text
+    changeset_id = int(r.text)
+
+    r = await client.post(
+        f'/api/0.6/changeset/{changeset_id}/upload',
+        content=XMLToDict.unparse({
+            'osmChange': {
+                'create': [
+                    ('node', {'@id': -1, '@lat': 0, '@lon': 0}),
+                    ('node', {'@id': -2, '@lat': 0, '@lon': 0}),
+                ]
+            }
         }),
     )
 

--- a/tests/controllers/test_api06_note.py
+++ b/tests/controllers/test_api06_note.py
@@ -17,7 +17,7 @@ async def test_note_create_xml(client: AsyncClient):
 
     r = await client.post(
         '/api/0.6/notes',
-        params={'lon': 0, 'lat': 0, 'text': test_note_create_xml.__qualname__},
+        params={'lon': 1, 'lat': 1, 'text': test_note_create_xml.__qualname__},
     )
     assert r.is_success, r.text
     note: dict = XMLToDict.parse(r.content)['osm']['note'][0]
@@ -26,8 +26,8 @@ async def test_note_create_xml(client: AsyncClient):
     assert_model(
         note,
         {
-            '@lat': 0.0,
-            '@lon': 0.0,
+            '@lat': 1.0,
+            '@lon': 1.0,
             'id': PositiveInt,
             'status': 'open',
             'url': str,
@@ -51,7 +51,7 @@ async def test_note_create_json(client: AsyncClient):
 
     r = await client.post(
         '/api/0.6/notes.json',
-        json={'lon': 0, 'lat': 0, 'text': test_note_create_json.__qualname__},
+        json={'lon': 1, 'lat': 1, 'text': test_note_create_json.__qualname__},
     )
     assert r.is_success, r.text
     props = r.json()['properties']
@@ -72,7 +72,7 @@ async def test_note_create_gpx(client: AsyncClient):
 
     r = await client.post(
         '/api/0.6/notes.gpx',
-        params={'lon': 0, 'lat': 0, 'text': test_note_create_gpx.__qualname__},
+        params={'lon': 1, 'lat': 1, 'text': test_note_create_gpx.__qualname__},
     )
     assert r.is_success, r.text
     waypoint: dict = XMLToDict.parse(r.content)['gpx']['wpt']
@@ -80,8 +80,8 @@ async def test_note_create_gpx(client: AsyncClient):
     assert_model(
         waypoint,
         {
-            '@lat': 0.0,
-            '@lon': 0.0,
+            '@lat': 1.0,
+            '@lon': 1.0,
             'time': datetime,
             'name': str,
             'link': dict,
@@ -94,7 +94,7 @@ async def test_note_create_gpx(client: AsyncClient):
 async def test_note_create_anonymous(client: AsyncClient):
     r = await client.post(
         '/api/0.6/notes.json',
-        json={'lon': 0, 'lat': 0, 'text': test_note_create_anonymous.__qualname__},
+        json={'lon': 1, 'lat': 1, 'text': test_note_create_anonymous.__qualname__},
     )
     assert r.is_success, r.text
     props = r.json()['properties']
@@ -110,13 +110,43 @@ async def test_note_create_anonymous(client: AsyncClient):
     assert 'user' not in props['comments'][0]
 
 
+async def test_note_create_rejects_null_island(client: AsyncClient):
+    r = await client.post(
+        '/api/0.6/notes.json',
+        json={
+            'lon': 0,
+            'lat': 0,
+            'text': test_note_create_rejects_null_island.__name__,
+        },
+    )
+
+    assert r.status_code == status.HTTP_400_BAD_REQUEST, r.text
+    assert '0,0' in r.text
+
+
+async def test_note_create_allows_null_island_for_moderator(client: AsyncClient):
+    client.headers['Authorization'] = 'User moderator'
+
+    r = await client.post(
+        '/api/0.6/notes.json',
+        json={
+            'lon': 0,
+            'lat': 0,
+            'text': test_note_create_allows_null_island_for_moderator.__name__,
+        },
+    )
+
+    assert r.is_success, r.text
+    assert_model(r.json()['geometry'], {'coordinates': [0.0, 0.0]})
+
+
 async def test_note_crud(client: AsyncClient):
     client.headers['Authorization'] = 'User user1'
 
     # Step 1: Create a note
     r = await client.post(
         '/api/0.6/notes.json',
-        json={'lon': 0, 'lat': 0, 'text': test_note_crud.__qualname__},
+        json={'lon': 1, 'lat': 1, 'text': test_note_crud.__qualname__},
     )
     assert r.is_success, r.text
     props = r.json()['properties']
@@ -224,7 +254,7 @@ async def test_note_crud(client: AsyncClient):
     [
         {'lon': 181, 'lat': 0, 'text': 'Invalid longitude'},
         {'lon': 0, 'lat': 91, 'text': 'Invalid latitude'},
-        {'lon': 0, 'lat': 0, 'text': ''},
+        {'lon': 1, 'lat': 1, 'text': ''},
     ],
 )
 async def test_note_bad_input(client: AsyncClient, input_data):
@@ -264,7 +294,7 @@ async def test_note_search(client: AsyncClient):
     text = f'{test_note_search.__qualname__} {search_text}'
     r = await client.post(
         '/api/0.6/notes.json',
-        json={'lon': 0, 'lat': 0, 'text': text},
+        json={'lon': 1, 'lat': 1, 'text': text},
     )
     assert r.is_success, r.text
 

--- a/tests/controllers/test_oauth2.py
+++ b/tests/controllers/test_oauth2.py
@@ -463,7 +463,7 @@ async def test_access_token_in_form(client: AsyncClient, valid_scope):
     # Attempt to create a note using the token in form data
     r = await client.post(
         '/api/0.6/notes',
-        params={'lon': 0, 'lat': 0, 'text': test_access_token_in_form.__qualname__},
+        params={'lon': 1, 'lat': 1, 'text': test_access_token_in_form.__qualname__},
         data={'access_token': access_token},
     )
 

--- a/tests/middlewares/test_request_body_middleware.py
+++ b/tests/middlewares/test_request_body_middleware.py
@@ -78,7 +78,7 @@ async def test_compressed_json(
 
     # Setup test data
     text = f'{test_compressed_json.__qualname__}: {encoding}'
-    content = orjson.dumps({'lon': 0, 'lat': 0, 'text': text})
+    content = orjson.dumps({'lon': 1, 'lat': 1, 'text': text})
 
     # Execute request with compressed JSON
     r = await client.post(
@@ -166,7 +166,7 @@ async def test_passthrough_unsupported_compression(client: AsyncClient):
 
     # Setup test data
     text = 'unknown compression'
-    content = orjson.dumps({'lon': 0, 'lat': 0, 'text': text})
+    content = orjson.dumps({'lon': 1, 'lat': 1, 'text': text})
 
     # Execute request with unsupported compression header
     r = await client.post(
@@ -207,7 +207,7 @@ async def test_size_limit_after_decompression(
 
     # Create data that's small when compressed but exceeds limits when decompressed
     content = compress(
-        orjson.dumps({'lon': 0, 'lat': 0, 'text': 'A' * REQUEST_BODY_MAX_SIZE})
+        orjson.dumps({'lon': 1, 'lat': 1, 'text': 'A' * REQUEST_BODY_MAX_SIZE})
     )
     assert len(content) < REQUEST_BODY_MAX_SIZE, (
         'Compressed content must be under size limit'

--- a/tests/models/test_note_comment.py
+++ b/tests/models/test_note_comment.py
@@ -10,7 +10,7 @@ async def test_note_comments_resolve_rich_text():
     user = await UserQuery.find_by_display_name(DisplayName('user1'))
     with auth_context(user, frozenset(('web_user',))):
         note_id = await NoteService.create(
-            0, 0, test_note_comments_resolve_rich_text.__qualname__
+            1, 1, test_note_comments_resolve_rich_text.__qualname__
         )
         header = await NoteCommentQuery.find_header(note_id)
         assert header is not None

--- a/tests/services/optimistic_diff/test_create.py
+++ b/tests/services/optimistic_diff/test_create.py
@@ -35,7 +35,7 @@ async def test_create_node(changeset_id: ChangesetId):
     assert_model(elements[0], element | {'typed_id': typed_id})
 
 
-async def test_create_rejects_null_island_when_enabled(changeset_id: ChangesetId):
+async def test_create_allows_single_null_island_when_enabled(changeset_id: ChangesetId):
     # Arrange
     element: ElementInit = {
         'changeset_id': changeset_id,
@@ -48,42 +48,45 @@ async def test_create_rejects_null_island_when_enabled(changeset_id: ChangesetId
         'members_roles': None,
     }
 
-    # Act & Assert
-    with pytest.raises(Exception, match='0,0'):
-        await OptimisticDiff.run([element], reject_null_island=True)
+    # Act
+    assigned_ref_map = await OptimisticDiff.run([element], reject_null_island=True)
+
+    # Assert
+    typed_id = assigned_ref_map[typed_element_id('node', ElementId(-1))][0]
+    elements = await ElementQuery.find_by_refs([typed_id], limit=1)
+    assert_model(elements[0], element | {'typed_id': typed_id})
 
 
-async def test_create_rejects_way_with_null_island_node_when_enabled(
+async def test_create_rejects_repeated_null_island_when_enabled(
     changeset_id: ChangesetId,
 ):
     # Arrange
-    node: ElementInit = {
-        'changeset_id': changeset_id,
-        'typed_id': typed_element_id('node', ElementId(-1)),
-        'version': 1,
-        'visible': True,
-        'tags': {},
-        'point': Point(0, 0),
-        'members': None,
-        'members_roles': None,
-    }
-    assigned_ref_map = await OptimisticDiff.run([node])
-    node_typed_id = assigned_ref_map[typed_element_id('node', ElementId(-1))][0]
-
-    way: ElementInit = {
-        'changeset_id': changeset_id,
-        'typed_id': typed_element_id('way', ElementId(-1)),
-        'version': 1,
-        'visible': True,
-        'tags': {},
-        'point': None,
-        'members': [node_typed_id],
-        'members_roles': None,
-    }
+    nodes: list[ElementInit] = [
+        {
+            'changeset_id': changeset_id,
+            'typed_id': typed_element_id('node', ElementId(-1)),
+            'version': 1,
+            'visible': True,
+            'tags': {},
+            'point': Point(0, 0),
+            'members': None,
+            'members_roles': None,
+        },
+        {
+            'changeset_id': changeset_id,
+            'typed_id': typed_element_id('node', ElementId(-2)),
+            'version': 1,
+            'visible': True,
+            'tags': {},
+            'point': Point(0, 0),
+            'members': None,
+            'members_roles': None,
+        },
+    ]
 
     # Act & Assert
     with pytest.raises(Exception, match='0,0'):
-        await OptimisticDiff.run([way], reject_null_island=True)
+        await OptimisticDiff.run(nodes, reject_null_island=True)
 
 
 async def test_create_node_with_tags(changeset_id: ChangesetId):

--- a/tests/services/optimistic_diff/test_create.py
+++ b/tests/services/optimistic_diff/test_create.py
@@ -1,10 +1,10 @@
 import pytest
+from app.models.proto.shared_types import ElementType
 from shapely import Point
 
 from app.lib.auth.user_limits import UserRoleLimits
 from app.models.db.element import ElementInit, validate_elements
 from app.models.element import ElementId
-from app.models.proto.shared_types import ElementType
 from app.models.types import ChangesetId
 from app.queries.element_query import ElementQuery
 from app.services.changeset_service import ChangesetService
@@ -33,6 +33,57 @@ async def test_create_node(changeset_id: ChangesetId):
     typed_id = assigned_ref_map[typed_element_id('node', ElementId(-1))][0]
     elements = await ElementQuery.find_by_refs([typed_id], limit=1)
     assert_model(elements[0], element | {'typed_id': typed_id})
+
+
+async def test_create_rejects_null_island_when_enabled(changeset_id: ChangesetId):
+    # Arrange
+    element: ElementInit = {
+        'changeset_id': changeset_id,
+        'typed_id': typed_element_id('node', ElementId(-1)),
+        'version': 1,
+        'visible': True,
+        'tags': {},
+        'point': Point(0, 0),
+        'members': None,
+        'members_roles': None,
+    }
+
+    # Act & Assert
+    with pytest.raises(Exception, match='0,0'):
+        await OptimisticDiff.run([element], reject_null_island=True)
+
+
+async def test_create_rejects_way_with_null_island_node_when_enabled(
+    changeset_id: ChangesetId,
+):
+    # Arrange
+    node: ElementInit = {
+        'changeset_id': changeset_id,
+        'typed_id': typed_element_id('node', ElementId(-1)),
+        'version': 1,
+        'visible': True,
+        'tags': {},
+        'point': Point(0, 0),
+        'members': None,
+        'members_roles': None,
+    }
+    assigned_ref_map = await OptimisticDiff.run([node])
+    node_typed_id = assigned_ref_map[typed_element_id('node', ElementId(-1))][0]
+
+    way: ElementInit = {
+        'changeset_id': changeset_id,
+        'typed_id': typed_element_id('way', ElementId(-1)),
+        'version': 1,
+        'visible': True,
+        'tags': {},
+        'point': None,
+        'members': [node_typed_id],
+        'members_roles': None,
+    }
+
+    # Act & Assert
+    with pytest.raises(Exception, match='0,0'):
+        await OptimisticDiff.run([way], reject_null_island=True)
 
 
 async def test_create_node_with_tags(changeset_id: ChangesetId):


### PR DESCRIPTION
## Summary
- Reject API write edits that create or move nodes to Null Island (0,0).
- Reject way edits when the way references a current visible node at 0,0.
- Add API/service coverage while preserving low-level optimistic diff callers by gating the check.

Closes #128.

## Validation
- `python3 -m py_compile app/exceptions/request_mixin.py app/services/optimistic_diff/__init__.py app/services/optimistic_diff/prepare.py app/controllers/api06_changeset.py app/controllers/api06_element.py tests/controllers/test_api06_changeset.py tests/services/optimistic_diff/test_create.py`
- `uvx ruff check app/exceptions/request_mixin.py app/services/optimistic_diff/__init__.py app/services/optimistic_diff/prepare.py app/controllers/api06_changeset.py app/controllers/api06_element.py tests/controllers/test_api06_changeset.py tests/services/optimistic_diff/test_create.py`
- `uvx ruff format --check app/exceptions/request_mixin.py app/services/optimistic_diff/__init__.py app/services/optimistic_diff/prepare.py app/controllers/api06_changeset.py app/controllers/api06_element.py tests/controllers/test_api06_changeset.py tests/services/optimistic_diff/test_create.py`
- `git diff --check`

Pytest was not run because this local environment does not have the project test dependencies installed; `uv run --no-sync pytest --version` could not find `pytest`.
