### PR TITLE
Add hybrid aerial base layer

### DIFF
--- a/app/views/index/sidebar/layers.tsx
+++ b/app/views/index/sidebar/layers.tsx
@@ -25,6 +25,7 @@ import {
   GPS_LAYER_ID,
   HOT_LAYER_ID,
   hasMapLayer,
+  HYBRID_LAYER_ID,
   type LayerId,
   LIBERTY_LAYER_ID,
   NOTES_LAYER_ID,
@@ -49,6 +50,7 @@ const BASE_LAYERS = new Set([
   TRANSPORTMAP_LAYER_ID,
   TRACESTRACKTOPO_LAYER_ID,
   LIBERTY_LAYER_ID,
+  HYBRID_LAYER_ID,
   HOT_LAYER_ID,
 ])
 
@@ -63,6 +65,7 @@ const OVERLAY_LAYERS = new Set([
 // Avoids "Too many active WebGL context even after destroyed".
 const LAYER_THUMBNAILS = new Map<LayerId, string>([
   [AERIAL_LAYER_ID, "/static/img/layer/aerial.webp"],
+  [HYBRID_LAYER_ID, "/static/img/layer/aerial.webp"],
 ])
 
 type Minimap =
@@ -385,6 +388,12 @@ export const LayersSidebar = ({ close }: { close: () => void }) => {
                 {layerId === LIBERTY_LAYER_ID && (
                   <>
                     {t("map.layers.liberty")}
+                    <span class="vector">{t("map.layers.vector")}</span>
+                  </>
+                )}
+                {layerId === HYBRID_LAYER_ID && (
+                  <>
+                    {t("map.layers.hybrid_aerial")}
                     <span class="vector">{t("map.layers.vector")}</span>
                   </>
                 )}

--- a/app/views/lib/map/layers/layers.ts
+++ b/app/views/lib/map/layers/layers.ts
@@ -26,6 +26,7 @@ export const DEFAULT_LAYER_ID = STANDARD_LAYER_ID
 export const DEFAULT_LAYER_CODE = "" as LayerCode
 
 export const LIBERTY_LAYER_ID = "liberty" as LayerId
+export const HYBRID_LAYER_ID = "hybrid" as LayerId
 export const CYCLOSM_LAYER_ID = "cyclosm" as LayerId
 export const CYCLEMAP_LAYER_ID = "cyclemap" as LayerId
 export const TRANSPORTMAP_LAYER_ID = "transportmap" as LayerId
@@ -33,6 +34,7 @@ export const TRACESTRACKTOPO_LAYER_ID = "tracestracktopo" as LayerId
 export const HOT_LAYER_ID = "hot" as LayerId
 
 const LIBERTY_LAYER_CODE = "L" as LayerCode
+const HYBRID_LAYER_CODE = "I" as LayerCode
 const CYCLOSM_LAYER_CODE = "Y" as LayerCode
 const CYCLEMAP_LAYER_CODE = "C" as LayerCode
 const TRANSPORTMAP_LAYER_CODE = "T" as LayerCode
@@ -93,6 +95,43 @@ const hotosmCredit = t("javascripts.map.hotosm_credit", {
 const aerialEsriCredit =
   "Esri, Maxar, Earthstar Geographics, and the GIS User Community"
 
+const aerialEsriSource = {
+  type: "raster",
+  maxzoom: 23,
+  tiles: [
+    "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+  ],
+  tileSize: 256,
+  attribution: aerialEsriCredit,
+} satisfies SourceSpecification
+
+const libertyVectorStyle = libertyStyle as unknown as StyleSpecification
+const cloneStylePart = <T,>(value: T): T => JSON.parse(JSON.stringify(value)) as T
+
+const HYBRID_AERIAL_SOURCE_ID = "aerial"
+const HYBRID_AERIAL_LAYER_ID = "aerial-underlay"
+const HYBRID_VECTOR_LAYER_TYPES = new Set(["line", "symbol", "circle"])
+const isHybridOverlayLayer = (layer: LayerSpecification) =>
+  HYBRID_VECTOR_LAYER_TYPES.has(layer.type)
+
+const hybridStyle: StyleSpecification = {
+  ...cloneStylePart(libertyVectorStyle),
+  sources: {
+    ...cloneStylePart(libertyVectorStyle.sources),
+    [HYBRID_AERIAL_SOURCE_ID]: cloneStylePart(aerialEsriSource),
+  },
+  layers: [
+    {
+      id: HYBRID_AERIAL_LAYER_ID,
+      type: "raster",
+      source: HYBRID_AERIAL_SOURCE_ID,
+    },
+    ...libertyVectorStyle.layers
+      .filter(isHybridOverlayLayer)
+      .map((layer) => cloneStylePart(layer)),
+  ],
+}
+
 export const emptyFeatureCollection: FeatureCollection = {
   type: "FeatureCollection",
   features: [],
@@ -133,10 +172,16 @@ layersConfig.set(STANDARD_LAYER_ID, {
 
 layersConfig.set(LIBERTY_LAYER_ID, {
   specification: { type: "vector" },
-  // @ts-expect-error
-  vectorStyle: libertyStyle,
+  vectorStyle: libertyVectorStyle,
   isBaseLayer: true,
   layerCode: LIBERTY_LAYER_CODE,
+})
+
+layersConfig.set(HYBRID_LAYER_ID, {
+  specification: { type: "vector" },
+  vectorStyle: hybridStyle,
+  isBaseLayer: true,
+  layerCode: HYBRID_LAYER_CODE,
 })
 
 layersConfig.set(CYCLOSM_LAYER_ID, {
@@ -217,15 +262,7 @@ layersConfig.set(HOT_LAYER_ID, {
 
 // Overlay layers
 layersConfig.set(AERIAL_LAYER_ID, {
-  specification: {
-    type: "raster",
-    maxzoom: 23,
-    tiles: [
-      "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
-    ],
-    tileSize: 256,
-    attribution: aerialEsriCredit,
-  },
+  specification: aerialEsriSource,
   layerOptions: {
     paint: {
       // @ts-expect-error loaded from storage

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -9,6 +9,7 @@ map:
   zoom_out_to_see_the_world_in_3d: Zoom out to see the world in 3D
   layers:
     esri_world_imagery: Esri World Imagery
+    hybrid_aerial: Hybrid Aerial
     liberty: Liberty
     vector: Vector
   overlays:


### PR DESCRIPTION
## Summary
- adds a dedicated Hybrid Aerial base layer
- uses Esri imagery as a full-opacity underlay
- overlays Liberty line/symbol/circle layers only, so landuse/fill layers do not cover the imagery
- adds the layer to the sidebar with the existing aerial thumbnail

Fixes #182

## Verification
- esbuild transform check for `app/views/lib/map/layers/layers.ts`
- esbuild transform check for `app/views/index/sidebar/layers.tsx`

/claim #182