### PR TITLE
Add founders seal logo assets

### DIFF
--- a/resources/founders-seal-wordmark-dark.svg
+++ b/resources/founders-seal-wordmark-dark.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="320" viewBox="0 0 960 320" role="img" aria-labelledby="title desc">
+  <title id="title">OSM-NG Founders wordmark dark</title>
+  <desc id="desc">A dark horizontal founders recognition wordmark based on the OpenStreetMap-NG folded map logo.</desc>
+  <defs>
+    <linearGradient id="mapLight" x1="62" y1="42" x2="245" y2="222" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#def4bd"/>
+      <stop offset="0.45" stop-color="#bfe894"/>
+      <stop offset="1" stop-color="#87ca79"/>
+    </linearGradient>
+    <linearGradient id="gold" x1="70" y1="25" x2="240" y2="282" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fff0a8"/>
+      <stop offset="0.48" stop-color="#d4a331"/>
+      <stop offset="1" stop-color="#8d661c"/>
+    </linearGradient>
+    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="150%">
+      <feDropShadow dx="0" dy="10" stdDeviation="10" flood-color="#000000" flood-opacity="0.32"/>
+    </filter>
+    <clipPath id="sealClip">
+      <circle cx="160" cy="144" r="104"/>
+    </clipPath>
+  </defs>
+
+  <rect width="960" height="320" rx="36" fill="#172316"/>
+  <g filter="url(#softShadow)">
+    <circle cx="160" cy="160" r="134" fill="#f7fbf1" stroke="url(#gold)" stroke-width="12"/>
+    <g clip-path="url(#sealClip)">
+      <path d="M60 60c31 8 56-9 87-2 35 8 58-2 107-15l9 181c-42 17-71 4-107 12-34 7-58 20-98 8z" fill="url(#mapLight)"/>
+      <path d="M54 128c37 10 62-4 91 5 32 11 56-7 110-12" fill="none" stroke="#6fb36e" stroke-width="2" stroke-opacity="0.3"/>
+      <path d="M45 169c28-12 45-19 72-13 31 8 38 25 71 11 22-10 38-6 74 1" fill="none" stroke="#7faee5" stroke-width="6" stroke-opacity="0.42" stroke-linecap="round"/>
+      <path d="M84 65l21 49-18 24 33 23 39-11 19 46 43-13 23 37" fill="none" stroke="#c95757" stroke-width="5" stroke-opacity="0.7" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    <text x="160" y="167" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="76" font-weight="900" letter-spacing="0" fill="#ffffff" stroke="#0d1710" stroke-width="8" paint-order="stroke">NG</text>
+    <text x="160" y="167" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="76" font-weight="900" letter-spacing="0" fill="#ffffff">NG</text>
+    <path d="M75 236h170l-17 42H92z" fill="url(#gold)" stroke="#7a5716" stroke-width="3" stroke-linejoin="round"/>
+    <text x="160" y="265" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="23" font-weight="800" letter-spacing="0" fill="#1c1407">FOUNDERS</text>
+  </g>
+
+  <text x="335" y="139" font-family="Arial, Helvetica, sans-serif" font-size="58" font-weight="900" letter-spacing="0" fill="#f6fbef">OpenStreetMap-NG</text>
+  <text x="338" y="198" font-family="Arial, Helvetica, sans-serif" font-size="46" font-weight="800" letter-spacing="0" fill="#f0cd66">Founders Group</text>
+  <path d="M340 222h380" stroke="#4f7245" stroke-width="8" stroke-linecap="round"/>
+  <text x="340" y="265" font-family="Arial, Helvetica, sans-serif" font-size="24" font-weight="700" letter-spacing="0" fill="#c8dec0">Recognizing early contributors, donors, testers, and builders</text>
+</svg>

--- a/resources/founders-seal-wordmark.svg
+++ b/resources/founders-seal-wordmark.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="320" viewBox="0 0 960 320" role="img" aria-labelledby="title desc">
+  <title id="title">OSM-NG Founders wordmark</title>
+  <desc id="desc">A horizontal founders recognition wordmark based on the OpenStreetMap-NG folded map logo.</desc>
+  <defs>
+    <linearGradient id="mapLight" x1="62" y1="42" x2="245" y2="222" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#def4bd"/>
+      <stop offset="0.45" stop-color="#bfe894"/>
+      <stop offset="1" stop-color="#87ca79"/>
+    </linearGradient>
+    <linearGradient id="gold" x1="70" y1="25" x2="240" y2="282" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fff0a8"/>
+      <stop offset="0.48" stop-color="#d4a331"/>
+      <stop offset="1" stop-color="#8d661c"/>
+    </linearGradient>
+    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="150%">
+      <feDropShadow dx="0" dy="8" stdDeviation="8" flood-color="#203019" flood-opacity="0.2"/>
+    </filter>
+    <clipPath id="sealClip">
+      <circle cx="160" cy="144" r="104"/>
+    </clipPath>
+  </defs>
+
+  <rect width="960" height="320" rx="36" fill="#f7fbf1"/>
+  <g filter="url(#softShadow)">
+    <circle cx="160" cy="160" r="134" fill="#ffffff" stroke="url(#gold)" stroke-width="12"/>
+    <g clip-path="url(#sealClip)">
+      <path d="M60 60c31 8 56-9 87-2 35 8 58-2 107-15l9 181c-42 17-71 4-107 12-34 7-58 20-98 8z" fill="url(#mapLight)"/>
+      <path d="M54 128c37 10 62-4 91 5 32 11 56-7 110-12" fill="none" stroke="#6fb36e" stroke-width="2" stroke-opacity="0.3"/>
+      <path d="M45 169c28-12 45-19 72-13 31 8 38 25 71 11 22-10 38-6 74 1" fill="none" stroke="#7faee5" stroke-width="6" stroke-opacity="0.42" stroke-linecap="round"/>
+      <path d="M84 65l21 49-18 24 33 23 39-11 19 46 43-13 23 37" fill="none" stroke="#c95757" stroke-width="5" stroke-opacity="0.7" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    <text x="160" y="167" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="76" font-weight="900" letter-spacing="0" fill="#ffffff" stroke="#0d1710" stroke-width="8" paint-order="stroke">NG</text>
+    <text x="160" y="167" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="76" font-weight="900" letter-spacing="0" fill="#ffffff">NG</text>
+    <path d="M75 236h170l-17 42H92z" fill="url(#gold)" stroke="#7a5716" stroke-width="3" stroke-linejoin="round"/>
+    <text x="160" y="265" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="23" font-weight="800" letter-spacing="0" fill="#1c1407">FOUNDERS</text>
+  </g>
+
+  <text x="335" y="139" font-family="Arial, Helvetica, sans-serif" font-size="58" font-weight="900" letter-spacing="0" fill="#182614">OpenStreetMap-NG</text>
+  <text x="338" y="198" font-family="Arial, Helvetica, sans-serif" font-size="46" font-weight="800" letter-spacing="0" fill="#9a6d1e">Founders Group</text>
+  <path d="M340 222h380" stroke="#b9d7a2" stroke-width="8" stroke-linecap="round"/>
+  <text x="340" y="265" font-family="Arial, Helvetica, sans-serif" font-size="24" font-weight="700" letter-spacing="0" fill="#4a5d43">Recognizing early contributors, donors, testers, and builders</text>
+</svg>

--- a/resources/founders-seal.svg
+++ b/resources/founders-seal.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">OSM-NG Founders seal</title>
+  <desc id="desc">A circular founder recognition seal based on the OpenStreetMap-NG folded map logo.</desc>
+  <defs>
+    <linearGradient id="mapLight" x1="80" y1="70" x2="395" y2="360" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#def4bd"/>
+      <stop offset="0.45" stop-color="#bfe894"/>
+      <stop offset="1" stop-color="#87ca79"/>
+    </linearGradient>
+    <linearGradient id="gold" x1="116" y1="44" x2="396" y2="468" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fff0a8"/>
+      <stop offset="0.48" stop-color="#d4a331"/>
+      <stop offset="1" stop-color="#8d661c"/>
+    </linearGradient>
+    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="150%">
+      <feDropShadow dx="0" dy="10" stdDeviation="10" flood-color="#203019" flood-opacity="0.22"/>
+    </filter>
+    <clipPath id="sealClip">
+      <circle cx="256" cy="238" r="174"/>
+    </clipPath>
+  </defs>
+
+  <circle cx="256" cy="256" r="232" fill="#f7fbf1"/>
+  <circle cx="256" cy="256" r="222" fill="none" stroke="url(#gold)" stroke-width="18"/>
+  <circle cx="256" cy="256" r="194" fill="#ffffff" stroke="#203019" stroke-opacity="0.12" stroke-width="2"/>
+
+  <g clip-path="url(#sealClip)" filter="url(#softShadow)">
+    <path d="M89 98c52 14 93-15 145-3 58 14 96-4 178-25l15 302c-70 28-119 7-178 19-56 12-97 33-164 14z" fill="url(#mapLight)"/>
+    <path d="M82 116c47 14 94-5 139 2 58 9 106-7 197-28" fill="none" stroke="#6fb36e" stroke-width="3" stroke-opacity="0.32"/>
+    <path d="M88 209c61 16 103-7 152 9 53 18 93-12 183-20" fill="none" stroke="#6fb36e" stroke-width="3" stroke-opacity="0.28"/>
+    <path d="M94 321c64 12 112-17 164-8 50 8 92-2 158-18" fill="none" stroke="#6fb36e" stroke-width="3" stroke-opacity="0.26"/>
+    <path d="M148 66c26 76 5 124 24 188 18 59 10 103 1 170" fill="none" stroke="#6aa05e" stroke-width="3" stroke-opacity="0.24"/>
+    <path d="M280 64c-30 61-16 121-37 174-23 59-4 105 4 171" fill="none" stroke="#6aa05e" stroke-width="3" stroke-opacity="0.22"/>
+    <path d="M372 70c-24 69 6 130-7 183-15 61-9 93 13 146" fill="none" stroke="#6aa05e" stroke-width="3" stroke-opacity="0.2"/>
+    <path d="M73 280c47-20 76-32 121-21 51 12 64 42 119 18 37-16 63-10 123 1" fill="none" stroke="#7faee5" stroke-width="9" stroke-opacity="0.42" stroke-linecap="round"/>
+    <path d="M123 105l35 81-29 40 54 38 65-18 31 76 71-21 39 61" fill="none" stroke="#c95757" stroke-width="7" stroke-opacity="0.72" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M282 118c48-6 78 19 75 55-3 45-67 57-101 34-34-24-19-84 26-89z" fill="#7cc96d" fill-opacity="0.3"/>
+    <path d="M212 245c36-8 67 9 70 37 4 35-42 51-75 35-33-16-33-63 5-72z" fill="#7cc96d" fill-opacity="0.25"/>
+  </g>
+
+  <g filter="url(#softShadow)">
+    <circle cx="256" cy="238" r="122" fill="#ffffff" fill-opacity="0.9"/>
+    <path d="M134 238a122 122 0 0 1 244 0" fill="none" stroke="#0d1710" stroke-width="12" stroke-linecap="round"/>
+    <text x="256" y="270" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="122" font-weight="900" letter-spacing="0" fill="#ffffff" stroke="#0d1710" stroke-width="12" paint-order="stroke">NG</text>
+    <text x="256" y="270" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="122" font-weight="900" letter-spacing="0" fill="#ffffff">NG</text>
+  </g>
+
+  <path d="M116 368h280l-28 70H144z" fill="url(#gold)" stroke="#7a5716" stroke-width="5" stroke-linejoin="round"/>
+  <path d="M116 368l-56 24 44 21 40-45z" fill="#b88626" stroke="#7a5716" stroke-width="5" stroke-linejoin="round"/>
+  <path d="M396 368l56 24-44 21-40-45z" fill="#b88626" stroke="#7a5716" stroke-width="5" stroke-linejoin="round"/>
+  <text x="256" y="414" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="38" font-weight="800" letter-spacing="0" fill="#1c1407">FOUNDERS</text>
+</svg>


### PR DESCRIPTION
## Summary
- add a circular `founders-seal.svg` recognition mark based on the existing folded-map + NG visual language
- add light and dark horizontal wordmark variants for places where the badge needs surrounding context
- use a seal/ribbon direction so this is visually distinct from the existing compact badge submissions

## Validation
- XML parsed all three SVG files with PowerShell `[xml]`
- `git diff --check`
- rendered all three SVG files with Chrome headless screenshots for a visual smoke check

Closes #114
/claim #114

If this direction is selected for the listed bounty, payout can go through: https://ko-fi.com/alan363