### PR TITLE
Validate oversized image uploads before submit

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Run tests
         run: |
           if [[ "${{ matrix.implementation }}" == "cython" ]]; then
-            nix-shell --pure --run 'python -m pytest --verbose --no-header --randomly-seed="$EPOCHSECONDS" --extended'
+            nix-shell --pure --run "python -c 'import os, pytest; os._exit(pytest.main([\"--verbose\", \"--no-header\", \"--randomly-seed=$EPOCHSECONDS\", \"--extended\"]))'"
           else
             nix-shell --pure --run "run-tests --extended --term"
           fi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,4 +36,8 @@ jobs:
 
       - name: Run tests
         run: |
-          nix-shell --pure --run "run-tests --extended --term"
+          if [[ "${{ matrix.implementation }}" == "cython" ]]; then
+            nix-shell --pure --run 'python -m pytest --verbose --no-header --randomly-seed="$EPOCHSECONDS" --extended'
+          else
+            nix-shell --pure --run "run-tests --extended --term"
+          fi

--- a/app/lib/auth/password.py
+++ b/app/lib/auth/password.py
@@ -4,12 +4,12 @@ from hmac import compare_digest
 from typing import Literal, NamedTuple, TypeAlias
 
 import cython
+from app.models.proto.auth_pb2 import TransmitUserPassword
+from app.models.proto.server_pb2 import UserPassword
 from argon2 import PasswordHasher, Type
 from argon2.exceptions import VerifyMismatchError
 
 from app.config import SECRET_32
-from app.models.proto.auth_pb2 import TransmitUserPassword
-from app.models.proto.server_pb2 import UserPassword
 from app.models.types import Password
 
 PasswordLike: TypeAlias = Password | TransmitUserPassword

--- a/app/lib/auth/webauthn.py
+++ b/app/lib/auth/webauthn.py
@@ -7,6 +7,7 @@ from uuid import UUID
 import cbor2
 import cython
 import orjson
+from app.models.proto.auth_pb2 import PasskeyAssertion
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric.ec import (
@@ -20,7 +21,6 @@ from starlette.exceptions import HTTPException
 
 from app.config import APP_URL
 from app.models.db.user_passkey import AAGUIDInfo, UserPasskey
-from app.models.proto.auth_pb2 import PasskeyAssertion
 
 _ClientDataType: TypeAlias = Literal['webauthn.create', 'webauthn.get']
 

--- a/app/lib/standard/pagination.py
+++ b/app/lib/standard/pagination.py
@@ -14,6 +14,10 @@ from typing import (
 )
 
 import cython
+from app.models.proto.shared_pb2 import (
+    StandardPaginationRequest,
+    StandardPaginationState,
+)
 from fastapi import Body
 from protovalidate import collect_violations
 from psycopg import AsyncConnection
@@ -28,10 +32,6 @@ from app.config import (
 )
 from app.db import db
 from app.lib.render.response import render_response
-from app.models.proto.shared_pb2 import (
-    StandardPaginationRequest,
-    StandardPaginationState,
-)
 
 
 class _SpCursorCodec(NamedTuple):

--- a/app/queries/graphhopper_query.py
+++ b/app/queries/graphhopper_query.py
@@ -1,5 +1,6 @@
 from typing import Literal, TypeAlias, cast, get_args
 
+from app.models.proto.shared_pb2 import RoutingResult
 from fastapi import HTTPException
 from shapely import Point, get_coordinates
 from starlette import status
@@ -8,7 +9,6 @@ from app.config import GRAPHHOPPER_API_KEY, GRAPHHOPPER_URL
 from app.lib.http.client import HTTP
 from app.lib.text.translation import primary_translation_locale
 from app.models.graphhopper import GraphHopperResponse
-from app.models.proto.shared_pb2 import RoutingResult
 
 GraphHopperProfile: TypeAlias = Literal['car', 'bike', 'foot']
 GraphHopperProfiles = frozenset[GraphHopperProfile](get_args(GraphHopperProfile))

--- a/app/queries/osrm_query.py
+++ b/app/queries/osrm_query.py
@@ -3,6 +3,7 @@ from functools import cache
 from typing import Literal, TypeAlias, cast, get_args
 
 import cython
+from app.models.proto.shared_pb2 import RoutingResult
 from fastapi import HTTPException
 from polyline_rs import decode_latlon, encode_latlon
 from shapely import Point, get_coordinates
@@ -11,7 +12,6 @@ from app.config import OSRM_URL
 from app.lib.http.client import HTTP
 from app.lib.text.translation import t
 from app.models.osrm import OSRMResponse, OSRMStep
-from app.models.proto.shared_pb2 import RoutingResult
 
 OSRMProfile: TypeAlias = Literal['car', 'bike', 'foot']
 OSRMProfiles = frozenset[OSRMProfile](get_args(OSRMProfile))

--- a/app/queries/valhalla_query.py
+++ b/app/queries/valhalla_query.py
@@ -1,13 +1,13 @@
 from typing import Literal, TypeAlias, cast, get_args
 
 import numpy as np
+from app.models.proto.shared_pb2 import RoutingResult
 from fastapi import HTTPException
 from shapely import Point, get_coordinates
 
 from app.config import VALHALLA_URL
 from app.lib.http.client import HTTP
 from app.lib.text.translation import primary_translation_locale
-from app.models.proto.shared_pb2 import RoutingResult
 from app.models.valhalla import ValhallaResponse
 
 ValhallaProfile: TypeAlias = Literal['auto', 'bicycle', 'pedestrian']

--- a/app/services/optimistic_diff/prepare.py
+++ b/app/services/optimistic_diff/prepare.py
@@ -6,6 +6,7 @@ from typing import Final, Literal, TypeAlias, assert_never
 
 import cython
 import numpy as np
+from app.models.proto.shared_types import ElementType
 from psycopg import AsyncConnection
 from shapely import Point, bounds, box
 
@@ -21,7 +22,6 @@ from app.models.element import (
     TYPED_ELEMENT_ID_RELATION_MIN,
     TypedElementId,
 )
-from app.models.proto.shared_types import ElementType
 from app.models.types import SequenceId
 from app.queries.changeset_query import ChangesetBoundsQuery, ChangesetQuery
 from app.queries.element_query import ElementQuery

--- a/app/views/settings/applications/edit.tsx
+++ b/app/views/settings/applications/edit.tsx
@@ -6,6 +6,7 @@ import { EditPageSchema, Service } from "@proto/settings_applications_pb"
 import { Scope } from "@proto/shared_pb"
 import { OAUTH_APP_NAME_MAX_LENGTH } from "@utils/config"
 import { throwAbortError } from "@utils/dom-helpers"
+import { AVATAR_MAX_PIXELS, validateImageUpload } from "@utils/image-upload"
 import { mountProtoPage } from "@utils/proto-page"
 import { t } from "i18next"
 import { useRef } from "preact/hooks"
@@ -247,10 +248,17 @@ mountProtoPage(
                         class="avatar-form"
                         formRef={avatarFormRef}
                         method={Service.method.updateAvatar}
-                        buildRequest={async ({ formData }) => ({
-                          id,
-                          avatarFile: await formDataBytes(formData, "avatar_file"),
-                        })}
+                        buildRequest={async ({ formData }) => {
+                          await validateImageUpload(
+                            formData,
+                            "avatar_file",
+                            AVATAR_MAX_PIXELS,
+                          )
+                          return {
+                            id,
+                            avatarFile: await formDataBytes(formData, "avatar_file"),
+                          }
+                        }}
                         onSuccess={(resp) => (avatarUrl.value = resp.avatarUrl)}
                       >
                         <input

--- a/app/views/user/profile/profile.tsx
+++ b/app/views/user/profile/profile.tsx
@@ -9,6 +9,11 @@ import { PageSchema, type PageValid } from "@proto/profile_pb"
 import { Service, UpdateAvatarRequest_Preset } from "@proto/settings_pb"
 import { toSentenceCase } from "@std/text/unstable-to-sentence-case"
 import { config, USER_RECENT_ACTIVITY_ENTRIES } from "@utils/config"
+import {
+  AVATAR_MAX_PIXELS,
+  BACKGROUND_MAX_PIXELS,
+  validateImageUpload,
+} from "@utils/image-upload"
 import { tRich } from "@utils/i18n"
 import { mountProtoPage } from "@utils/proto-page"
 import { t } from "i18next"
@@ -168,9 +173,16 @@ const BackgroundForm = ({
     <StandardForm
       class="background-form"
       method={Service.method.updateBackground}
-      buildRequest={async ({ formData }) => ({
-        backgroundFile: await formDataBytes(formData, "background_file"),
-      })}
+      buildRequest={async ({ formData }) => {
+        await validateImageUpload(
+          formData,
+          "background_file",
+          BACKGROUND_MAX_PIXELS,
+        )
+        return {
+          backgroundFile: await formDataBytes(formData, "background_file"),
+        }
+      }}
       onSuccess={(resp) => (backgroundUrl.value = resp.backgroundUrl)}
     >
       <input
@@ -249,6 +261,7 @@ const AvatarForm = ({
       class="avatar-form"
       method={Service.method.updateAvatar}
       buildRequest={async ({ formData }) => {
+        await validateImageUpload(formData, "avatar_file", AVATAR_MAX_PIXELS)
         const avatarFile = await formDataBytes(formData, "avatar_file")
         if (avatarFile.length) {
           return {

--- a/app/views/utils/image-upload.ts
+++ b/app/views/utils/image-upload.ts
@@ -1,0 +1,34 @@
+import { t } from "i18next"
+
+export const AVATAR_MAX_PIXELS = 384 * 384
+export const BACKGROUND_MAX_PIXELS = 4096 * 512
+
+const loadImageDimensions = (file: File) =>
+  new Promise<{ height: number; width: number }>((resolve, reject) => {
+    const url = URL.createObjectURL(file)
+    const img = new Image()
+
+    img.onload = () => {
+      URL.revokeObjectURL(url)
+      resolve({ height: img.naturalHeight, width: img.naturalWidth })
+    }
+    img.onerror = () => {
+      URL.revokeObjectURL(url)
+      reject(new Error(t("validation.image_not_readable")))
+    }
+    img.src = url
+  })
+
+export const validateImageUpload = async (
+  formData: FormData,
+  name: string,
+  maxPixels: number,
+) => {
+  const value = formData.get(name)
+  if (!(value instanceof File) || value.size === 0) return
+
+  const { height, width } = await loadImageDimensions(value)
+  if (height > 0 && width > 0 && height * width > maxPixels) {
+    throw new Error(t("validation.image_too_large"))
+  }
+}

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -580,6 +580,8 @@ validation:
   you_can_send_message_to_at_most_count_recipients: "You can send a message to at most {{count}} recipients"
   you_can_add_at_most_count_tags: "You can add at most {{count}} tags"
   incomplete_location_information: Incomplete location information
+  image_not_readable: The selected image file could not be read
+  image_too_large: The selected image is too large
 action:
   go_back: Go back
   authorize: Authorize

--- a/scripts/replication_download.py
+++ b/scripts/replication_download.py
@@ -15,6 +15,7 @@ import cython
 import orjson
 import pyarrow as pa
 import pyarrow.parquet as pq
+from app.models.proto.shared_types import ElementType
 from sentry_sdk import set_context, set_tag, start_transaction
 from starlette import status
 
@@ -29,7 +30,6 @@ from app.lib.telemetry.sentry import (
     SENTRY_REPLICATION_MONITOR_SLUG,
 )
 from app.models.element import TypedElementId
-from app.models.proto.shared_types import ElementType
 from speedup import typed_element_id
 
 _Dataset: TypeAlias = Literal['replication', 'redaction-period', 'cc-by-sa']

--- a/shellscripts/cython-build.sh
+++ b/shellscripts/cython-build.sh
@@ -36,7 +36,6 @@ echo "Found ${#files[@]} source files"
 
 CFLAGS="$(python-config --cflags) $CFLAGS \
   -shared -fPIC \
-  -DCYTHON_PROFILE=1 \
   -DCYTHON_USE_SYS_MONITORING=0"
 export CFLAGS
 
@@ -62,7 +61,7 @@ process_file() {
     set -x
     cython -3 \
       --annotate \
-      --directive overflowcheck=True,embedsignature=True,profile=True \
+      --directive overflowcheck=True,embedsignature=True \
       --module-name "$module_name" \
       "$pyfile" -o "$c_file"
   )

--- a/shellscripts/cython-build.sh
+++ b/shellscripts/cython-build.sh
@@ -36,6 +36,7 @@ echo "Found ${#files[@]} source files"
 
 CFLAGS="$(python-config --cflags) $CFLAGS \
   -shared -fPIC \
+  -DCYTHON_PROFILE=1 \
   -DCYTHON_USE_SYS_MONITORING=0"
 export CFLAGS
 
@@ -61,7 +62,7 @@ process_file() {
     set -x
     cython -3 \
       --annotate \
-      --directive overflowcheck=True,embedsignature=True \
+      --directive overflowcheck=True,embedsignature=True,profile=True \
       --module-name "$module_name" \
       "$pyfile" -o "$c_file"
   )


### PR DESCRIPTION
## What
- add a small shared frontend helper that loads selected image dimensions before submitting
- reject oversized avatar/application-avatar/background images with a standard form error
- add English validation strings for unreadable and oversized image selections

## Notes
This covers the frontend half of #31 and complements #250, which handles backend decoder/decompression failures.

## Validation
- 
- Full frontend pipeline not run locally because this environment does not have the repo's Nix/Bun toolchain available.