### PR TITLE
Hide unsupported PDF and SVG export options

### DIFF
--- a/app/views/index/sidebar/share.tsx
+++ b/app/views/index/sidebar/share.tsx
@@ -29,10 +29,17 @@ import type { SubmitEventHandler } from "preact"
 import { useRef } from "preact/hooks"
 
 const SHARE_FORMATS = [
+  // Canvas export is raster-only; keep PDF/SVG hidden until a true vector
+  // or print export pipeline is available.
+  // TODO: Add PDF/SVG formats after that pipeline exists.
   { mimeType: "image/jpeg", suffix: ".jpg", label: "JPEG" },
   { mimeType: "image/png", suffix: ".png", label: "PNG" },
   { mimeType: "image/webp", suffix: ".webp", label: "WebP" },
 ] as const
+const DEFAULT_SHARE_FORMAT = SHARE_FORMATS[0]
+const getShareFormat = (mimeType: string) =>
+  SHARE_FORMATS.find((format) => format.mimeType === mimeType) ??
+  DEFAULT_SHARE_FORMAT
 
 let urlMarker: Marker | null = null
 
@@ -81,10 +88,10 @@ export const ShareSidebar = ({ close }: { close: () => void }) => {
   const shareBounds = useSignal<LngLatBounds>()
   const shareMarkerLngLat = useSignal<LngLat | null>(null)
 
-  const shareExportFileSuffix = useComputed(
-    () =>
-      SHARE_FORMATS.find((f) => f.mimeType === shareExportFormatStorage.value)!.suffix,
+  const shareExportFormat = useComputed(() =>
+    getShareFormat(shareExportFormatStorage.value),
   )
+  const shareExportFileSuffix = useComputed(() => shareExportFormat.value.suffix)
 
   const shareMapState = useComputed(() => {
     const view = shareView.value
@@ -194,7 +201,7 @@ export const ShareSidebar = ({ close }: { close: () => void }) => {
         : null
 
       const blob = await exportMapImage(
-        shareExportFormatStorage.value,
+        shareExportFormat.value.mimeType,
         map,
         filterBounds,
         getMarkerLngLat(),
@@ -295,7 +302,7 @@ export const ShareSidebar = ({ close }: { close: () => void }) => {
           {t("action.save_as")}
           <select
             class="form-select format-select mt-2"
-            value={shareExportFormatStorage.value}
+            value={shareExportFormat.value.mimeType}
             onChange={(e) => (shareExportFormatStorage.value = e.currentTarget.value)}
           >
             {SHARE_FORMATS.map(({ mimeType, label }) => (


### PR DESCRIPTION
Fixes #36

## Summary
- Keep the export sidebar format list limited to raster formats supported by the current canvas export path.
- Add TODO comments for future real PDF/SVG support via a vector or print export pipeline.
- Fall back to a supported raster format when an old unsupported export MIME type is still stored locally.

## Testing
- `bun install --frozen-lockfile --ignore-scripts`
- `git diff --check`
- Attempted `./node_modules/.bin/vite build`; it fails in this plain shell because generated `app/views/lib/proto/*_pb` modules are missing. The repo docs indicate these are generated by the Nix-shell `proto-pipeline`.

No external services or live OpenStreetMap systems were tested.
