### PR TITLE
Add built-in GPS trace tiles

### DIFF
--- a/app/controllers/trace_tiles.py
+++ b/app/controllers/trace_tiles.py
@@ -5,7 +5,6 @@ from io import BytesIO
 from math import atan, degrees, log, pi, radians, sinh, tan
 from typing import Annotated
 
-import cython
 from fastapi import APIRouter, HTTPException, Path
 from PIL import Image, ImageDraw
 from shapely import LineString, MultiLineString, Polygon, box, get_coordinates
@@ -66,7 +65,6 @@ async def _tile_response(
     return Response(tile, media_type='image/png', headers=headers)
 
 
-@cython.cfunc
 def _validate_tile(z: int, x: int, y: int):
     limit = 1 << z
     if x >= limit or y >= limit:
@@ -97,12 +95,10 @@ def _tile_bounds(z: int, x: int, y: int):
     )
 
 
-@cython.cfunc
 def _tile_lat(y: int, n: int) -> float:
     return degrees(atan(sinh(pi * (1 - 2 * y / n))))
 
 
-@cython.cfunc
 def _mercator_y(lat: float) -> float:
     return log(tan(pi / 4 + radians(lat) / 2))
 
@@ -138,7 +134,6 @@ def _iter_lines(geometry) -> Iterable[LineString]:
         yield from _iter_lines(geom)
 
 
-@cython.cfunc
 def _project_point(lon: float, lat: float, bounds: _TileBounds):
     x = (lon - bounds.west) / (bounds.east - bounds.west) * _TILE_SIZE
     y = (

--- a/app/controllers/trace_tiles.py
+++ b/app/controllers/trace_tiles.py
@@ -1,0 +1,133 @@
+from collections.abc import Iterable
+from dataclasses import dataclass
+from io import BytesIO
+from math import atan, degrees, log, pi, radians, sinh, tan
+from typing import Annotated
+
+import cython
+from fastapi import APIRouter, HTTPException, Path
+from PIL import Image, ImageDraw
+from shapely import LineString, MultiLineString, Polygon, box, get_coordinates
+from starlette import status
+from starlette.responses import Response
+
+from app.queries.trace_query import TraceQuery
+
+router = APIRouter(prefix='/api/web/traces/tiles')
+
+_TILE_SIZE = 256
+_MAX_ZOOM = 23
+_MAX_TRACES_PER_TILE = 500
+_TRACE_COLOR = (37, 99, 235, 190)
+
+
+@router.get('/lines/{z:int}/{x:int}/{y:int}')
+@router.get('/lines/{z:int}/{x:int}/{y:int}.png')
+async def public_tile(
+    z: Annotated[int, Path(ge=0, le=_MAX_ZOOM)],
+    x: Annotated[int, Path(ge=0)],
+    y: Annotated[int, Path(ge=0)],
+):
+    return await _tile_response(z, x, y)
+
+
+async def _tile_response(
+    z: int,
+    x: int,
+    y: int,
+):
+    _validate_tile(z, x, y)
+
+    headers = {'Cache-Control': 'public, max-age=300'}
+
+    bounds = _tile_bounds(z, x, y)
+    traces = await TraceQuery.find_tile_segments(
+        bounds.geometry,
+        limit=_MAX_TRACES_PER_TILE,
+    )
+    tile = _render_png_tile(traces, bounds)
+    return Response(tile, media_type='image/png', headers=headers)
+
+
+@cython.cfunc
+def _validate_tile(z: int, x: int, y: int):
+    limit = 1 << z
+    if x >= limit or y >= limit:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+
+
+@dataclass(slots=True)
+class _TileBounds:
+    geometry: Polygon
+    west: float
+    east: float
+    north_mercator: float
+    south_mercator: float
+
+
+def _tile_bounds(z: int, x: int, y: int):
+    n = 1 << z
+    west = x / n * 360 - 180
+    east = (x + 1) / n * 360 - 180
+    north = _tile_lat(y, n)
+    south = _tile_lat(y + 1, n)
+    return _TileBounds(
+        geometry=box(west, south, east, north),
+        west=west,
+        east=east,
+        north_mercator=_mercator_y(north),
+        south_mercator=_mercator_y(south),
+    )
+
+
+@cython.cfunc
+def _tile_lat(y: int, n: int) -> float:
+    return degrees(atan(sinh(pi * (1 - 2 * y / n))))
+
+
+@cython.cfunc
+def _mercator_y(lat: float) -> float:
+    return log(tan(pi / 4 + radians(lat) / 2))
+
+
+def _render_png_tile(traces: list[MultiLineString], bounds: _TileBounds) -> bytes:
+    image = Image.new('RGBA', (_TILE_SIZE, _TILE_SIZE), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(image)
+
+    for segments in traces:
+        clipped = segments.intersection(bounds.geometry)
+        for line in _iter_lines(clipped):
+            coords = get_coordinates(line)
+            if len(coords) < 2:
+                continue
+            points = [_project_point(lon, lat, bounds) for lon, lat in coords]
+            draw.line(points, fill=_TRACE_COLOR, width=2)
+
+    buffer = BytesIO()
+    image.save(buffer, format='PNG', optimize=True)
+    return buffer.getvalue()
+
+
+def _iter_lines(geometry) -> Iterable[LineString]:
+    if isinstance(geometry, LineString):
+        yield geometry
+        return
+
+    if isinstance(geometry, MultiLineString):
+        yield from geometry.geoms
+        return
+
+    geoms = getattr(geometry, 'geoms', ())
+    for geom in geoms:
+        yield from _iter_lines(geom)
+
+
+@cython.cfunc
+def _project_point(lon: float, lat: float, bounds: _TileBounds):
+    x = (lon - bounds.west) / (bounds.east - bounds.west) * _TILE_SIZE
+    y = (
+        (bounds.north_mercator - _mercator_y(lat))
+        / (bounds.north_mercator - bounds.south_mercator)
+        * _TILE_SIZE
+    )
+    return x, y

--- a/app/controllers/trace_tiles.py
+++ b/app/controllers/trace_tiles.py
@@ -1,3 +1,4 @@
+from asyncio import TaskGroup
 from collections.abc import Iterable
 from dataclasses import dataclass
 from io import BytesIO
@@ -13,7 +14,7 @@ from starlette.responses import Response
 
 from app.queries.trace_query import TraceQuery
 
-router = APIRouter(prefix='/api/web/traces/tiles')
+router = APIRouter()
 
 _TILE_SIZE = 256
 _MAX_ZOOM = 23
@@ -21,8 +22,12 @@ _MAX_TRACES_PER_TILE = 500
 _TRACE_COLOR = (37, 99, 235, 190)
 
 
+@router.get('/gps/lines/{z:int}/{x:int}/{y:int}')
+@router.get('/gps/lines/{z:int}/{x:int}/{y:int}.png')
 @router.get('/lines/{z:int}/{x:int}/{y:int}')
 @router.get('/lines/{z:int}/{x:int}/{y:int}.png')
+@router.get('/api/web/traces/tiles/lines/{z:int}/{x:int}/{y:int}')
+@router.get('/api/web/traces/tiles/lines/{z:int}/{x:int}/{y:int}.png')
 async def public_tile(
     z: Annotated[int, Path(ge=0, le=_MAX_ZOOM)],
     x: Annotated[int, Path(ge=0)],
@@ -41,11 +46,23 @@ async def _tile_response(
     headers = {'Cache-Control': 'public, max-age=300'}
 
     bounds = _tile_bounds(z, x, y)
-    traces = await TraceQuery.find_tile_segments(
-        bounds.geometry,
-        limit=_MAX_TRACES_PER_TILE,
-    )
-    tile = _render_png_tile(traces, bounds)
+    async with TaskGroup() as tg:
+        identifiable_t = tg.create_task(
+            TraceQuery.find_tile_segments(
+                bounds.geometry,
+                identifiable_trackable=True,
+                limit=_MAX_TRACES_PER_TILE,
+            )
+        )
+        anonymous_t = tg.create_task(
+            TraceQuery.find_tile_segments(
+                bounds.geometry,
+                identifiable_trackable=False,
+                limit=_MAX_TRACES_PER_TILE,
+            )
+        )
+
+    tile = _render_png_tile([*identifiable_t.result(), *anonymous_t.result()], bounds)
     return Response(tile, media_type='image/png', headers=headers)
 
 
@@ -95,8 +112,7 @@ def _render_png_tile(traces: list[MultiLineString], bounds: _TileBounds) -> byte
     draw = ImageDraw.Draw(image)
 
     for segments in traces:
-        clipped = segments.intersection(bounds.geometry)
-        for line in _iter_lines(clipped):
+        for line in _iter_lines(segments):
             coords = get_coordinates(line)
             if len(coords) < 2:
                 continue

--- a/app/controllers/trace_tiles.py
+++ b/app/controllers/trace_tiles.py
@@ -3,15 +3,20 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from io import BytesIO
 from math import atan, degrees, log, pi, radians, sinh, tan
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import APIRouter, HTTPException, Path
 from PIL import Image, ImageDraw
+from psycopg import IsolationLevel
+from psycopg.sql import SQL
+from psycopg.sql import Literal as PgLiteral
 from shapely import LineString, MultiLineString, Polygon, box, get_coordinates
 from starlette import status
 from starlette.responses import Response
 
-from app.queries.trace_query import TraceQuery
+from app.db import db
+from app.lib.geo_utils import polygon_to_h3
+from app.queries.timescaledb_query import TimescaleDBQuery
 
 router = APIRouter()
 
@@ -47,14 +52,14 @@ async def _tile_response(
     bounds = _tile_bounds(z, x, y)
     async with TaskGroup() as tg:
         identifiable_t = tg.create_task(
-            TraceQuery.find_tile_segments(
+            _find_tile_segments(
                 bounds.geometry,
                 identifiable_trackable=True,
                 limit=_MAX_TRACES_PER_TILE,
             )
         )
         anonymous_t = tg.create_task(
-            TraceQuery.find_tile_segments(
+            _find_tile_segments(
                 bounds.geometry,
                 identifiable_trackable=False,
                 limit=_MAX_TRACES_PER_TILE,
@@ -93,6 +98,66 @@ def _tile_bounds(z: int, x: int, y: int):
         north_mercator=_mercator_y(north),
         south_mercator=_mercator_y(south),
     )
+
+
+async def _find_tile_segments(
+    geometry: Polygon,
+    *,
+    identifiable_trackable: bool,
+    limit: int,
+) -> list[MultiLineString]:
+    """Find only trace geometry needed for a public GPS tile."""
+    params: dict[str, Any] = {
+        'h3_cells': polygon_to_h3(geometry, max_resolution=11),
+        'visibility': (
+            ['identifiable', 'trackable']
+            if identifiable_trackable
+            else ['public', 'private']
+        ),
+        'limit': limit,
+    }
+
+    async with db(isolation_level=IsolationLevel.REPEATABLE_READ) as conn:
+        query = SQL("""
+            /*+ BitmapScan(trace trace_segments_idx) */
+            {query}
+            LIMIT %(limit)s
+        """).format(
+            query=SQL(' UNION ALL ').join([
+                SQL("""(
+                    SELECT segments FROM trace
+                    WHERE h3_points_to_cells_range(segments, 11) && %(h3_cells)s::h3index[]
+                    AND visibility = ANY(%(visibility)s)
+                    AND id BETWEEN {chunk_start} AND {chunk_end}
+                    ORDER BY id DESC
+                )""").format(
+                    chunk_start=PgLiteral(chunk_start),
+                    chunk_end=PgLiteral(chunk_end),
+                )
+                for chunk_start, chunk_end in await TimescaleDBQuery.get_chunks_ranges(
+                    'trace', conn
+                )
+            ])
+        )
+
+        async with await conn.execute(query, params) as r:
+            segments_list = [segments for (segments,) in await r.fetchall()]
+
+    if not segments_list:
+        return []
+
+    lines = [
+        line
+        for segments in segments_list
+        for line in _iter_lines(segments.intersection(geometry))
+    ]
+    if not lines:
+        return []
+
+    if identifiable_trackable:
+        return [MultiLineString([line]) for line in lines]
+
+    return [MultiLineString(lines)]
 
 
 def _tile_lat(y: int, n: int) -> float:

--- a/app/controllers/trace_tiles.py
+++ b/app/controllers/trace_tiles.py
@@ -15,7 +15,7 @@ from starlette import status
 from starlette.responses import Response
 
 from app.db import db
-from app.lib.geo_utils import polygon_to_h3
+from app.lib.geo.h3 import polygon_to_h3
 from app.queries.timescaledb_query import TimescaleDBQuery
 
 router = APIRouter()

--- a/app/queries/trace_query.py
+++ b/app/queries/trace_query.py
@@ -1,4 +1,3 @@
-from collections.abc import Iterable
 from string.templatelib import Template
 from typing import Any
 
@@ -10,7 +9,6 @@ from psycopg.rows import dict_row
 from psycopg.sql import SQL, Composable
 from psycopg.sql import Literal as PgLiteral
 from shapely import (
-    LineString,
     MultiLineString,
     MultiPoint,
     MultiPolygon,
@@ -277,68 +275,6 @@ class TraceQuery:
         return [simplified]
 
     @staticmethod
-    async def find_tile_segments(
-        geometry: Polygon,
-        *,
-        identifiable_trackable: cython.bint,
-        limit: int,
-    ) -> list[MultiLineString]:
-        """Find trace segments intersecting a map tile geometry."""
-        params: dict[str, Any] = {
-            'h3_cells': polygon_to_h3(geometry, max_resolution=11),
-            'visibility': (
-                ['identifiable', 'trackable']
-                if identifiable_trackable
-                else ['public', 'private']
-            ),
-            'limit': limit,
-        }
-
-        async with db(isolation_level=IsolationLevel.REPEATABLE_READ) as conn:
-            query = SQL("""
-                /*+ BitmapScan(trace trace_segments_idx) */
-                {query}
-                LIMIT %(limit)s
-            """).format(
-                query=SQL(' UNION ALL ').join([
-                    SQL("""(
-                        SELECT segments FROM trace
-                        WHERE h3_points_to_cells_range(segments, 11) && %(h3_cells)s::h3index[]
-                        AND visibility = ANY(%(visibility)s)
-                        AND id BETWEEN {chunk_start} AND {chunk_end}
-                        ORDER BY id DESC
-                    )""").format(
-                        chunk_start=PgLiteral(chunk_start),
-                        chunk_end=PgLiteral(chunk_end),
-                    )
-                    for chunk_start, chunk_end in await TimescaleDBQuery.get_chunks_ranges(
-                        'trace', conn
-                    )
-                ])
-            )
-
-            async with await conn.execute(query, params) as r:
-                segments_list: list[MultiLineString] = [
-                    segments for (segments,) in await r.fetchall()
-                ]
-
-        if not segments_list:
-            return []
-
-        lines = [
-            line
-            for segments in segments_list
-            for line in _iter_line_segments(segments.intersection(geometry))
-        ]
-        if not lines:
-            return []
-
-        if identifiable_trackable:
-            return [MultiLineString([line]) for line in lines]
-
-        return [MultiLineString(lines)]
-
-    @staticmethod
     async def resolve_coords(
         traces: list[Trace],
         *,
@@ -393,17 +329,3 @@ class TraceQuery:
                     )
 
                 trace_map[trace_id]['coords'] = coords
-
-
-def _iter_line_segments(geometry) -> Iterable[LineString]:
-    if isinstance(geometry, LineString):
-        yield geometry
-        return
-
-    if isinstance(geometry, MultiLineString):
-        yield from geometry.geoms
-        return
-
-    geoms = getattr(geometry, 'geoms', ())
-    for geom in geoms:
-        yield from _iter_line_segments(geom)

--- a/app/queries/trace_query.py
+++ b/app/queries/trace_query.py
@@ -275,6 +275,32 @@ class TraceQuery:
         return [simplified]
 
     @staticmethod
+    async def find_tile_segments(
+        geometry: Polygon,
+        *,
+        limit: int,
+    ) -> list[MultiLineString]:
+        """Find trace segments intersecting a map tile geometry."""
+        where = [
+            SQL('h3_points_to_cells_range(segments, 11) && %(h3_cells)s::h3index[]')
+        ]
+        params: dict[str, Any] = {
+            'h3_cells': polygon_to_h3(geometry, max_resolution=11),
+            'limit': limit,
+        }
+
+        query = SQL("""
+            /*+ BitmapScan(trace trace_segments_idx) */
+            SELECT segments FROM trace
+            WHERE {where}
+            ORDER BY id DESC
+            LIMIT %(limit)s
+        """).format(where=SQL(' AND ').join(where))
+
+        async with db() as conn, await conn.execute(query, params) as r:
+            return [segments for (segments,) in await r.fetchall()]
+
+    @staticmethod
     async def resolve_coords(
         traces: list[Trace],
         *,

--- a/app/queries/trace_query.py
+++ b/app/queries/trace_query.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from string.templatelib import Template
 from typing import Any
 
@@ -9,6 +10,7 @@ from psycopg.rows import dict_row
 from psycopg.sql import SQL, Composable
 from psycopg.sql import Literal as PgLiteral
 from shapely import (
+    LineString,
     MultiLineString,
     MultiPoint,
     MultiPolygon,
@@ -278,27 +280,63 @@ class TraceQuery:
     async def find_tile_segments(
         geometry: Polygon,
         *,
+        identifiable_trackable: cython.bint,
         limit: int,
     ) -> list[MultiLineString]:
         """Find trace segments intersecting a map tile geometry."""
-        where = [
-            SQL('h3_points_to_cells_range(segments, 11) && %(h3_cells)s::h3index[]')
-        ]
         params: dict[str, Any] = {
             'h3_cells': polygon_to_h3(geometry, max_resolution=11),
+            'visibility': (
+                ['identifiable', 'trackable']
+                if identifiable_trackable
+                else ['public', 'private']
+            ),
             'limit': limit,
         }
 
-        query = SQL("""
-            /*+ BitmapScan(trace trace_segments_idx) */
-            SELECT segments FROM trace
-            WHERE {where}
-            ORDER BY id DESC
-            LIMIT %(limit)s
-        """).format(where=SQL(' AND ').join(where))
+        async with db(isolation_level=IsolationLevel.REPEATABLE_READ) as conn:
+            query = SQL("""
+                /*+ BitmapScan(trace trace_segments_idx) */
+                {query}
+                LIMIT %(limit)s
+            """).format(
+                query=SQL(' UNION ALL ').join([
+                    SQL("""(
+                        SELECT segments FROM trace
+                        WHERE h3_points_to_cells_range(segments, 11) && %(h3_cells)s::h3index[]
+                        AND visibility = ANY(%(visibility)s)
+                        AND id BETWEEN {chunk_start} AND {chunk_end}
+                        ORDER BY id DESC
+                    )""").format(
+                        chunk_start=PgLiteral(chunk_start),
+                        chunk_end=PgLiteral(chunk_end),
+                    )
+                    for chunk_start, chunk_end in await TimescaleDBQuery.get_chunks_ranges(
+                        'trace', conn
+                    )
+                ])
+            )
 
-        async with db() as conn, await conn.execute(query, params) as r:
-            return [segments for (segments,) in await r.fetchall()]
+            async with await conn.execute(query, params) as r:
+                segments_list: list[MultiLineString] = [
+                    segments for (segments,) in await r.fetchall()
+                ]
+
+        if not segments_list:
+            return []
+
+        lines = [
+            line
+            for segments in segments_list
+            for line in _iter_line_segments(segments.intersection(geometry))
+        ]
+        if not lines:
+            return []
+
+        if identifiable_trackable:
+            return [MultiLineString([line]) for line in lines]
+
+        return [MultiLineString(lines)]
 
     @staticmethod
     async def resolve_coords(
@@ -355,3 +393,17 @@ class TraceQuery:
                     )
 
                 trace_map[trace_id]['coords'] = coords
+
+
+def _iter_line_segments(geometry) -> Iterable[LineString]:
+    if isinstance(geometry, LineString):
+        yield geometry
+        return
+
+    if isinstance(geometry, MultiLineString):
+        yield from geometry.geoms
+        return
+
+    geoms = getattr(geometry, 'geoms', ())
+    for geom in geoms:
+        yield from _iter_line_segments(geom)

--- a/app/views/map/layers/layers.ts
+++ b/app/views/map/layers/layers.ts
@@ -239,7 +239,7 @@ layersConfig.set(AERIAL_LAYER_ID, {
 layersConfig.set(GPS_LAYER_ID, {
   specification: {
     type: "raster",
-    tiles: ["/api/web/traces/tiles/lines/{z}/{x}/{y}.png"],
+    tiles: ["/gps/lines/{z}/{x}/{y}.png"],
     tileSize: 256,
   },
   layerCode: GPS_LAYER_CODE,

--- a/app/views/map/layers/layers.ts
+++ b/app/views/map/layers/layers.ts
@@ -239,8 +239,7 @@ layersConfig.set(AERIAL_LAYER_ID, {
 layersConfig.set(GPS_LAYER_ID, {
   specification: {
     type: "raster",
-    // This layer has no zoom limits
-    tiles: ["https://gps.tile.openstreetmap.org/lines/{z}/{x}/{y}.png"],
+    tiles: ["/api/web/traces/tiles/lines/{z}/{x}/{y}.png"],
     tileSize: 256,
   },
   layerCode: GPS_LAYER_CODE,

--- a/tests/controllers/test_trace_tiles.py
+++ b/tests/controllers/test_trace_tiles.py
@@ -12,8 +12,8 @@ from app.models.proto.trace_pb2 import (
 )
 
 _GPX_BYTES = Path('tests/data/8473730.gpx').read_bytes()
-_TRACE_TILE = '/api/web/traces/tiles/lines/14/9141/5422.png'
-_TRACE_TILE_DEFAULT_FORMAT = '/api/web/traces/tiles/lines/14/9141/5422'
+_TRACE_TILE = '/gps/lines/14/9141/5422.png'
+_TRACE_TILE_DEFAULT_FORMAT = '/gps/lines/14/9141/5422'
 _PNG_SIGNATURE = b'\x89PNG\r\n\x1a\n'
 
 

--- a/tests/controllers/test_trace_tiles.py
+++ b/tests/controllers/test_trace_tiles.py
@@ -37,7 +37,7 @@ async def _upload_trace(client: AsyncClient, visibility: int):
 
 def _has_visible_pixel(content: bytes):
     image = Image.open(BytesIO(content)).convert('RGBA')
-    return any(alpha for *_, alpha in image.getdata())
+    return image.getchannel('A').getbbox() is not None
 
 
 async def test_public_trace_tile(client: AsyncClient):

--- a/tests/controllers/test_trace_tiles.py
+++ b/tests/controllers/test_trace_tiles.py
@@ -1,0 +1,57 @@
+from io import BytesIO
+from pathlib import Path
+
+from httpx import AsyncClient
+from PIL import Image
+
+from app.models.proto.trace_pb2 import (
+    Metadata,
+    UploadRequest,
+    UploadResponse,
+    Visibility,
+)
+
+_GPX_BYTES = Path('tests/data/8473730.gpx').read_bytes()
+_TRACE_TILE = '/api/web/traces/tiles/lines/14/9141/5422.png'
+_TRACE_TILE_DEFAULT_FORMAT = '/api/web/traces/tiles/lines/14/9141/5422'
+_PNG_SIGNATURE = b'\x89PNG\r\n\x1a\n'
+
+
+async def _upload_trace(client: AsyncClient, visibility: int):
+    r = await client.post(
+        '/rpc/trace.Service/Upload',
+        headers={'Content-Type': 'application/proto'},
+        content=UploadRequest(
+            file=_GPX_BYTES,
+            metadata=Metadata(
+                name='trace-tile-test.gpx',
+                description='Trace tile test',
+                tags=['trace-tile-test'],
+                visibility=visibility,
+            ),
+        ).SerializeToString(),
+    )
+    assert r.is_success, r.text
+    return int(UploadResponse.FromString(r.content).id)
+
+
+def _has_visible_pixel(content: bytes):
+    image = Image.open(BytesIO(content)).convert('RGBA')
+    return any(alpha for *_, alpha in image.getdata())
+
+
+async def test_public_trace_tile(client: AsyncClient):
+    client.headers['Authorization'] = 'User user1'
+    await _upload_trace(client, Visibility.private)
+    client.headers.pop('Authorization')
+
+    r = await client.get(_TRACE_TILE)
+
+    assert r.is_success, r.text
+    assert r.headers['Content-Type'] == 'image/png'
+    assert r.content.startswith(_PNG_SIGNATURE)
+    assert _has_visible_pixel(r.content)
+
+    r_default = await client.get(_TRACE_TILE_DEFAULT_FORMAT)
+    assert r_default.is_success, r_default.text
+    assert r_default.content == r.content


### PR DESCRIPTION
Closes #108.

This adds a built-in transparent PNG GPS trace tile renderer so OSM-NG can serve `/gps/lines/{z}/{x}/{y}.png` locally instead of depending on `gps.tile.openstreetmap.org`.

## Summary
- Add `/gps/lines/{z}/{x}/{y}` and `/gps/lines/{z}/{x}/{y}.png` tile endpoints, plus compatibility aliases for `/lines/...` and the previous `/api/web/traces/tiles/lines/...` path.
- Switch the GPS map layer to the built-in `/gps/lines/...` endpoint.
- Use a tile-specific query path that fetches only trace geometries instead of full trace rows.
- Preserve the existing trackpoints visibility split: `identifiable`/`trackable` traces are queried separately from anonymous `public`/`private` traces.
- Render intersecting trace linework into transparent PNG tiles.
- Add controller coverage that uploads a GPX trace and verifies the matching tile returns a non-empty PNG.

## Difference from #232
I noticed #232 after opening this draft. This PR takes a similar high-level approach, but the updated implementation is intentionally narrower in the data it loads: it selects only `segments`, keeps the existing TimescaleDB chunk-range pattern, and applies the same visibility grouping used by `/api/0.6/trackpoints` before rendering. That should make it easier to review the privacy boundary and avoid carrying metadata/timestamps through the tile path.

## Testing
- `python3 -m py_compile app/controllers/trace_tiles.py tests/controllers/test_trace_tiles.py`
- `git diff --check`