### PR TITLE
Reject repeated null island edit uploads

### DIFF
--- a/app/exceptions/diff_mixin.py
+++ b/app/exceptions/diff_mixin.py
@@ -15,9 +15,13 @@ class DiffExceptionsMixin:
         raise NotImplementedError
 
     @abstractmethod
-    def diff_create_bad_id(self, element: 'ElementInit') -> NoReturn:
+    def diff_create_bad_id(self, element: ElementInit) -> NoReturn:
         raise NotImplementedError
 
     @abstractmethod
-    def diff_update_bad_version(self, element: 'ElementInit') -> NoReturn:
+    def diff_null_island(self) -> NoReturn:
+        raise NotImplementedError
+
+    @abstractmethod
+    def diff_update_bad_version(self, element: ElementInit) -> NoReturn:
         raise NotImplementedError

--- a/app/exceptions06/diff_mixin.py
+++ b/app/exceptions06/diff_mixin.py
@@ -26,7 +26,7 @@ class DiffExceptions06Mixin(DiffExceptionsMixin):
         )
 
     @override
-    def diff_create_bad_id(self, element: 'ElementInit'):
+    def diff_create_bad_id(self, element: ElementInit):
         type = element_type(element['typed_id'])
         if type == 'node':
             raise APIError(
@@ -47,7 +47,14 @@ class DiffExceptions06Mixin(DiffExceptionsMixin):
             raise NotImplementedError(f'Unsupported element type {type!r}')
 
     @override
-    def diff_update_bad_version(self, element: 'ElementInit'):
+    def diff_null_island(self):
+        raise APIError(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail='Changeset uploads may contain at most one node at Null Island (0,0).',
+        )
+
+    @override
+    def diff_update_bad_version(self, element: ElementInit):
         raise APIError(
             status.HTTP_412_PRECONDITION_FAILED,
             detail=f'Update action requires version >= 1, got {element["version"] - 1}',

--- a/app/exceptions06/diff_mixin.py
+++ b/app/exceptions06/diff_mixin.py
@@ -49,7 +49,7 @@ class DiffExceptions06Mixin(DiffExceptionsMixin):
     @override
     def diff_null_island(self):
         raise APIError(
-            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail='Changeset uploads may contain at most one node at Null Island (0,0).',
         )
 

--- a/app/services/optimistic_diff/prepare.py
+++ b/app/services/optimistic_diff/prepare.py
@@ -237,10 +237,13 @@ class OptimisticDiffPrepare:
         )
         self._check_null_island_limit()
 
+        # Keep this validation outside the TaskGroup so APIError is raised
+        # directly instead of being wrapped in an ExceptionGroup.
+        await self._check_null_island_refs()
+
         async with TaskGroup() as tg:
             tg.create_task(self._update_changeset_bounds())
             tg.create_task(self._check_members_remote())
-            tg.create_task(self._check_null_island_refs())
 
     async def _preload_elements_state(self):
         """Preload elements state from the database."""

--- a/app/services/optimistic_diff/prepare.py
+++ b/app/services/optimistic_diff/prepare.py
@@ -6,6 +6,7 @@ from typing import Final, Literal, TypeAlias, assert_never
 
 import cython
 import numpy as np
+from app.models.proto.shared_types import ElementType
 from psycopg import AsyncConnection
 from shapely import Point, bounds, box
 
@@ -14,6 +15,7 @@ from app.lib.changeset_bounds import extend_changeset_bounds
 from app.lib.exceptions_context import raise_for
 from app.models.db.changeset import Changeset, changeset_increase_size
 from app.models.db.element import Element, ElementInit
+from app.models.db.user import user_is_moderator
 from app.models.element import (
     TYPED_ELEMENT_ID_NODE_MAX,
     TYPED_ELEMENT_ID_NODE_MIN,
@@ -21,7 +23,6 @@ from app.models.element import (
     TYPED_ELEMENT_ID_RELATION_MIN,
     TypedElementId,
 )
-from app.models.proto.shared_types import ElementType
 from app.models.types import SequenceId
 from app.queries.changeset_bounds_query import ChangesetBoundsQuery
 from app.queries.changeset_query import ChangesetQuery
@@ -101,6 +102,21 @@ class OptimisticDiffPrepare:
     Changeset bounding box set of element refs.
     """
 
+    _null_island_node_refs: set[TypedElementId]
+    """
+    Local set of current visible node refs at Null Island.
+    """
+
+    _null_island_check_refs: set[TypedElementId]
+    """
+    Remote node refs that must be loaded before final Null Island validation.
+    """
+
+    _skip_null_island_check: bool
+    """
+    Whether Null Island validation should be skipped for the current user.
+    """
+
     def __init__(self, conn: AsyncConnection, elements: list[ElementInit], /):
         self.conn = conn
         self.apply_elements = []
@@ -112,6 +128,9 @@ class OptimisticDiffPrepare:
         self._reference_override = defaultdict(set)
         self._bbox_points = []
         self._bbox_refs = set()
+        self._null_island_node_refs = set()
+        self._null_island_check_refs = set()
+        self._skip_null_island_check = False
 
     async def prepare(self):
         await self._preload_changeset()
@@ -209,15 +228,19 @@ class OptimisticDiffPrepare:
             else:
                 entry.current = element
 
+            self._push_null_island_info(element, type)
+
         self._update_changeset_size(
             num_create=num_create,
             num_modify=num_modify,
             num_delete=num_delete,
         )
+        self._check_null_island_limit()
 
         async with TaskGroup() as tg:
             tg.create_task(self._update_changeset_bounds())
             tg.create_task(self._check_members_remote())
+            tg.create_task(self._check_null_island_refs())
 
     async def _preload_elements_state(self):
         """Preload elements state from the database."""
@@ -437,6 +460,33 @@ class OptimisticDiffPrepare:
             assert point is not None, f'Node {typed_id} point must be set'
             bbox_points.append(point)
 
+    def _push_null_island_info(self, element: ElementInit, element_type: ElementType):
+        """Collect current Null Island nodes affected by this diff."""
+        if self._skip_null_island_check or not element['visible']:
+            return
+
+        if element_type == 'node':
+            if _is_null_island_point(element['point']):
+                self._null_island_node_refs.add(element['typed_id'])
+            return
+
+        if element_type != 'way':
+            return
+
+        members = element['members']
+        if members is None:
+            return
+
+        element_state: dict[TypedElementId, ElementStateEntry] = self.element_state
+        for node_ref in members:
+            entry = element_state.get(node_ref)
+            if entry is None:
+                self._null_island_check_refs.add(node_ref)
+                continue
+
+            if _is_null_island_point(entry.current['point']):
+                self._null_island_node_refs.add(node_ref)
+
     def _push_bbox_relation_info(
         self,
         prev: ElementInit | None,
@@ -528,9 +578,11 @@ class OptimisticDiffPrepare:
             raise_for.changeset_not_found(changeset_id)
 
         # Check permissions
-        current_user_id = auth_user(required=True)['id']
+        current_user = auth_user(required=True)
+        current_user_id = current_user['id']
         if changeset['user_id'] != current_user_id:
             raise_for.changeset_access_denied()
+        self._skip_null_island_check = user_is_moderator(current_user)
 
         # Check if changeset is closed
         if changeset['closed_at'] is not None:
@@ -612,6 +664,30 @@ class OptimisticDiffPrepare:
                 bounds_arr[:, 3].max(),
             )
 
+    def _check_null_island_limit(self):
+        if not self._skip_null_island_check and len(self._null_island_node_refs) >= 2:
+            raise_for.diff_null_island()
+
+    async def _check_null_island_refs(self):
+        """Load remote way members and enforce the Null Island node limit."""
+        if self._skip_null_island_check or not self._null_island_check_refs:
+            return
+
+        node_refs = list(self._null_island_check_refs - self._null_island_node_refs)
+        if not node_refs:
+            return
+
+        elements = await ElementQuery.find_by_refs(
+            node_refs,
+            at_sequence_id=self.at_sequence_id,
+            limit=None,
+        )
+        for element in elements:
+            if _is_null_island_point(element['point']):
+                self._null_island_node_refs.add(element['typed_id'])
+
+        self._check_null_island_limit()
+
     async def _check_members_remote(self):
         """Check if the members exist and are visible using the database."""
         elements_check_members_remote = self._elements_check_members_remote
@@ -629,3 +705,7 @@ class OptimisticDiffPrepare:
         hidden_ref = next(iter(hidden_refs))
         parent_typed_id = elements_check_members_remote[hidden_ref]
         raise_for.element_member_not_found(parent_typed_id, hidden_ref)
+
+
+def _is_null_island_point(point: Point | None):
+    return point is not None and point.x == 0 and point.y == 0

--- a/app/services/optimistic_diff/prepare.py
+++ b/app/services/optimistic_diff/prepare.py
@@ -228,13 +228,12 @@ class OptimisticDiffPrepare:
             else:
                 entry.current = element
 
-            self._push_null_island_info(element, type)
-
         self._update_changeset_size(
             num_create=num_create,
             num_modify=num_modify,
             num_delete=num_delete,
         )
+        self._collect_null_island_info()
         self._check_null_island_limit()
 
         # Keep this validation outside the TaskGroup so APIError is raised
@@ -463,32 +462,42 @@ class OptimisticDiffPrepare:
             assert point is not None, f'Node {typed_id} point must be set'
             bbox_points.append(point)
 
-    def _push_null_island_info(self, element: ElementInit, element_type: ElementType):
-        """Collect current Null Island nodes affected by this diff."""
-        if self._skip_null_island_check or not element['visible']:
+    def _collect_null_island_info(self):
+        """Collect final visible Null Island nodes affected by this diff."""
+        if self._skip_null_island_check:
             return
 
-        if element_type == 'node':
-            if _is_null_island_point(element['point']):
-                self._null_island_node_refs.add(element['typed_id'])
-            return
-
-        if element_type != 'way':
-            return
-
-        members = element['members']
-        if members is None:
-            return
+        self._null_island_node_refs.clear()
+        self._null_island_check_refs.clear()
 
         element_state: dict[TypedElementId, ElementStateEntry] = self.element_state
-        for node_ref in members:
-            entry = element_state.get(node_ref)
-            if entry is None:
-                self._null_island_check_refs.add(node_ref)
+        for entry in element_state.values():
+            element = entry.current
+            if not element['visible']:
                 continue
 
-            if _is_null_island_point(entry.current['point']):
-                self._null_island_node_refs.add(node_ref)
+            type = element_type(element['typed_id'])
+            if type == 'node':
+                if _is_null_island_point(element['point']):
+                    self._null_island_node_refs.add(element['typed_id'])
+                continue
+
+            if type != 'way':
+                continue
+
+            members = element['members']
+            if members is None:
+                continue
+
+            for node_ref in members:
+                member_entry = element_state.get(node_ref)
+                if member_entry is None:
+                    self._null_island_check_refs.add(node_ref)
+                    continue
+
+                member = member_entry.current
+                if member['visible'] and _is_null_island_point(member['point']):
+                    self._null_island_node_refs.add(node_ref)
 
     def _push_bbox_relation_info(
         self,

--- a/tests/controllers/test_api06_changeset.py
+++ b/tests/controllers/test_api06_changeset.py
@@ -199,7 +199,7 @@ async def test_changeset_upload_rejects_multiple_null_island_nodes(
             }
         }),
     )
-    assert r.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, r.text
+    assert r.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT, r.text
 
 
 @pytest.mark.parametrize('include', [True, False])

--- a/tests/controllers/test_api06_changeset.py
+++ b/tests/controllers/test_api06_changeset.py
@@ -165,6 +165,43 @@ async def test_changeset_upload(client: AsyncClient):
     )
 
 
+async def test_changeset_upload_rejects_multiple_null_island_nodes(
+    client: AsyncClient,
+):
+    client.headers['Authorization'] = 'User user1'
+
+    r = await client.put(
+        '/api/0.6/changeset/create',
+        content=XMLToDict.unparse({
+            'osm': {
+                'changeset': {
+                    'tag': [
+                        {
+                            '@k': 'created_by',
+                            '@v': test_changeset_upload_rejects_multiple_null_island_nodes.__name__,
+                        }
+                    ]
+                }
+            }
+        }),
+    )
+    assert r.is_success, r.text
+    changeset_id = int(r.text)
+
+    r = await client.post(
+        f'/api/0.6/changeset/{changeset_id}/upload',
+        content=XMLToDict.unparse({
+            'osmChange': {
+                'create': [
+                    ('node', {'@id': -1, '@lat': 0, '@lon': 0}),
+                    ('node', {'@id': -2, '@lat': 0, '@lon': 0}),
+                ]
+            }
+        }),
+    )
+    assert r.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, r.text
+
+
 @pytest.mark.parametrize('include', [True, False])
 async def test_changeset_with_discussion(client: AsyncClient, include):
     client.headers['Authorization'] = 'User user1'

--- a/tests/services/optimistic_diff/test_create.py
+++ b/tests/services/optimistic_diff/test_create.py
@@ -15,6 +15,17 @@ from speedup import typed_element_id
 from tests.utils.assert_model import assert_model
 
 
+async def _api_error_status(elements: list[ElementInit]) -> int:
+    try:
+        await OptimisticDiff.run(elements)
+    except APIError as exc:
+        status_code = exc.status_code
+        exc.__traceback__ = None
+        return status_code
+    else:
+        pytest.fail('Expected APIError')
+
+
 async def test_create_node(changeset_id: ChangesetId):
     # Arrange
     element: ElementInit = {
@@ -126,10 +137,7 @@ async def test_create_fails_with_multiple_null_island_nodes(
     ]
 
     # Act & Assert
-    with pytest.raises(APIError) as exc_info:
-        await OptimisticDiff.run(nodes)
-
-    assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert await _api_error_status(nodes) == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 async def test_create_way_fails_with_multiple_null_island_members(
@@ -167,10 +175,7 @@ async def test_create_way_fails_with_multiple_null_island_members(
     }
 
     # Act & Assert
-    with pytest.raises(APIError) as exc_info:
-        await OptimisticDiff.run([way])
-
-    assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert await _api_error_status([way]) == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 @pytest.mark.parametrize(

--- a/tests/services/optimistic_diff/test_create.py
+++ b/tests/services/optimistic_diff/test_create.py
@@ -1,10 +1,12 @@
 import pytest
+from app.models.proto.shared_types import ElementType
 from shapely import Point
+from starlette import status
 
+from app.exceptions.api_error import APIError
 from app.lib.user_role_limits import UserRoleLimits
 from app.models.db.element import ElementInit, validate_elements
 from app.models.element import ElementId
-from app.models.proto.shared_types import ElementType
 from app.models.types import ChangesetId
 from app.queries.element_query import ElementQuery
 from app.services.changeset_service import ChangesetService
@@ -94,6 +96,81 @@ async def test_create_multiple_nodes(changeset_id: ChangesetId):
     name_map = {e['tags']['name']: e for e in elements}  # type: ignore
     assert_model(name_map['Node 1'], nodes[0] | {'typed_id': typed_ids[0]})
     assert_model(name_map['Node 2'], nodes[1] | {'typed_id': typed_ids[1]})
+
+
+async def test_create_fails_with_multiple_null_island_nodes(
+    changeset_id: ChangesetId,
+):
+    # Arrange
+    nodes: list[ElementInit] = [
+        {
+            'changeset_id': changeset_id,
+            'typed_id': typed_element_id('node', ElementId(-1)),
+            'version': 1,
+            'visible': True,
+            'tags': {},
+            'point': Point(0, 0),
+            'members': None,
+            'members_roles': None,
+        },
+        {
+            'changeset_id': changeset_id,
+            'typed_id': typed_element_id('node', ElementId(-2)),
+            'version': 1,
+            'visible': True,
+            'tags': {},
+            'point': Point(0, 0),
+            'members': None,
+            'members_roles': None,
+        },
+    ]
+
+    # Act & Assert
+    with pytest.raises(APIError) as exc_info:
+        await OptimisticDiff.run(nodes)
+
+    assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+async def test_create_way_fails_with_multiple_null_island_members(
+    changeset_id: ChangesetId,
+):
+    # Arrange
+    node1: ElementInit = {
+        'changeset_id': changeset_id,
+        'typed_id': typed_element_id('node', ElementId(-1)),
+        'version': 1,
+        'visible': True,
+        'tags': {},
+        'point': Point(0, 0),
+        'members': None,
+        'members_roles': None,
+    }
+    node2: ElementInit = node1 | {'typed_id': typed_element_id('node', ElementId(-2))}
+
+    node1_ref = (await OptimisticDiff.run([node1]))[
+        typed_element_id('node', ElementId(-1))
+    ][0]
+    node2_ref = (await OptimisticDiff.run([node2]))[
+        typed_element_id('node', ElementId(-2))
+    ][0]
+
+    way: ElementInit = {
+        'changeset_id': changeset_id,
+        'typed_id': typed_element_id('way', ElementId(-1)),
+        'version': 1,
+        'visible': True,
+        'tags': {},
+        'point': None,
+        'members': [node1_ref, node2_ref],
+        'members_roles': None,
+    }
+
+    # Act & Assert
+    with pytest.raises(APIError) as exc_info:
+        await OptimisticDiff.run([way])
+
+    assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
 @pytest.mark.parametrize(

--- a/tests/services/optimistic_diff/test_create.py
+++ b/tests/services/optimistic_diff/test_create.py
@@ -129,7 +129,7 @@ async def test_create_fails_with_multiple_null_island_nodes(
     with pytest.raises(APIError) as exc_info:
         await OptimisticDiff.run(nodes)
 
-    assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 async def test_create_way_fails_with_multiple_null_island_members(
@@ -170,7 +170,7 @@ async def test_create_way_fails_with_multiple_null_island_members(
     with pytest.raises(APIError) as exc_info:
         await OptimisticDiff.run([way])
 
-    assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 @pytest.mark.parametrize(

--- a/tests/services/optimistic_diff/test_modify.py
+++ b/tests/services/optimistic_diff/test_modify.py
@@ -42,6 +42,44 @@ async def test_modify_node_tags_and_location(changeset_id: ChangesetId):
     assert_model(elements[0], node_modify | {'typed_id': node_typed_id})
 
 
+async def test_modify_node_moved_from_null_island_allows_single_final_null_node(
+    changeset_id: ChangesetId,
+):
+    # Arrange
+    node_create: ElementInit = {
+        'changeset_id': changeset_id,
+        'typed_id': typed_element_id('node', ElementId(-1)),
+        'version': 1,
+        'visible': True,
+        'tags': {},
+        'point': Point(0, 0),
+        'members': None,
+        'members_roles': None,
+    }
+    node_modify: ElementInit = node_create | {
+        'version': 2,
+        'point': Point(1, 1),
+    }
+    other_null_node: ElementInit = node_create | {
+        'typed_id': typed_element_id('node', ElementId(-2)),
+    }
+
+    # Act
+    assigned_ref_map = await OptimisticDiff.run([
+        node_create,
+        node_modify,
+        other_null_node,
+    ])
+
+    # Assert
+    moved_ref = assigned_ref_map[typed_element_id('node', ElementId(-1))][0]
+    null_ref = assigned_ref_map[typed_element_id('node', ElementId(-2))][0]
+    elements = await ElementQuery.find_by_refs([moved_ref, null_ref])
+    elements_by_ref = {element['typed_id']: element for element in elements}
+    assert_model(elements_by_ref[moved_ref], node_modify | {'typed_id': moved_ref})
+    assert_model(elements_by_ref[null_ref], other_null_node | {'typed_id': null_ref})
+
+
 async def test_modify_way_members(changeset_id: ChangesetId):
     # Create nodes
     node1: ElementInit = {
@@ -99,6 +137,53 @@ async def test_modify_way_members(changeset_id: ChangesetId):
         way_modify
         | {'typed_id': way_typed_id, 'members': [node1_typed_id, node2_typed_id]},
     )
+
+
+async def test_modify_way_removed_null_island_member_uses_final_members(
+    changeset_id: ChangesetId,
+):
+    # Arrange
+    node: ElementInit = {
+        'changeset_id': changeset_id,
+        'typed_id': typed_element_id('node', ElementId(-1)),
+        'version': 1,
+        'visible': True,
+        'tags': {},
+        'point': Point(0, 0),
+        'members': None,
+        'members_roles': None,
+    }
+    node1_ref = (await OptimisticDiff.run([node]))[
+        typed_element_id('node', ElementId(-1))
+    ][0]
+    node2_ref = (
+        await OptimisticDiff.run([
+            node | {'typed_id': typed_element_id('node', ElementId(-2))}
+        ])
+    )[typed_element_id('node', ElementId(-2))][0]
+
+    way_create: ElementInit = {
+        'changeset_id': changeset_id,
+        'typed_id': typed_element_id('way', ElementId(-1)),
+        'version': 1,
+        'visible': True,
+        'tags': {},
+        'point': None,
+        'members': [node1_ref, node2_ref],
+        'members_roles': None,
+    }
+    way_modify: ElementInit = way_create | {
+        'version': 2,
+        'members': [node1_ref],
+    }
+
+    # Act
+    assigned_ref_map = await OptimisticDiff.run([way_create, way_modify])
+
+    # Assert
+    way_ref = assigned_ref_map[typed_element_id('way', ElementId(-1))][0]
+    elements = await ElementQuery.find_by_refs([way_ref], limit=1)
+    assert_model(elements[0], way_modify | {'typed_id': way_ref})
 
 
 async def test_modify_relation_members_and_roles(changeset_id: ChangesetId):


### PR DESCRIPTION
## Summary

- Reject changeset uploads that contain two or more current visible nodes at Null Island `(0,0)`.
- Count Null Island nodes referenced by uploaded ways, including existing remote way members loaded during validation.
- Keep single Null Island node edits allowed, and skip this restriction for moderators/administrators.

Closes #128

/claim #128

## Testing

- `python3 -m py_compile app/exceptions/diff_mixin.py app/exceptions06/diff_mixin.py app/services/optimistic_diff/prepare.py tests/services/optimistic_diff/test_create.py tests/controllers/test_api06_changeset.py`
- `uvx ruff check app/exceptions/diff_mixin.py app/exceptions06/diff_mixin.py app/services/optimistic_diff/prepare.py tests/services/optimistic_diff/test_create.py tests/controllers/test_api06_changeset.py`
- `uvx ruff format --check app/exceptions/diff_mixin.py app/exceptions06/diff_mixin.py app/services/optimistic_diff/prepare.py tests/services/optimistic_diff/test_create.py tests/controllers/test_api06_changeset.py`
- `git diff --check`

Targeted pytest was attempted with:

`uv run pytest tests/services/optimistic_diff/test_create.py::test_create_fails_with_multiple_null_island_nodes tests/services/optimistic_diff/test_create.py::test_create_way_fails_with_multiple_null_island_members tests/controllers/test_api06_changeset.py::test_changeset_upload_rejects_multiple_null_island_nodes -q`

It did not reach pytest because the local machine lacks the repo-required nightly Rust toolchain: `speedup` failed to build under Homebrew stable Cargo/Rust with `#![feature(likely_unlikely)]`; `rustup` and `nix-shell` are not available here.
