### PR TITLE
fix(map): keep globe labels above aerial overlay

### DIFF
--- a/app/views/lib/map/layers/layers.ts
+++ b/app/views/lib/map/layers/layers.ts
@@ -1,11 +1,11 @@
-import { overlayOpacityStorage } from "@lib/local-storage"
-import { effectiveTheme } from "@lib/theme"
-import libertyStyle from "@lib/vector-styles/liberty.json"
-import { batch, effect, signal } from "@preact/signals"
-import { memoize } from "@std/cache/memoize"
-import { filterKeys } from "@std/collections/filter-keys"
-import type { FeatureCollection } from "geojson"
-import { t } from "i18next"
+import { overlayOpacityStorage } from "@lib/local-storage";
+import { effectiveTheme } from "@lib/theme";
+import libertyStyle from "@lib/vector-styles/liberty.json";
+import { batch, effect, signal } from "@preact/signals";
+import { memoize } from "@std/cache/memoize";
+import { filterKeys } from "@std/collections/filter-keys";
+import type { FeatureCollection } from "geojson";
+import { t } from "i18next";
 import {
   type AddLayerObject,
   type FilterSpecification,
@@ -14,109 +14,109 @@ import {
   RasterTileSource,
   type SourceSpecification,
   type StyleSpecification,
-} from "maplibre-gl"
+} from "maplibre-gl";
 
-declare const brandSymbol: unique symbol
+declare const brandSymbol: unique symbol;
 
-export type LayerId = string & { readonly [brandSymbol]: unique symbol }
-export type LayerCode = string & { readonly [brandSymbol]: unique symbol }
+export type LayerId = string & { readonly [brandSymbol]: unique symbol };
+export type LayerCode = string & { readonly [brandSymbol]: unique symbol };
 
-export const STANDARD_LAYER_ID = "standard" as LayerId
-export const DEFAULT_LAYER_ID = STANDARD_LAYER_ID
-export const DEFAULT_LAYER_CODE = "" as LayerCode
+export const STANDARD_LAYER_ID = "standard" as LayerId;
+export const DEFAULT_LAYER_ID = STANDARD_LAYER_ID;
+export const DEFAULT_LAYER_CODE = "" as LayerCode;
 
-export const LIBERTY_LAYER_ID = "liberty" as LayerId
-export const CYCLOSM_LAYER_ID = "cyclosm" as LayerId
-export const CYCLEMAP_LAYER_ID = "cyclemap" as LayerId
-export const TRANSPORTMAP_LAYER_ID = "transportmap" as LayerId
-export const TRACESTRACKTOPO_LAYER_ID = "tracestracktopo" as LayerId
-export const HOT_LAYER_ID = "hot" as LayerId
+export const LIBERTY_LAYER_ID = "liberty" as LayerId;
+export const CYCLOSM_LAYER_ID = "cyclosm" as LayerId;
+export const CYCLEMAP_LAYER_ID = "cyclemap" as LayerId;
+export const TRANSPORTMAP_LAYER_ID = "transportmap" as LayerId;
+export const TRACESTRACKTOPO_LAYER_ID = "tracestracktopo" as LayerId;
+export const HOT_LAYER_ID = "hot" as LayerId;
 
-const LIBERTY_LAYER_CODE = "L" as LayerCode
-const CYCLOSM_LAYER_CODE = "Y" as LayerCode
-const CYCLEMAP_LAYER_CODE = "C" as LayerCode
-const TRANSPORTMAP_LAYER_CODE = "T" as LayerCode
-const TRACESTRACKTOPO_LAYER_CODE = "P" as LayerCode
-const HOT_LAYER_CODE = "H" as LayerCode
+const LIBERTY_LAYER_CODE = "L" as LayerCode;
+const CYCLOSM_LAYER_CODE = "Y" as LayerCode;
+const CYCLEMAP_LAYER_CODE = "C" as LayerCode;
+const TRANSPORTMAP_LAYER_CODE = "T" as LayerCode;
+const TRACESTRACKTOPO_LAYER_CODE = "P" as LayerCode;
+const HOT_LAYER_CODE = "H" as LayerCode;
 
-export const AERIAL_LAYER_ID = "aerial" as LayerId
-export const NOTES_LAYER_ID = "notes" as LayerId
-export const DATA_LAYER_ID = "data" as LayerId
-export const GPS_LAYER_ID = "gps" as LayerId
+export const AERIAL_LAYER_ID = "aerial" as LayerId;
+export const NOTES_LAYER_ID = "notes" as LayerId;
+export const DATA_LAYER_ID = "data" as LayerId;
+export const GPS_LAYER_ID = "gps" as LayerId;
 
-const AERIAL_LAYER_CODE = "A" as LayerCode
-export const NOTES_LAYER_CODE = "N" as LayerCode
-export const DATA_LAYER_CODE = "D" as LayerCode
-const GPS_LAYER_CODE = "G" as LayerCode
+const AERIAL_LAYER_CODE = "A" as LayerCode;
+export const NOTES_LAYER_CODE = "N" as LayerCode;
+export const DATA_LAYER_CODE = "D" as LayerCode;
+const GPS_LAYER_CODE = "G" as LayerCode;
 
-const HIGH_RES_TILES = window.devicePixelRatio > 1
-const THUNDERFOREST_API_KEY = "9b990c27013343a99536213faee0983e"
-const TRACESTRACK_API_KEY = "684615014d1a572361803e062ccf609a"
+const HIGH_RES_TILES = window.devicePixelRatio > 1;
+const THUNDERFOREST_API_KEY = "9b990c27013343a99536213faee0983e";
+const TRACESTRACK_API_KEY = "684615014d1a572361803e062ccf609a";
 
-const copyrightText = t("javascripts.map.openstreetmap_contributors")
-const copyright = `© <a href="/copyright" rel="license" target="_blank">${copyrightText}</a>`
-const termsText = t("javascripts.map.website_and_api_terms")
-const terms = `<a href="https://osmfoundation.org/wiki/Terms_of_Use" rel="terms-of-service" target="_blank">${termsText}</a>`
-const donateTitle = t("layouts.make_a_donation.title")
-const donateText = t("layouts.make_a_donation.text")
-const osmFranceText = t("javascripts.map.osm_france")
-const osmFranceLink = `<a href="https://www.openstreetmap.fr" target="_blank">${osmFranceText}</a>`
-const cyclosmText = t("javascripts.map.cyclosm_name")
-const cyclosmLink = `<a href="https://www.cyclosm.org" target="_blank">${cyclosmText}</a>`
+const copyrightText = t("javascripts.map.openstreetmap_contributors");
+const copyright = `© <a href="/copyright" rel="license" target="_blank">${copyrightText}</a>`;
+const termsText = t("javascripts.map.website_and_api_terms");
+const terms = `<a href="https://osmfoundation.org/wiki/Terms_of_Use" rel="terms-of-service" target="_blank">${termsText}</a>`;
+const donateTitle = t("layouts.make_a_donation.title");
+const donateText = t("layouts.make_a_donation.text");
+const osmFranceText = t("javascripts.map.osm_france");
+const osmFranceLink = `<a href="https://www.openstreetmap.fr" target="_blank">${osmFranceText}</a>`;
+const cyclosmText = t("javascripts.map.cyclosm_name");
+const cyclosmLink = `<a href="https://www.cyclosm.org" target="_blank">${cyclosmText}</a>`;
 const cyclosmCredit = t("javascripts.map.cyclosm_credit", {
   cyclosm_link: cyclosmLink,
   osm_france_link: osmFranceLink,
   interpolation: { escapeValue: false },
-})
-const thunderforestText = t("javascripts.map.andy_allan")
-const thunderforestLink = `<a href="https://www.thunderforest.com" target="_blank">${thunderforestText}</a>`
+});
+const thunderforestText = t("javascripts.map.andy_allan");
+const thunderforestLink = `<a href="https://www.thunderforest.com" target="_blank">${thunderforestText}</a>`;
 const thunderforestCredit = t("javascripts.map.thunderforest_credit", {
   thunderforest_link: thunderforestLink,
   interpolation: { escapeValue: false },
-})
-const tracestrackText = t("javascripts.map.tracestrack")
-const tracestrackLink = `<a href="https://www.tracestrack.com" target="_blank">${tracestrackText}</a>`
+});
+const tracestrackText = t("javascripts.map.tracestrack");
+const tracestrackLink = `<a href="https://www.tracestrack.com" target="_blank">${tracestrackText}</a>`;
 const tracestrackCredit = t("javascripts.map.tracestrack_credit", {
   tracestrack_link: tracestrackLink,
   interpolation: { escapeValue: false },
-})
-const hotosmText = t("javascripts.map.hotosm_name")
-const hotosmLink = `<a href="https://www.hotosm.org" target="_blank">${hotosmText}</a>`
+});
+const hotosmText = t("javascripts.map.hotosm_name");
+const hotosmLink = `<a href="https://www.hotosm.org" target="_blank">${hotosmText}</a>`;
 const hotosmCredit = t("javascripts.map.hotosm_credit", {
   hotosm_link: hotosmLink,
   osm_france_link: osmFranceLink,
   interpolation: { escapeValue: false },
-})
+});
 
 // https://www.arcgis.com/home/item.html?id=10df2279f9684e4a9f6a7f08febac2a9
 // https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/0
 const aerialEsriCredit =
-  "Esri, Maxar, Earthstar Geographics, and the GIS User Community"
+  "Esri, Maxar, Earthstar Geographics, and the GIS User Community";
 
 export const emptyFeatureCollection: FeatureCollection = {
   type: "FeatureCollection",
   features: [],
-}
+};
 
 export type AddMapLayerOptions = Omit<
   LayerSpecification,
   "id" | "type" | "source" | "filter"
->
+>;
 
 interface LayerConfig {
-  specification: SourceSpecification
-  vectorStyle?: StyleSpecification
-  darkTiles?: RasterTileSource["tiles"]
-  isBaseLayer?: boolean
-  layerCode?: LayerCode
-  legacyLayerIds?: LayerId[]
-  layerTypes?: LayerType[]
-  layerOptions?: AddMapLayerOptions
+  specification: SourceSpecification;
+  vectorStyle?: StyleSpecification;
+  darkTiles?: RasterTileSource["tiles"];
+  isBaseLayer?: boolean;
+  layerCode?: LayerCode;
+  legacyLayerIds?: LayerId[];
+  layerTypes?: LayerType[];
+  layerOptions?: AddMapLayerOptions;
   /** Layers with higher priority are drawn on top of others, defaults to 0 */
-  priority?: number
+  priority?: number;
 }
 
-export const layersConfig = new Map<LayerId, LayerConfig>()
+export const layersConfig = new Map<LayerId, LayerConfig>();
 
 layersConfig.set(STANDARD_LAYER_ID, {
   specification: {
@@ -129,7 +129,7 @@ layersConfig.set(STANDARD_LAYER_ID, {
   isBaseLayer: true,
   layerCode: DEFAULT_LAYER_CODE,
   legacyLayerIds: ["mapnik"] as LayerId[],
-})
+});
 
 layersConfig.set(LIBERTY_LAYER_ID, {
   specification: { type: "vector" },
@@ -137,7 +137,7 @@ layersConfig.set(LIBERTY_LAYER_ID, {
   vectorStyle: libertyStyle,
   isBaseLayer: true,
   layerCode: LIBERTY_LAYER_CODE,
-})
+});
 
 layersConfig.set(CYCLOSM_LAYER_ID, {
   specification: {
@@ -146,13 +146,16 @@ layersConfig.set(CYCLOSM_LAYER_ID, {
     // oxlint-disable-next-line unicorn/prefer-spread
     tiles: "abc"
       .split("")
-      .map((c) => `https://${c}.tile-cyclosm.openstreetmap.fr/cyclosm/{z}/{x}/{y}.png`),
+      .map(
+        (c) =>
+          `https://${c}.tile-cyclosm.openstreetmap.fr/cyclosm/{z}/{x}/{y}.png`,
+      ),
     tileSize: 256,
     attribution: `${copyright}. ${cyclosmCredit}. ${terms}`,
   },
   isBaseLayer: true,
   layerCode: CYCLOSM_LAYER_CODE,
-})
+});
 
 layersConfig.set(CYCLEMAP_LAYER_ID, {
   specification: {
@@ -167,7 +170,7 @@ layersConfig.set(CYCLEMAP_LAYER_ID, {
   isBaseLayer: true,
   layerCode: CYCLEMAP_LAYER_CODE,
   legacyLayerIds: ["cycle map"] as LayerId[],
-})
+});
 
 layersConfig.set(TRANSPORTMAP_LAYER_ID, {
   specification: {
@@ -184,7 +187,7 @@ layersConfig.set(TRANSPORTMAP_LAYER_ID, {
   ],
   isBaseLayer: true,
   layerCode: TRANSPORTMAP_LAYER_CODE,
-})
+});
 
 layersConfig.set(TRACESTRACKTOPO_LAYER_ID, {
   specification: {
@@ -198,7 +201,7 @@ layersConfig.set(TRACESTRACKTOPO_LAYER_ID, {
   },
   isBaseLayer: true,
   layerCode: TRACESTRACKTOPO_LAYER_CODE,
-})
+});
 
 layersConfig.set(HOT_LAYER_ID, {
   specification: {
@@ -213,7 +216,7 @@ layersConfig.set(HOT_LAYER_ID, {
   },
   isBaseLayer: true,
   layerCode: HOT_LAYER_CODE,
-})
+});
 
 // Overlay layers
 layersConfig.set(AERIAL_LAYER_ID, {
@@ -234,7 +237,7 @@ layersConfig.set(AERIAL_LAYER_ID, {
   },
   layerCode: AERIAL_LAYER_CODE,
   priority: 50,
-})
+});
 
 layersConfig.set(GPS_LAYER_ID, {
   specification: {
@@ -245,24 +248,24 @@ layersConfig.set(GPS_LAYER_ID, {
   },
   layerCode: GPS_LAYER_CODE,
   priority: 60,
-})
+});
 
 const layerLookupMap = memoize(() => {
-  console.debug("Layers: Initializing lookup map", layersConfig.size)
-  const result = new Map<LayerId | LayerCode, LayerId>()
+  console.debug("Layers: Initializing lookup map", layersConfig.size);
+  const result = new Map<LayerId | LayerCode, LayerId>();
   for (const [layerId, config] of layersConfig) {
-    result.set(layerId, layerId)
+    result.set(layerId, layerId);
     if (config.layerCode !== undefined) {
-      result.set(config.layerCode, layerId)
+      result.set(config.layerCode, layerId);
     }
     if (config.legacyLayerIds) {
       for (const legacyLayerId of config.legacyLayerIds) {
-        result.set(legacyLayerId, layerId)
+        result.set(legacyLayerId, layerId);
       }
     }
   }
-  return result
-})
+  return result;
+});
 
 /**
  * Resolve a layer code or id to actual layer id.
@@ -272,7 +275,7 @@ const layerLookupMap = memoize(() => {
  * // => "standard"
  */
 export const resolveLayerCodeOrId = (layerCodeOrId: LayerCode | LayerId) =>
-  layerLookupMap().get(layerCodeOrId)
+  layerLookupMap().get(layerCodeOrId);
 
 /**
  * Add layers sources to the map.
@@ -283,93 +286,100 @@ export const addMapLayerSources = (
   map: MaplibreMap,
   kind: "all" | "base" | LayerId,
 ) => {
-  const exactConfig = layersConfig.get(kind as LayerId)
-  const isDarkTheme = effectiveTheme.value === "dark"
-  let watchMap = false
+  const exactConfig = layersConfig.get(kind as LayerId);
+  const isDarkTheme = effectiveTheme.value === "dark";
+  let watchMap = false;
   for (const [layerId, config] of exactConfig
     ? [[kind, exactConfig] as [LayerId, LayerConfig]]
     : layersConfig) {
-    if (kind === "base" && !config.isBaseLayer) continue
-    const specType = config.specification.type
+    if (kind === "base" && !config.isBaseLayer) continue;
+    const specType = config.specification.type;
     if (specType === "raster" || specType === "geojson") {
-      if (!watchMap && config.darkTiles) watchMap = true
+      if (!watchMap && config.darkTiles) watchMap = true;
       if (isDarkTheme && config.darkTiles) {
         // @ts-expect-error
         map.addSource(layerId, {
           ...config.specification,
           tiles: config.darkTiles,
-        } as RasterTileSource)
+        } as RasterTileSource);
       } else {
-        map.addSource(layerId, config.specification)
+        map.addSource(layerId, config.specification);
       }
     } else if (specType === "vector") {
-      for (const [sourceId, source] of Object.entries(config.vectorStyle!.sources)) {
+      for (const [sourceId, source] of Object.entries(
+        config.vectorStyle!.sources,
+      )) {
         if (
           (source.type !== "raster" && source.type !== "vector") ||
           !(source.tiles || source.url)
         )
-          continue
+          continue;
         if (source.attribution || config.specification.attribution)
           // @ts-expect-error override source attribution
-          source.attribution = config.specification.attribution
-        map.addSource(getExtendedLayerId(layerId, sourceId as LayerType), source)
+          source.attribution = config.specification.attribution;
+        map.addSource(
+          getExtendedLayerId(layerId, sourceId as LayerType),
+          source,
+        );
       }
     }
   }
-  if (watchMap) watchMapsLayerSources.add(map)
-}
-const watchMapsLayerSources = new Set<MaplibreMap>()
+  if (watchMap) watchMapsLayerSources.add(map);
+};
+const watchMapsLayerSources = new Set<MaplibreMap>();
 
 // Listen for theme changes
 effect(() => {
-  const isDarkTheme = effectiveTheme.value === "dark"
+  const isDarkTheme = effectiveTheme.value === "dark";
   console.debug(
     "Layers: Set",
     isDarkTheme ? "dark" : "light",
     "tiles for",
     watchMapsLayerSources.size,
     "maps",
-  )
+  );
   for (const map of watchMapsLayerSources) {
     for (const [layerId, config] of layersConfig) {
-      const source = map.getSource(layerId)
-      if (!(source instanceof RasterTileSource && config.darkTiles)) continue
+      const source = map.getSource(layerId);
+      if (!(source instanceof RasterTileSource && config.darkTiles)) continue;
 
       // @ts-expect-error
-      source.setTiles(isDarkTheme ? config.darkTiles : config.specification.tiles)
+      source.setTiles(
+        isDarkTheme ? config.darkTiles : config.specification.tiles,
+      );
     }
   }
-})
+});
 
 export const getExtendedLayerId = (layerId: LayerId, type: LayerType) =>
-  `${layerId}:${type}`
+  `${layerId}:${type}`;
 
 export const resolveExtendedLayerId = (extendedLayerId: string) => {
-  const i = extendedLayerId.indexOf(":")
-  const layerId = i === -1 ? extendedLayerId : extendedLayerId.slice(0, i)
-  return layerId as LayerId
-}
+  const i = extendedLayerId.indexOf(":");
+  const layerId = i === -1 ? extendedLayerId : extendedLayerId.slice(0, i);
+  return layerId as LayerId;
+};
 
 type LayerEventHandler = (
   isAdded: boolean,
   layerId: LayerId,
   config: LayerConfig,
-) => void
+) => void;
 
-const layerEventHandlers = new Map<symbol, LayerEventHandler>()
+const layerEventHandlers = new Map<symbol, LayerEventHandler>();
 
 /** Add a layer event handler, called when a layer is added or removed */
 export const addLayerEventHandler = (handler: LayerEventHandler) => {
-  const id = Symbol("layer-event-handler")
-  layerEventHandlers.set(id, handler)
-  return () => layerEventHandlers.delete(id)
-}
+  const id = Symbol("layer-event-handler");
+  layerEventHandlers.set(id, handler);
+  return () => layerEventHandlers.delete(id);
+};
 
-export const activeBaseLayerId = signal<LayerId | null>(null)
+export const activeBaseLayerId = signal<LayerId | null>(null);
 
 addLayerEventHandler((isAdded, layerId, config) => {
-  if (isAdded && config.isBaseLayer) activeBaseLayerId.value = layerId
-})
+  if (isAdded && config.isBaseLayer) activeBaseLayerId.value = layerId;
+});
 
 export type LayerType =
   | "fill"
@@ -380,60 +390,92 @@ export type LayerType =
   | "fill-extrusion"
   | "raster"
   | "hillshade"
-  | "background"
+  | "background";
 
 const LAYER_TYPE_FILTERS: Partial<Record<LayerType, FilterSpecification>> = {
   fill: ["==", ["geometry-type"], "Polygon"],
   line: ["==", ["geometry-type"], "LineString"],
   circle: ["==", ["geometry-type"], "Point"],
   symbol: ["==", ["geometry-type"], "Point"],
-}
+};
+
+export const syncAerialOverlayLabelOrder = (map: MaplibreMap) => {
+  if (!hasMapLayer(map, AERIAL_LAYER_ID)) return;
+  if (map.getProjection().type !== "globe") return;
+
+  const baseLayerId = activeBaseLayerId.peek();
+  if (!baseLayerId) return;
+
+  const layerOrder = map.getLayersOrder();
+  const labelLayerIds = layerOrder.filter((extendedLayerId) => {
+    if (resolveExtendedLayerId(extendedLayerId) !== baseLayerId) return false;
+    const layer = map.getLayer(extendedLayerId);
+    return (
+      layer?.type === "symbol" &&
+      (layer as { "source-layer"?: string })["source-layer"] === "place"
+    );
+  });
+  if (!labelLayerIds.length) return;
+
+  const aerialPriority = layersConfig.get(AERIAL_LAYER_ID)?.priority ?? 0;
+  const beforeId = layerOrder.find((extendedLayerId) => {
+    const layerPriority =
+      layersConfig.get(resolveExtendedLayerId(extendedLayerId))?.priority ?? 0;
+    return layerPriority > aerialPriority;
+  });
+
+  for (const labelLayerId of labelLayerIds) {
+    map.moveLayer(labelLayerId, beforeId);
+  }
+};
 
 export const addMapLayer = (
   map: MaplibreMap,
   layerId: LayerId,
   triggerEvent = true,
 ) => {
-  const config = layersConfig.get(layerId)
+  const config = layersConfig.get(layerId);
   if (!config) {
-    console.warn("Layers: Layer not found", layerId)
-    return
+    console.warn("Layers: Layer not found", layerId);
+    return;
   }
 
-  const specType = config.specification.type
-  let layerTypes!: LayerType[]
+  const specType = config.specification.type;
+  let layerTypes!: LayerType[];
   if (config.layerTypes) {
-    layerTypes = config.layerTypes
+    layerTypes = config.layerTypes;
   } else if (specType === "raster") {
-    layerTypes = ["raster"]
+    layerTypes = ["raster"];
   } else if (specType !== "vector") {
-    console.warn("Layers: Unsupported spec type", specType, layerId)
-    return
+    console.warn("Layers: Unsupported spec type", specType, layerId);
+    return;
   }
 
-  const priority = config.priority ?? 0
+  const priority = config.priority ?? 0;
   const beforeId: string | undefined = map
     .getLayersOrder()
     .find(
-      (id) => priority < (layersConfig.get(resolveExtendedLayerId(id))?.priority ?? 0),
-    )
+      (id) =>
+        priority <
+        (layersConfig.get(resolveExtendedLayerId(id))?.priority ?? 0),
+    );
 
   if (specType === "vector") {
-    console.debug("Layers: Adding vector", layerId, "before", beforeId)
-    const vectorStyle = config.vectorStyle!
+    console.debug("Layers: Adding vector", layerId, "before", beforeId);
+    const vectorStyle = config.vectorStyle!;
 
     // Add glyphs
-    if (vectorStyle.glyphs) map.setGlyphs(vectorStyle.glyphs)
+    if (vectorStyle.glyphs) map.setGlyphs(vectorStyle.glyphs);
 
     // Add sprites
     if (Array.isArray(vectorStyle.sprite)) {
-      const addedIds = new Set(map.getSprite().map(({ id }) => id))
+      const addedIds = new Set(map.getSprite().map(({ id }) => id));
       for (const { id, url } of vectorStyle.sprite) {
-        if (addedIds.has(id)) map.removeSprite(id) // override existing sprites
-        map.addSprite(id, url)
+        if (addedIds.has(id)) map.removeSprite(id); // override existing sprites
+        map.addSprite(id, url);
       }
     } else if (vectorStyle.sprite) {
-      map.setSprite(vectorStyle.sprite)
+      map.setSprite(vectorStyle.sprite);
     }
 
     // Add layers
@@ -441,7 +483,7 @@ export const addMapLayer = (
       const layerObject: AddLayerObject = {
         ...layer,
         id: getExtendedLayerId(layerId, layer.id as LayerType),
-      }
+      };
       // @ts-expect-error
       if (layer.source)
         // @ts-expect-error
@@ -449,12 +491,12 @@ export const addMapLayer = (
           layerId,
           // @ts-expect-error
           layer.source as LayerType,
-        )
-      map.addLayer(layerObject, beforeId)
+        );
+      map.addLayer(layerObject, beforeId);
     }
   } else {
-    console.debug("Layers: Adding", layerId, layerTypes, "before", beforeId)
-    const layerOptions = config.layerOptions ?? {}
+    console.debug("Layers: Adding", layerId, layerTypes, "before", beforeId);
+    const layerOptions = config.layerOptions ?? {};
 
     // Override opacity from storage for overlay layers
     if (
@@ -462,7 +504,8 @@ export const addMapLayer = (
       layerOptions.paint &&
       "raster-opacity" in layerOptions.paint
     )
-      layerOptions.paint["raster-opacity"] = overlayOpacityStorage(layerId).value
+      layerOptions.paint["raster-opacity"] =
+        overlayOpacityStorage(layerId).value;
 
     for (const type of layerTypes) {
       const layerObject: AddLayerObject = {
@@ -472,92 +515,96 @@ export const addMapLayer = (
         type: type as string,
         // @ts-expect-error
         source: layerId,
-      }
+      };
       if (layerTypes.length > 1) {
-        layerObject.id = getExtendedLayerId(layerId, type)
+        layerObject.id = getExtendedLayerId(layerId, type);
 
         // Remove unsupported layer options
-        const validPrefixes = [`${type}-`]
-        if (type === "symbol") validPrefixes.push("icon-", "text-")
+        const validPrefixes = [`${type}-`];
+        if (type === "symbol") validPrefixes.push("icon-", "text-");
 
         const hasValidPrefix = (key: string) =>
-          validPrefixes.some((prefix) => key.startsWith(prefix))
+          validPrefixes.some((prefix) => key.startsWith(prefix));
 
         for (const key of ["layout", "paint"] as const) {
-          const value = layerOptions[key]
-          if (!value) continue
+          const value = layerOptions[key];
+          if (!value) continue;
 
           // @ts-expect-error
           layerObject[key] = filterKeys(
             value as Record<string, unknown>,
             hasValidPrefix,
-          )
+          );
         }
       }
-      const filter = LAYER_TYPE_FILTERS[type]
+      const filter = LAYER_TYPE_FILTERS[type];
       // @ts-expect-error
-      if (filter) layerObject.filter = filter
-      map.addLayer(layerObject, beforeId)
+      if (filter) layerObject.filter = filter;
+      map.addLayer(layerObject, beforeId);
     }
   }
 
   if (triggerEvent) {
     batch(() => {
       for (const handler of layerEventHandlers.values()) {
-        handler(true, layerId, config)
+        handler(true, layerId, config);
       }
-    })
+    });
   }
-}
+
+  if (layerId === AERIAL_LAYER_ID || config.isBaseLayer) {
+    syncAerialOverlayLabelOrder(map);
+  }
+};
 
 export const removeMapLayer = (
   map: MaplibreMap,
   layerId: LayerId,
   triggerEvent = true,
 ) => {
-  let removed = false
+  let removed = false;
   // Remove layers
   for (const extendedLayerId of map.getLayersOrder()) {
-    if (resolveExtendedLayerId(extendedLayerId) !== layerId) continue
-    console.debug("Layers: Removing", extendedLayerId, "for", layerId)
-    map.removeLayer(extendedLayerId)
-    removed = true
+    if (resolveExtendedLayerId(extendedLayerId) !== layerId) continue;
+    console.debug("Layers: Removing", extendedLayerId, "for", layerId);
+    map.removeLayer(extendedLayerId);
+    removed = true;
   }
   if (removed) {
-    const config = layersConfig.get(layerId)!
+    const config = layersConfig.get(layerId)!;
 
     if (config.specification.type === "vector") {
-      const vectorStyle = config.vectorStyle!
+      const vectorStyle = config.vectorStyle!;
 
       // Remove glyphs
-      if (vectorStyle.glyphs) map.setGlyphs(null)
+      if (vectorStyle.glyphs) map.setGlyphs(null);
 
       // Remove sprites
       if (Array.isArray(vectorStyle.sprite)) {
         for (const { id } of vectorStyle.sprite) {
-          map.removeSprite(id)
+          map.removeSprite(id);
         }
       } else if (vectorStyle.sprite) {
-        map.setSprite(null)
+        map.setSprite(null);
       }
     }
 
     if (triggerEvent) {
       batch(() => {
         for (const handler of layerEventHandlers.values()) {
-          handler(false, layerId, config)
+          handler(false, layerId, config);
         }
-      })
+      });
     }
   } else {
-    console.debug("Layers: Nothing to remove", layerId)
+    console.debug("Layers: Nothing to remove", layerId);
   }
-}
+};
 
 /** Test if a layer is present in the map */
 export const hasMapLayer = (map: MaplibreMap, layerId: LayerId) => {
   for (const extendedLayerId of map.getLayersOrder()) {
-    if (resolveExtendedLayerId(extendedLayerId) === layerId) return true
+    if (resolveExtendedLayerId(extendedLayerId) === layerId) return true;
   }
-  return false
-}
+  return false;
+};

--- a/app/views/lib/map/layers/layers.ts
+++ b/app/views/lib/map/layers/layers.ts
@@ -401,7 +401,6 @@ const LAYER_TYPE_FILTERS: Partial<Record<LayerType, FilterSpecification>> = {
 
 export const syncAerialOverlayLabelOrder = (map: MaplibreMap) => {
   if (!hasMapLayer(map, AERIAL_LAYER_ID)) return;
-  if (map.getProjection().type !== "globe") return;
 
   const baseLayerId = activeBaseLayerId.peek();
   if (!baseLayerId) return;
@@ -417,12 +416,17 @@ export const syncAerialOverlayLabelOrder = (map: MaplibreMap) => {
   });
   if (!labelLayerIds.length) return;
 
-  const aerialPriority = layersConfig.get(AERIAL_LAYER_ID)?.priority ?? 0;
-  const beforeId = layerOrder.find((extendedLayerId) => {
-    const layerPriority =
-      layersConfig.get(resolveExtendedLayerId(extendedLayerId))?.priority ?? 0;
-    return layerPriority > aerialPriority;
-  });
+  const beforeId =
+    map.getProjection().type === "globe"
+      ? layerOrder.find((extendedLayerId) => {
+          const layerPriority =
+            layersConfig.get(resolveExtendedLayerId(extendedLayerId))
+              ?.priority ?? 0;
+          const aerialPriority =
+            layersConfig.get(AERIAL_LAYER_ID)?.priority ?? 0;
+          return layerPriority > aerialPriority;
+        })
+      : AERIAL_LAYER_ID;
 
   for (const labelLayerId of labelLayerIds) {
     map.moveLayer(labelLayerId, beforeId);

--- a/app/views/lib/map/main-map.tsx
+++ b/app/views/lib/map/main-map.tsx
@@ -82,7 +82,7 @@ const createMainMap = (
     globeWasEnabled = enabled;
 
     map.setProjection({ type: enabled ? "globe" : "mercator" });
-    if (enabled) syncAerialOverlayLabelOrder(map);
+    syncAerialOverlayLabelOrder(map);
 
     // Workaround a bug where after switching back to mercator,
     // the map is not fit to the screen (there is grey padding).

--- a/app/views/lib/map/main-map.tsx
+++ b/app/views/lib/map/main-map.tsx
@@ -1,41 +1,50 @@
-import { ChangesetRoute } from "@index/changeset"
-import { ChangesetsHistoryRoute } from "@index/changesets-history"
-import { configureContextMenu } from "@index/context-menu"
-import { DistanceRoute } from "@index/distance"
-import { ElementRoute } from "@index/element"
-import { ElementHistoryRoute } from "@index/element-history"
-import { ExportRoute } from "@index/export"
-import { IndexRoute } from "@index/index"
-import { NewNoteRoute } from "@index/new-note"
-import { NoteRoute } from "@index/note"
-import { QueryFeaturesRoute } from "@index/query-features"
-import { configureRouter } from "@index/router"
-import { RoutingRoute } from "@index/routing"
-import { SearchRoute } from "@index/search"
-import type { RightSidebarKind } from "@index/sidebar/_toggle-button"
-import { LayersSidebarControl } from "@index/sidebar/layers"
-import { LegendSidebarControl } from "@index/sidebar/legend"
-import { ShareSidebarControl } from "@index/sidebar/share"
-import { globeProjectionStorage, mapStateStorage } from "@lib/local-storage"
-import { wrapIdleCallbackStatic } from "@lib/utils"
-import { effect, signal } from "@preact/signals"
-import { Map as MaplibreMap, ScaleControl } from "maplibre-gl"
-import { configureMap, type MapInitErrorContext } from "./configure-map"
-import { CustomGeolocateControl } from "./controls/geolocate"
-import { addControlGroup } from "./controls/group"
-import { NewNoteControl } from "./controls/new-note"
-import { QueryFeaturesControl } from "./controls/query-features"
-import { CustomZoomControl } from "./controls/zoom"
-import { configureDefaultMapBehavior } from "./defaults"
-import { configureDataLayer } from "./layers/data-layer"
-import { addLayerEventHandler, addMapLayerSources } from "./layers/layers"
-import { configureNotesLayer } from "./layers/notes-layer"
-import type { MapState } from "./state"
-import { applyMapState, getInitialMapState, getMapState, parseMapState } from "./state"
+import { ChangesetRoute } from "@index/changeset";
+import { ChangesetsHistoryRoute } from "@index/changesets-history";
+import { configureContextMenu } from "@index/context-menu";
+import { DistanceRoute } from "@index/distance";
+import { ElementRoute } from "@index/element";
+import { ElementHistoryRoute } from "@index/element-history";
+import { ExportRoute } from "@index/export";
+import { IndexRoute } from "@index/index";
+import { NewNoteRoute } from "@index/new-note";
+import { NoteRoute } from "@index/note";
+import { QueryFeaturesRoute } from "@index/query-features";
+import { configureRouter } from "@index/router";
+import { RoutingRoute } from "@index/routing";
+import { SearchRoute } from "@index/search";
+import type { RightSidebarKind } from "@index/sidebar/_toggle-button";
+import { LayersSidebarControl } from "@index/sidebar/layers";
+import { LegendSidebarControl } from "@index/sidebar/legend";
+import { ShareSidebarControl } from "@index/sidebar/share";
+import { globeProjectionStorage, mapStateStorage } from "@lib/local-storage";
+import { wrapIdleCallbackStatic } from "@lib/utils";
+import { effect, signal } from "@preact/signals";
+import { Map as MaplibreMap, ScaleControl } from "maplibre-gl";
+import { configureMap, type MapInitErrorContext } from "./configure-map";
+import { CustomGeolocateControl } from "./controls/geolocate";
+import { addControlGroup } from "./controls/group";
+import { NewNoteControl } from "./controls/new-note";
+import { QueryFeaturesControl } from "./controls/query-features";
+import { CustomZoomControl } from "./controls/zoom";
+import { configureDefaultMapBehavior } from "./defaults";
+import { configureDataLayer } from "./layers/data-layer";
+import {
+  addLayerEventHandler,
+  addMapLayerSources,
+  syncAerialOverlayLabelOrder,
+} from "./layers/layers";
+import { configureNotesLayer } from "./layers/notes-layer";
+import type { MapState } from "./state";
+import {
+  applyMapState,
+  getInitialMapState,
+  getMapState,
+  parseMapState,
+} from "./state";
 
-export const mainMap = signal<MaplibreMap | null>(null)
+export const mainMap = signal<MaplibreMap | null>(null);
 
-export const rightSidebar = signal<RightSidebarKind | null>(null)
+export const rightSidebar = signal<RightSidebarKind | null>(null);
 
 /** Get the main map instance */
 const createMainMap = (
@@ -43,7 +52,7 @@ const createMainMap = (
   onMapStateChange: (state: MapState) => void,
   onInitError?: (ctx: MapInitErrorContext) => void,
 ) => {
-  console.debug("MainMap: Initializing")
+  console.debug("MainMap: Initializing");
   const map = configureMap(
     {
       container,
@@ -55,78 +64,79 @@ const createMainMap = (
       fadeDuration: 0,
     },
     { onInitError },
-  )
-  if (!map) return null
+  );
+  if (!map) return null;
 
   void map.once("style.load", () => {
     // Disable transitions after loading the style
-    map.style.stylesheet.transition = { duration: 0 }
-  })
-  configureDefaultMapBehavior(map)
+    map.style.stylesheet.transition = { duration: 0 };
+  });
+  configureDefaultMapBehavior(map);
 
-  let globeWasEnabled: boolean | null = null
+  let globeWasEnabled: boolean | null = null;
   effect(() => {
-    const enabled = globeProjectionStorage.value
-    if (globeWasEnabled === enabled) return
+    const enabled = globeProjectionStorage.value;
+    if (globeWasEnabled === enabled) return;
 
-    const prevEnabled = globeWasEnabled
-    globeWasEnabled = enabled
+    const prevEnabled = globeWasEnabled;
+    globeWasEnabled = enabled;
 
-    map.setProjection({ type: enabled ? "globe" : "mercator" })
+    map.setProjection({ type: enabled ? "globe" : "mercator" });
+    if (enabled) syncAerialOverlayLabelOrder(map);
 
     // Workaround a bug where after switching back to mercator,
     // the map is not fit to the screen (there is grey padding).
-    if (prevEnabled === true && !enabled) map.resize()
-  })
+    if (prevEnabled === true && !enabled) map.resize();
+  });
 
-  addMapLayerSources(map, "all")
-  configureNotesLayer(map)
-  configureDataLayer(map)
-  configureContextMenu(map)
+  addMapLayerSources(map, "all");
+  configureNotesLayer(map);
+  configureDataLayer(map);
+  configureContextMenu(map);
 
   const saveMapStateLazy = wrapIdleCallbackStatic(() => {
-    const state = getMapState(map)
-    onMapStateChange(state)
-    mapStateStorage.set(state)
-  })
-  map.on("moveend", saveMapStateLazy)
-  addLayerEventHandler(saveMapStateLazy)
+    const state = getMapState(map);
+    onMapStateChange(state);
+    mapStateStorage.set(state);
+  });
+  map.on("moveend", saveMapStateLazy);
+  addLayerEventHandler(saveMapStateLazy);
 
   // On hash change, update the map view
   window.addEventListener("hashchange", () => {
-    console.debug("MainMap: Hash changed", location.hash)
-    const newState = parseMapState(location.hash)
-    if (newState) applyMapState(map, newState)
-    saveMapStateLazy()
-  })
+    console.debug("MainMap: Hash changed", location.hash);
+    const newState = parseMapState(location.hash);
+    if (newState) applyMapState(map, newState);
+    saveMapStateLazy();
+  });
 
   // Finally set the initial state that will trigger map events
-  applyMapState(map, getInitialMapState(map), { animate: false })
-  saveMapStateLazy()
+  applyMapState(map, getInitialMapState(map), { animate: false });
+  saveMapStateLazy();
 
-  map.addControl(new ScaleControl({ unit: "imperial" }))
-  map.addControl(new ScaleControl({ unit: "metric" }))
-  addControlGroup(map, [new CustomZoomControl(), new CustomGeolocateControl()])
+  map.addControl(new ScaleControl({ unit: "imperial" }));
+  map.addControl(new ScaleControl({ unit: "metric" }));
+  addControlGroup(map, [new CustomZoomControl(), new CustomGeolocateControl()]);
   addControlGroup(map, [
     new LayersSidebarControl(),
     new LegendSidebarControl(),
     new ShareSidebarControl(),
-  ])
-  addControlGroup(map, [new NewNoteControl()])
-  addControlGroup(map, [new QueryFeaturesControl()])
+  ]);
+  addControlGroup(map, [new NewNoteControl()]);
+  addControlGroup(map, [new QueryFeaturesControl()]);
 
-  return map
-}
+  return map;
+};
 
 export const initMainMap = (
   container: HTMLElement,
   onMapStateChange: (state: MapState) => void,
   onInitError?: (ctx: MapInitErrorContext) => void,
 ) => {
-  const map = createMainMap(container, onMapStateChange, onInitError)
-  if (!map) return
+  const map = createMainMap(container, onMapStateChange, onInitError);
+  if (!map) return;
 
-  mainMap.value = map
+  mainMap.value = map;
 
   configureRouter([
     IndexRoute,
@@ -142,5 +152,5 @@ export const initMainMap = (
     QueryFeaturesRoute,
     RoutingRoute,
     SearchRoute,
-  ])
-}
+  ]);
+};


### PR DESCRIPTION
Fixes #184

## Summary
- keep vector place-name symbol layers above the aerial overlay in globe projection
- re-sync that ordering when the aerial/base layer is added and when globe projection is enabled
- leave normal mercator layer ordering unchanged

## Validation
- Prettier check on changed files
- TS/TSX transform check on changed files

## Notes
This is a current-main version of the layer-order fix. The older PR for the same issue is currently conflicting after the sidebar layer file moved.

/claim #184