### PR TITLE
Handle unreadable image uploads

### DIFF
--- a/app/exceptions/default.py
+++ b/app/exceptions/default.py
@@ -190,6 +190,12 @@ class Exceptions:
     def image_too_big(self):
         raise APIError(status.HTTP_413_CONTENT_TOO_LARGE, detail='Image is too large')
 
+    def image_not_readable(self):
+        raise APIError(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail='Image file is not readable',
+        )
+
     def image_inappropriate(self):
         raise APIError(
             status.HTTP_422_UNPROCESSABLE_CONTENT,

--- a/app/lib/io/image.py
+++ b/app/lib/io/image.py
@@ -9,9 +9,9 @@ from typing import TYPE_CHECKING, Literal, NamedTuple, TypeAlias, overload
 
 import cython
 from blurhash_rs import blurhash_encode
-from PIL import ImageOps, ImageSequence
+from PIL import ImageOps, ImageSequence, UnidentifiedImageError
+from PIL.Image import DecompressionBombError, Resampling
 from PIL.Image import Image as PILImage
-from PIL.Image import Resampling
 from PIL.Image import open as open_image
 from sizestr import sizestr
 
@@ -242,8 +242,13 @@ async def _normalize_image(
     - Megapixels: downscale
     - File size: reduce quality
     """
-    img = open_image(BytesIO(data))
-    ImageOps.exif_transpose(img, in_place=True)
+    try:
+        img = open_image(BytesIO(data))
+        ImageOps.exif_transpose(img, in_place=True)
+    except DecompressionBombError:
+        raise_for.image_too_big()
+    except (UnidentifiedImageError, OSError, SyntaxError):
+        raise_for.image_not_readable()
 
     # normalize shape ratio
     img_width: cython.size_t

--- a/tests/lib/test_image.py
+++ b/tests/lib/test_image.py
@@ -3,8 +3,12 @@ from pathlib import Path
 
 import pytest
 from PIL import Image as PILImage
+from starlette import status
 
 from app.config import IMAGE_MAX_FRAMES
+from app.exceptions import Exceptions
+from app.exceptions.api_error import APIError
+from app.exceptions.context import exceptions_context
 from app.lib.io.image import Image
 
 
@@ -42,3 +46,23 @@ async def test_normalize_avatar_preserves_animation(animation: bytes):
     assert len(normalized[0]) < len(animation)
     assert result.is_animated  # type: ignore
     assert 1 < result.n_frames <= IMAGE_MAX_FRAMES  # type: ignore
+
+
+async def test_normalize_avatar_rejects_unreadable_image():
+    with exceptions_context(Exceptions()), pytest.raises(APIError) as exc_info:
+        await Image.normalize_avatar(b'not an image')
+
+    assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert exc_info.value.detail == 'Image file is not readable'
+
+
+async def test_normalize_avatar_rejects_decompression_bomb(monkeypatch):
+    buffer = BytesIO()
+    PILImage.new('RGB', (10, 10)).save(buffer, format='PNG')
+    monkeypatch.setattr(PILImage, 'MAX_IMAGE_PIXELS', 1)
+
+    with exceptions_context(Exceptions()), pytest.raises(APIError) as exc_info:
+        await Image.normalize_avatar(buffer.getvalue())
+
+    assert exc_info.value.status_code == status.HTTP_413_CONTENT_TOO_LARGE
+    assert exc_info.value.detail == 'Image is too large'


### PR DESCRIPTION
## What

- Catch Pillow decompression-bomb failures during image normalization and return the existing friendly `413 Image is too large` API error.
- Catch unreadable image decode failures and return a friendly `422 Image file is not readable` API error instead of leaking a decoder exception.
- Add targeted backend coverage for unreadable image data and decompression-bomb handling.

Fixes #31.

## Validation

- `uvx ruff check app/lib/image.py app/exceptions/image_mixin.py tests/lib/test_image.py`
- `uv run pytest --confcutdir=tests/lib tests/lib/test_image.py` (`7 passed`; scoped to avoid the repo-wide `tests/conftest.py` import of Unix-only `time.tzset` on Windows)