### PR TITLE
Handle oversized avatar uploads gracefully

### DIFF
--- a/app/exceptions/image_mixin.py
+++ b/app/exceptions/image_mixin.py
@@ -10,6 +10,12 @@ class ImageExceptionsMixin:
     def image_too_big(self):
         raise APIError(status.HTTP_413_CONTENT_TOO_LARGE, detail='Image is too large')
 
+    def image_invalid(self):
+        raise APIError(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail='Image is invalid',
+        )
+
     def image_inappropriate(self):
         raise APIError(
             status.HTTP_422_UNPROCESSABLE_CONTENT,

--- a/app/lib/image.py
+++ b/app/lib/image.py
@@ -9,7 +9,8 @@ from typing import TYPE_CHECKING, Literal, NamedTuple, overload
 
 import cython
 from blurhash_rs import blurhash_encode
-from PIL import ImageOps, ImageSequence
+from PIL import ImageOps, ImageSequence, UnidentifiedImageError
+from PIL.Image import DecompressionBombError, DecompressionBombWarning
 from PIL.Image import Image as PILImage
 from PIL.Image import Resampling
 from PIL.Image import open as open_image
@@ -242,8 +243,16 @@ async def _normalize_image(
     - Megapixels: downscale
     - File size: reduce quality
     """
-    img = open_image(BytesIO(data))
-    ImageOps.exif_transpose(img, in_place=True)
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', DecompressionBombWarning)
+            img = open_image(BytesIO(data))
+            ImageOps.exif_transpose(img, in_place=True)
+            img.load()
+    except (DecompressionBombError, DecompressionBombWarning):
+        raise_for.image_too_big()
+    except (UnidentifiedImageError, OSError, SyntaxError):
+        raise_for.image_invalid()
 
     # normalize shape ratio
     img_width: cython.size_t

--- a/tests/lib/test_image.py
+++ b/tests/lib/test_image.py
@@ -5,6 +5,9 @@ import pytest
 from PIL import Image as PILImage
 
 from app.config import IMAGE_MAX_FRAMES
+from app.exceptions import Exceptions
+from app.exceptions.api_error import APIError
+from app.lib.exceptions_context import exceptions_context
 from app.lib.image import Image
 
 
@@ -42,3 +45,24 @@ async def test_normalize_avatar_preserves_animation(animation: bytes):
     assert len(normalized[0]) < len(animation)
     assert result.is_animated  # type: ignore
     assert 1 < result.n_frames <= IMAGE_MAX_FRAMES  # type: ignore
+
+
+async def test_normalize_avatar_rejects_decompression_bomb(monkeypatch):
+    image = PILImage.new('RGB', (2, 2))
+    buffer = BytesIO()
+    image.save(buffer, format='PNG')
+    monkeypatch.setattr('PIL.Image.MAX_IMAGE_PIXELS', 1)
+
+    with exceptions_context(Exceptions()), pytest.raises(APIError) as exc_info:
+        await Image.normalize_avatar(buffer.getvalue())
+
+    assert exc_info.value.status_code == 413
+    assert exc_info.value.detail == 'Image is too large'
+
+
+async def test_normalize_avatar_rejects_invalid_image():
+    with exceptions_context(Exceptions()), pytest.raises(APIError) as exc_info:
+        await Image.normalize_avatar(b'not an image')
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == 'Image is invalid'


### PR DESCRIPTION
Fixes openstreetmap-ng/openstreetmap-ng#31

## Summary
- Map Pillow decompression-bomb failures to the existing `Image is too large` 413 response.
- Map unreadable image data to a friendly 422 `Image is invalid` response.
- Add focused backend coverage for oversized and invalid avatar uploads.

## Validation
- `python -m py_compile app/lib/image.py app/exceptions/image_mixin.py tests/lib/test_image.py`

Note: I could not run the full pytest suite locally because the full project environment/dependency stack is not installed on this machine.