### PR TITLE
Add compact Founder badge assets

### DIFF
--- a/resources/founder-badge.svg
+++ b/resources/founder-badge.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">OpenStreetMap-NG Founder badge</title>
+  <desc id="desc">A compact founder badge based on the OpenStreetMap-NG folded map logo with the NG mark, gold recognition ring, and Founder label.</desc>
+  <defs>
+    <linearGradient id="founderGold" x1="88" y1="62" x2="424" y2="450" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fff0b0"/>
+      <stop offset="0.42" stop-color="#d6a938"/>
+      <stop offset="1" stop-color="#8d5d12"/>
+    </linearGradient>
+    <linearGradient id="mapPaper" x1="76" y1="80" x2="428" y2="426" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#def4c4"/>
+      <stop offset="0.48" stop-color="#bce7a6"/>
+      <stop offset="1" stop-color="#8ecf83"/>
+    </linearGradient>
+    <linearGradient id="labelFill" x1="116" y1="358" x2="396" y2="430" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1f6f4e"/>
+      <stop offset="1" stop-color="#123f36"/>
+    </linearGradient>
+    <filter id="badgeShadow" x="-18%" y="-18%" width="136%" height="136%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#17351f" flood-opacity="0.24"/>
+    </filter>
+    <clipPath id="mapClip">
+      <path d="M86 86c54 14 96-16 153-4 59 13 104-19 169-2l27 162-26 180c-65-17-116 16-178 2-56-13-99 15-156 1L50 262z"/>
+    </clipPath>
+  </defs>
+
+  <circle cx="256" cy="256" r="238" fill="url(#founderGold)"/>
+  <circle cx="256" cy="256" r="218" fill="#f8fff3"/>
+  <circle cx="256" cy="256" r="199" fill="none" stroke="#2d5f42" stroke-width="8" opacity="0.22"/>
+
+  <g filter="url(#badgeShadow)">
+    <g clip-path="url(#mapClip)">
+      <path d="M86 86c54 14 96-16 153-4 59 13 104-19 169-2l27 162-26 180c-65-17-116 16-178 2-56-13-99 15-156 1L50 262z" fill="url(#mapPaper)"/>
+      <path d="M64 150c63 19 103-20 169-1 70 20 111-14 175 4" fill="none" stroke="#6baa69" stroke-width="7" stroke-linecap="round" opacity="0.32"/>
+      <path d="M65 266c67-18 109 16 176-3 69-19 109 16 174-4" fill="none" stroke="#4f8b5b" stroke-width="5" stroke-linecap="round" opacity="0.36"/>
+      <path d="M142 90c19 82-9 137 8 218 9 39 8 70-4 119" fill="none" stroke="#77aa6f" stroke-width="5" opacity="0.34"/>
+      <path d="M298 80c-11 62 17 116 9 178-7 67 14 110 27 162" fill="none" stroke="#77aa6f" stroke-width="5" opacity="0.32"/>
+      <path d="M104 128l77 30 39 66 68 18 39 69 74 37" fill="none" stroke="#bd5454" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" opacity="0.68"/>
+      <path d="M68 326c70-50 127-55 171-35 45 21 91 20 174-36" fill="none" stroke="#739ad8" stroke-width="10" stroke-linecap="round" opacity="0.62"/>
+      <path d="M221 82c39 28 79 35 126 12 35-17 59-10 83 8v74c-51-2-83 14-115 36-44 32-84 20-129-13-35-25-71-26-110-2V101c45-10 91-4 145-19z" fill="#e8f8d9" opacity="0.46"/>
+    </g>
+    <path d="M86 86c54 14 96-16 153-4 59 13 104-19 169-2l27 162-26 180c-65-17-116 16-178 2-56-13-99 15-156 1L50 262z" fill="none" stroke="#1b3327" stroke-width="9" stroke-linejoin="round"/>
+  </g>
+
+  <path d="M92 243a164 164 0 0 1 328 0" fill="none" stroke="url(#founderGold)" stroke-width="18" stroke-linecap="round"/>
+  <g font-family="Arial Black, Arial, sans-serif" font-weight="900" text-anchor="middle">
+    <text x="256" y="272" font-size="144" fill="#101714" stroke="#101714" stroke-width="18" stroke-linejoin="round">NG</text>
+    <text x="256" y="272" font-size="144" fill="#ffffff">NG</text>
+  </g>
+
+  <path d="M100 358h312a20 20 0 0 1 20 20v31a20 20 0 0 1-20 20H100a20 20 0 0 1-20-20v-31a20 20 0 0 1 20-20z" fill="url(#labelFill)" stroke="#0f3027" stroke-width="6"/>
+  <text x="256" y="407" font-family="Arial, sans-serif" font-size="44" font-weight="800" letter-spacing="3" fill="#fff2bf" text-anchor="middle">FOUNDER</text>
+
+  <g fill="url(#founderGold)" stroke="#8b5e16" stroke-width="4" stroke-linejoin="round">
+    <path d="M256 36l11 25 27 2-21 18 7 27-24-14-24 14 7-27-21-18 27-2z"/>
+    <path d="M150 63l8 19 21 2-16 14 5 21-18-11-18 11 5-21-16-14 21-2z"/>
+    <path d="M362 63l8 19 21 2-16 14 5 21-18-11-18 11 5-21-16-14 21-2z"/>
+  </g>
+</svg>

--- a/resources/founder-wordmark-dark.svg
+++ b/resources/founder-wordmark-dark.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="320" viewBox="0 0 1024 320" role="img" aria-labelledby="title desc">
+  <title id="title">OpenStreetMap-NG Founder wordmark dark</title>
+  <desc id="desc">A dark-background OpenStreetMap-NG Founder wordmark using the compact founder badge and high-contrast text.</desc>
+  <defs>
+    <linearGradient id="founderGold" x1="52" y1="36" x2="268" y2="284" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fff0b0"/>
+      <stop offset="0.42" stop-color="#d6a938"/>
+      <stop offset="1" stop-color="#8d5d12"/>
+    </linearGradient>
+    <linearGradient id="mapPaper" x1="48" y1="50" x2="274" y2="274" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#def4c4"/>
+      <stop offset="0.48" stop-color="#bce7a6"/>
+      <stop offset="1" stop-color="#8ecf83"/>
+    </linearGradient>
+    <linearGradient id="labelFill" x1="74" y1="224" x2="246" y2="268" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1f6f4e"/>
+      <stop offset="1" stop-color="#123f36"/>
+    </linearGradient>
+    <clipPath id="mapClip">
+      <path d="M62 58c34 9 61-10 97-2 37 8 65-12 106-1l17 102-16 113c-41-11-73 10-112 1-35-8-62 10-98 1L40 170z"/>
+    </clipPath>
+    <filter id="softShadow" x="-18%" y="-18%" width="136%" height="136%">
+      <feDropShadow dx="0" dy="7" stdDeviation="8" flood-color="#000000" flood-opacity="0.34"/>
+    </filter>
+  </defs>
+
+  <rect width="1024" height="320" rx="32" fill="#10241d"/>
+
+  <g filter="url(#softShadow)">
+    <circle cx="160" cy="160" r="139" fill="url(#founderGold)"/>
+    <circle cx="160" cy="160" r="127" fill="#f8fff3"/>
+    <g clip-path="url(#mapClip)">
+      <path d="M62 58c34 9 61-10 97-2 37 8 65-12 106-1l17 102-16 113c-41-11-73 10-112 1-35-8-62 10-98 1L40 170z" fill="url(#mapPaper)"/>
+      <path d="M48 100c40 13 66-13 108-1 44 13 70-9 110 3" fill="none" stroke="#6baa69" stroke-width="5" stroke-linecap="round" opacity="0.32"/>
+      <path d="M48 172c42-11 68 10 111-2 43-12 68 10 109-3" fill="none" stroke="#4f8b5b" stroke-width="4" stroke-linecap="round" opacity="0.36"/>
+      <path d="M94 60c12 51-6 86 5 137 6 24 5 44-3 75" fill="none" stroke="#77aa6f" stroke-width="4" opacity="0.34"/>
+      <path d="M191 54c-7 39 11 73 6 112-4 42 9 69 17 102" fill="none" stroke="#77aa6f" stroke-width="4" opacity="0.32"/>
+      <path d="M73 87l48 19 24 42 43 11 24 43 47 23" fill="none" stroke="#bd5454" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" opacity="0.68"/>
+      <path d="M50 211c44-31 80-34 107-21 29 13 57 13 110-23" fill="none" stroke="#739ad8" stroke-width="7" stroke-linecap="round" opacity="0.62"/>
+    </g>
+    <path d="M62 58c34 9 61-10 97-2 37 8 65-12 106-1l17 102-16 113c-41-11-73 10-112 1-35-8-62 10-98 1L40 170z" fill="none" stroke="#1b3327" stroke-width="6" stroke-linejoin="round"/>
+    <path d="M58 151a102 102 0 0 1 204 0" fill="none" stroke="url(#founderGold)" stroke-width="11" stroke-linecap="round"/>
+    <g font-family="Arial Black, Arial, sans-serif" font-weight="900" text-anchor="middle">
+      <text x="160" y="169" font-size="88" fill="#101714" stroke="#101714" stroke-width="11" stroke-linejoin="round">NG</text>
+      <text x="160" y="169" font-size="88" fill="#ffffff">NG</text>
+    </g>
+    <rect x="70" y="222" width="180" height="45" rx="14" fill="url(#labelFill)" stroke="#0f3027" stroke-width="4"/>
+    <text x="160" y="254" font-family="Arial, sans-serif" font-size="24" font-weight="800" letter-spacing="2" fill="#fff2bf" text-anchor="middle">FOUNDER</text>
+  </g>
+
+  <g font-family="Arial, sans-serif">
+    <text x="320" y="126" font-size="44" font-weight="800" fill="#f1fff5">OpenStreetMap-NG</text>
+    <text x="320" y="198" font-size="72" font-weight="900" fill="#c9edca">Founder</text>
+    <path d="M323 226h430" stroke="url(#founderGold)" stroke-width="8" stroke-linecap="round"/>
+    <text x="320" y="268" font-size="27" font-weight="700" fill="#bbd0c1">Contributor recognition badge</text>
+  </g>
+</svg>

--- a/resources/founder-wordmark.svg
+++ b/resources/founder-wordmark.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="320" viewBox="0 0 1024 320" role="img" aria-labelledby="title desc">
+  <title id="title">OpenStreetMap-NG Founder wordmark</title>
+  <desc id="desc">A light-background wordmark using a compact OpenStreetMap-NG Founder badge next to the OpenStreetMap-NG Founder name.</desc>
+  <defs>
+    <linearGradient id="founderGold" x1="52" y1="36" x2="268" y2="284" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fff0b0"/>
+      <stop offset="0.42" stop-color="#d6a938"/>
+      <stop offset="1" stop-color="#8d5d12"/>
+    </linearGradient>
+    <linearGradient id="mapPaper" x1="48" y1="50" x2="274" y2="274" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#def4c4"/>
+      <stop offset="0.48" stop-color="#bce7a6"/>
+      <stop offset="1" stop-color="#8ecf83"/>
+    </linearGradient>
+    <linearGradient id="labelFill" x1="74" y1="224" x2="246" y2="268" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1f6f4e"/>
+      <stop offset="1" stop-color="#123f36"/>
+    </linearGradient>
+    <clipPath id="mapClip">
+      <path d="M62 58c34 9 61-10 97-2 37 8 65-12 106-1l17 102-16 113c-41-11-73 10-112 1-35-8-62 10-98 1L40 170z"/>
+    </clipPath>
+    <filter id="softShadow" x="-18%" y="-18%" width="136%" height="136%">
+      <feDropShadow dx="0" dy="7" stdDeviation="8" flood-color="#17351f" flood-opacity="0.20"/>
+    </filter>
+  </defs>
+
+  <rect width="1024" height="320" rx="32" fill="#ffffff"/>
+
+  <g filter="url(#softShadow)">
+    <circle cx="160" cy="160" r="139" fill="url(#founderGold)"/>
+    <circle cx="160" cy="160" r="127" fill="#f8fff3"/>
+    <g clip-path="url(#mapClip)">
+      <path d="M62 58c34 9 61-10 97-2 37 8 65-12 106-1l17 102-16 113c-41-11-73 10-112 1-35-8-62 10-98 1L40 170z" fill="url(#mapPaper)"/>
+      <path d="M48 100c40 13 66-13 108-1 44 13 70-9 110 3" fill="none" stroke="#6baa69" stroke-width="5" stroke-linecap="round" opacity="0.32"/>
+      <path d="M48 172c42-11 68 10 111-2 43-12 68 10 109-3" fill="none" stroke="#4f8b5b" stroke-width="4" stroke-linecap="round" opacity="0.36"/>
+      <path d="M94 60c12 51-6 86 5 137 6 24 5 44-3 75" fill="none" stroke="#77aa6f" stroke-width="4" opacity="0.34"/>
+      <path d="M191 54c-7 39 11 73 6 112-4 42 9 69 17 102" fill="none" stroke="#77aa6f" stroke-width="4" opacity="0.32"/>
+      <path d="M73 87l48 19 24 42 43 11 24 43 47 23" fill="none" stroke="#bd5454" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" opacity="0.68"/>
+      <path d="M50 211c44-31 80-34 107-21 29 13 57 13 110-23" fill="none" stroke="#739ad8" stroke-width="7" stroke-linecap="round" opacity="0.62"/>
+    </g>
+    <path d="M62 58c34 9 61-10 97-2 37 8 65-12 106-1l17 102-16 113c-41-11-73 10-112 1-35-8-62 10-98 1L40 170z" fill="none" stroke="#1b3327" stroke-width="6" stroke-linejoin="round"/>
+    <path d="M58 151a102 102 0 0 1 204 0" fill="none" stroke="url(#founderGold)" stroke-width="11" stroke-linecap="round"/>
+    <g font-family="Arial Black, Arial, sans-serif" font-weight="900" text-anchor="middle">
+      <text x="160" y="169" font-size="88" fill="#101714" stroke="#101714" stroke-width="11" stroke-linejoin="round">NG</text>
+      <text x="160" y="169" font-size="88" fill="#ffffff">NG</text>
+    </g>
+    <rect x="70" y="222" width="180" height="45" rx="14" fill="url(#labelFill)" stroke="#0f3027" stroke-width="4"/>
+    <text x="160" y="254" font-family="Arial, sans-serif" font-size="24" font-weight="800" letter-spacing="2" fill="#fff2bf" text-anchor="middle">FOUNDER</text>
+  </g>
+
+  <g font-family="Arial, sans-serif">
+    <text x="320" y="126" font-size="44" font-weight="800" fill="#1d2d24">OpenStreetMap-NG</text>
+    <text x="320" y="198" font-size="72" font-weight="900" fill="#17543d">Founder</text>
+    <path d="M323 226h430" stroke="url(#founderGold)" stroke-width="8" stroke-linecap="round"/>
+    <text x="320" y="268" font-size="27" font-weight="700" fill="#627364">Contributor recognition badge</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add a compact `founder-badge.svg` optimized for profile-badge scale
- add light and dark wordmark variants using the same badge mark
- keep the design based on the existing folded-map + NG visual language, with a gold recognition ring and singular `Founder` wording from the contributor incentives page

This is an alternate direction for #114, focused on small-size readability and profile-badge use.

## Validation
- `python3` XML parse for all three SVGs
- `git diff --cached --check` before commit
- rendered the SVGs with macOS Quick Look to check the badge and wordmark previews