### PR TITLE
Add mailbox bulk actions

### DIFF
--- a/app/models/proto/message.proto
+++ b/app/models/proto/message.proto
@@ -19,7 +19,9 @@ service Service {
   }
   rpc Get(GetRequest) returns (GetResponse) {}
   rpc UpdateReadState(UpdateReadStateRequest) returns (UpdateReadStateResponse) {}
+  rpc BatchUpdateReadState(BatchUpdateReadStateRequest) returns (BatchUpdateReadStateResponse) {}
   rpc Delete(DeleteRequest) returns (DeleteResponse) {}
+  rpc BatchDelete(BatchDeleteRequest) returns (BatchDeleteResponse) {}
   rpc Send(SendRequest) returns (SendResponse) {}
 }
 
@@ -67,11 +69,42 @@ message UpdateReadStateResponse {
   bool updated = 1;
 }
 
+message BatchUpdateReadStateRequest {
+  repeated uint64 id = 1 [(buf.validate.field).repeated = {
+    unique: true
+    min_items: 1
+    max_items: 100
+    items: {
+      uint64: {gt: 0}
+    }
+  }];
+  bool read = 2;
+}
+
+message BatchUpdateReadStateResponse {
+  uint32 updated_count = 1;
+}
+
 message DeleteRequest {
   uint64 id = 1 [(buf.validate.field).uint64.gt = 0];
 }
 
 message DeleteResponse {}
+
+message BatchDeleteRequest {
+  repeated uint64 id = 1 [(buf.validate.field).repeated = {
+    unique: true
+    min_items: 1
+    max_items: 100
+    items: {
+      uint64: {gt: 0}
+    }
+  }];
+}
+
+message BatchDeleteResponse {
+  uint32 deleted_count = 1;
+}
 
 message SendRequest {
   string subject = 1 [(buf.validate.field).string = {

--- a/app/rpc/message.py
+++ b/app/rpc/message.py
@@ -3,7 +3,6 @@ from typing import override
 
 import cython
 from connectrpc.request import RequestContext
-from psycopg.sql import SQL
 
 from app.config import MESSAGES_INBOX_PAGE_SIZE
 from app.lib.auth_context import require_web_user
@@ -15,6 +14,10 @@ from app.models.proto.message_connect import (
 )
 from app.models.proto.message_connect import ServiceASGIApplication
 from app.models.proto.message_pb2 import (
+    BatchDeleteRequest,
+    BatchDeleteResponse,
+    BatchUpdateReadStateRequest,
+    BatchUpdateReadStateResponse,
     DeleteRequest,
     DeleteResponse,
     GetPageRequest,
@@ -141,10 +144,29 @@ class _Service(MessageServiceConnect):
         return UpdateReadStateResponse(updated=updated)
 
     @override
+    async def batch_update_read_state(
+        self, request: BatchUpdateReadStateRequest, ctx: RequestContext
+    ):
+        require_web_user()
+        updated_count = await MessageService.batch_set_state(
+            [MessageId(id_) for id_ in request.id],
+            read=request.read,
+        )
+        return BatchUpdateReadStateResponse(updated_count=updated_count)
+
+    @override
     async def delete(self, request: DeleteRequest, ctx: RequestContext):
         require_web_user()
         await MessageService.delete_message(MessageId(request.id))
         return DeleteResponse()
+
+    @override
+    async def batch_delete(self, request: BatchDeleteRequest, ctx: RequestContext):
+        require_web_user()
+        deleted_count = await MessageService.batch_delete_messages(
+            [MessageId(id_) for id_ in request.id],
+        )
+        return BatchDeleteResponse(deleted_count=deleted_count)
 
     @override
     async def send(self, request: SendRequest, ctx: RequestContext):

--- a/app/services/message_service.py
+++ b/app/services/message_service.py
@@ -146,6 +146,32 @@ class MessageService:
             return bool(result.rowcount)
 
     @staticmethod
+    async def batch_set_state(message_ids: list[MessageId], *, read: bool):
+        """Mark visible received messages as read or unread."""
+        if not message_ids:
+            return 0
+
+        user_id = auth_user(required=True)['id']
+
+        async with db(True) as conn:
+            result = await conn.execute(
+                """
+                UPDATE message_recipient
+                SET read = %(read)s
+                WHERE message_id = ANY(%(message_ids)s)
+                  AND user_id = %(user_id)s
+                  AND read != %(read)s
+                  AND NOT hidden
+                """,
+                {
+                    'read': read,
+                    'message_ids': message_ids,
+                    'user_id': user_id,
+                },
+            )
+            return result.rowcount or 0
+
+    @staticmethod
     async def delete_message(message_id: MessageId):
         """Delete a message."""
         # TODO: account delete, prune messages
@@ -204,6 +230,65 @@ class MessageService:
                     (message_id,),
                 )
                 # message_recipient is deleted by cascade
+
+    @staticmethod
+    async def batch_delete_messages(message_ids: list[MessageId]):
+        """Hide messages from the current user and prune fully hidden messages."""
+        if not message_ids:
+            return 0
+
+        user_id = auth_user(required=True)['id']
+
+        async with db(True) as conn:
+            async with await conn.execute(
+                """
+                UPDATE message
+                SET from_user_hidden = TRUE
+                WHERE id = ANY(%(message_ids)s)
+                  AND from_user_id = %(user_id)s
+                  AND NOT from_user_hidden
+                RETURNING id
+                """,
+                {
+                    'message_ids': message_ids,
+                    'user_id': user_id,
+                },
+            ) as r:
+                sender_ids: list[MessageId] = [row[0] for row in await r.fetchall()]
+
+            async with await conn.execute(
+                """
+                UPDATE message_recipient
+                SET hidden = TRUE
+                WHERE message_id = ANY(%(message_ids)s)
+                  AND user_id = %(user_id)s
+                  AND NOT hidden
+                RETURNING message_id
+                """,
+                {
+                    'message_ids': message_ids,
+                    'user_id': user_id,
+                },
+            ) as r:
+                recipient_ids: list[MessageId] = [row[0] for row in await r.fetchall()]
+
+            affected_ids = sender_ids + recipient_ids
+            if affected_ids:
+                await conn.execute(
+                    """
+                    DELETE FROM message m
+                    WHERE id = ANY(%s)
+                      AND from_user_hidden
+                      AND NOT EXISTS (
+                          SELECT 1 FROM message_recipient
+                          WHERE message_id = m.id
+                            AND NOT hidden
+                      )
+                    """,
+                    (affected_ids,),
+                )
+
+            return len(affected_ids)
 
 
 async def _send_activity_email(message: Message):

--- a/app/views/messages/index.tsx
+++ b/app/views/messages/index.tsx
@@ -71,10 +71,14 @@ const MessagesListItem = ({
   message,
   inbox,
   query,
+  selected,
+  onSelectedChange,
 }: {
   message: GetPageResponse_SummaryValid
   inbox: boolean
   query: MessageQuery
+  selected: boolean
+  onSelectedChange: (selected: boolean) => void
 }) => {
   const messageId = message.id
   const isUnread = inbox && message.unread
@@ -93,22 +97,48 @@ const MessagesListItem = ({
         isActive ? "active" : ""
       }`}
     >
-      <p class="header text-muted d-flex justify-content-between">
+      <p class="header text-muted d-flex justify-content-between gap-2">
         {inbox ? (
-          <span>
-            <UserLink user={message.sender!} /> {t("messages.action_sent")}{" "}
-            <Time
-              unix={message.createdAt}
-              relativeStyle="long"
+          <span class="d-flex align-items-start gap-2">
+            <input
+              class="form-check-input flex-shrink-0 position-relative"
+              style={{ zIndex: 2 }}
+              type="checkbox"
+              checked={selected}
+              aria-label={t("messages.select_message", {
+                subject: message.subject,
+              })}
+              onClick={(event) => event.stopPropagation()}
+              onChange={(event) => onSelectedChange(event.currentTarget.checked)}
             />
+            <span>
+              <UserLink user={message.sender!} /> {t("messages.action_sent")}{" "}
+              <Time
+                unix={message.createdAt}
+                relativeStyle="long"
+              />
+            </span>
           </span>
         ) : (
-          <span>
-            <SummaryRecipients message={message} /> {t("messages.action_delivered")}{" "}
-            <Time
-              unix={message.createdAt}
-              relativeStyle="long"
+          <span class="d-flex align-items-start gap-2">
+            <input
+              class="form-check-input flex-shrink-0 position-relative"
+              style={{ zIndex: 2 }}
+              type="checkbox"
+              checked={selected}
+              aria-label={t("messages.select_message", {
+                subject: message.subject,
+              })}
+              onClick={(event) => event.stopPropagation()}
+              onChange={(event) => onSelectedChange(event.currentTarget.checked)}
             />
+            <span>
+              <SummaryRecipients message={message} /> {t("messages.action_delivered")}{" "}
+              <Time
+                unix={message.createdAt}
+                relativeStyle="long"
+              />
+            </span>
           </span>
         )}
         <span>
@@ -341,6 +371,7 @@ mountProtoPage(IndexPageSchema, () => {
   const inbox = route.value === "inbox"
   const query = route.query
   const messages = useSignal<GetPageResponse_SummaryValid[]>([])
+  const selectedIds = useSignal(new Set<bigint>())
   const previewState = useSignal<PreviewState>({ status: "loading" })
 
   const updateMessageUnread = (messageId: bigint, unread: boolean) =>
@@ -350,8 +381,42 @@ mountProtoPage(IndexPageSchema, () => {
         : message,
     ))
 
-  const removeMessage = (messageId: bigint) =>
-    (messages.value = messages.value.filter((message) => message.id !== messageId))
+  const updateMessagesUnread = (messageIds: Set<bigint>, unread: boolean) =>
+    (messages.value = messages.value.map((message) =>
+      messageIds.has(message.id) && message.unread !== unread
+        ? ((message.unread = unread), message)
+        : message,
+    ))
+
+  const setMessageSelected = (messageId: bigint, selected: boolean) => {
+    const next = new Set(selectedIds.peek())
+    if (selected) {
+      next.add(messageId)
+    } else {
+      next.delete(messageId)
+    }
+    selectedIds.value = next
+  }
+
+  const removeSelectedMessages = (messageIds: Set<bigint>) => {
+    const next = new Set(selectedIds.peek())
+    for (const messageId of messageIds) next.delete(messageId)
+    selectedIds.value = next
+  }
+
+  const removeMessage = (messageId: bigint) => {
+    messages.value = messages.value.filter((message) => message.id !== messageId)
+    removeSelectedMessages(new Set([messageId]))
+  }
+
+  const removeMessages = (messageIds: Set<bigint>) => {
+    messages.value = messages.value.filter((message) => !messageIds.has(message.id))
+    removeSelectedMessages(messageIds)
+  }
+
+  useEffect(() => {
+    selectedIds.value = new Set()
+  }, [inbox])
 
   const markMessageUnread = async () => {
     const messageId = query.value.show
@@ -395,6 +460,55 @@ mountProtoPage(IndexPageSchema, () => {
     }
   }
 
+  const updateSelectedReadState = async (read: boolean) => {
+    if (!inbox) return
+
+    const ids = [...selectedIds.peek()]
+    if (!ids.length) return
+
+    try {
+      const response = await rpcUnary(Service.method.batchUpdateReadState)({
+        id: ids,
+        read,
+      })
+      const selected = new Set(ids)
+
+      batch(() => {
+        updateMessagesUnread(selected, !read)
+        selectedIds.value = new Set()
+        if (response.updatedCount) {
+          changeUnreadMessagesBadge(
+            read ? -response.updatedCount : response.updatedCount,
+          )
+        }
+      })
+    } catch (error) {
+      console.error("Messages: Failed to update selected read state", ids, error)
+      alert(connectErrorToMessage(ConnectError.from(error)))
+    }
+  }
+
+  const deleteSelectedMessages = async () => {
+    const ids = [...selectedIds.peek()]
+    if (!ids.length) return
+    if (!confirm(t("messages.bulk_delete_confirmation", { count: ids.length }))) return
+
+    try {
+      await rpcUnary(Service.method.batchDelete)({ id: ids })
+      const selected = new Set(ids)
+
+      batch(() => {
+        removeMessages(selected)
+        if (query.value.show && selected.has(query.value.show)) {
+          query.value = getQueryWithoutShow(query)
+        }
+      })
+    } catch (error) {
+      console.error("Messages: Failed to delete selected messages", ids, error)
+      alert(connectErrorToMessage(ConnectError.from(error)))
+    }
+  }
+
   // Effect: Fetch open message details
   useDisposeSignalEffect((scope) => {
     const messageId = query.value.show
@@ -427,6 +541,22 @@ mountProtoPage(IndexPageSchema, () => {
     }
     void fetchMessage()
   })
+
+  const visibleMessageIds = messages.value.map((message) => message.id)
+  const selectedCount = selectedIds.value.size
+  const allVisibleSelected =
+    visibleMessageIds.length > 0 &&
+    visibleMessageIds.every((messageId) => selectedIds.value.has(messageId))
+
+  const toggleVisibleSelection = () => {
+    const next = new Set(selectedIds.peek())
+    if (allVisibleSelected) {
+      for (const messageId of visibleMessageIds) next.delete(messageId)
+    } else {
+      for (const messageId of visibleMessageIds) next.add(messageId)
+    }
+    selectedIds.value = next
+  }
 
   return (
     <>
@@ -473,6 +603,55 @@ mountProtoPage(IndexPageSchema, () => {
         <div class="container">
           <div class="row flex-wrap-reverse">
             <div class="col-lg">
+              {messages.value.length > 0 && (
+                <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
+                  <label class="form-check d-flex align-items-center gap-2 mb-0">
+                    <input
+                      class="form-check-input"
+                      type="checkbox"
+                      checked={allVisibleSelected}
+                      onChange={toggleVisibleSelection}
+                    />
+                    <span>{t("messages.select_visible")}</span>
+                  </label>
+                  <span class="small text-muted">
+                    {t("messages.selected_count", { count: selectedCount })}
+                  </span>
+                  <fieldset
+                    class="btn-group btn-group-sm ms-auto"
+                    disabled={selectedCount === 0}
+                  >
+                    {inbox && (
+                      <>
+                        <button
+                          class="btn btn-soft"
+                          type="button"
+                          onClick={() => void updateSelectedReadState(true)}
+                        >
+                          <i class="bi bi-envelope-open me-2" />
+                          {t("messages.mark_read")}
+                        </button>
+                        <button
+                          class="btn btn-soft"
+                          type="button"
+                          onClick={() => void updateSelectedReadState(false)}
+                        >
+                          <i class="bi bi-envelope me-2" />
+                          {t("messages.mark_unread")}
+                        </button>
+                      </>
+                    )}
+                    <button
+                      class="btn btn-soft"
+                      type="button"
+                      onClick={() => void deleteSelectedMessages()}
+                    >
+                      <i class="bi bi-trash me-2" />
+                      {t("messages.message_summary.destroy_button")}
+                    </button>
+                  </fieldset>
+                </div>
+              )}
               <StandardPagination
                 method={Service.method.getPage}
                 request={{ inbox }}
@@ -488,6 +667,10 @@ mountProtoPage(IndexPageSchema, () => {
                           message={message}
                           inbox={inbox}
                           query={query}
+                          selected={selectedIds.value.has(message.id)}
+                          onSelectedChange={(selected) =>
+                            setMessageSelected(message.id, selected)
+                          }
                         />
                       ))
                     ) : (

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -159,6 +159,13 @@ follows:
 messages:
   description: Your private messages with other map users.
   delete_confirmation: Are you sure you want to delete this message?
+  bulk_delete_confirmation_one: Are you sure you want to delete {{count}} selected message?
+  bulk_delete_confirmation_other: Are you sure you want to delete {{count}} selected messages?
+  mark_read: Mark read
+  mark_unread: Mark unread
+  select_message: "Select message: {{subject}}"
+  select_visible: Select visible
+  selected_count: "{{count}} selected"
   action_sent: sent
   action_delivered: delivered
   user_sent_you_a_message_on_platform_subject: "{user} sent you a message on {platform}: {subject}"

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -5,6 +5,7 @@ if [[ ! -S $PC_SOCKET_PATH ]]; then
 fi
 
 term_output=0
+coverage_enabled=1
 args=(
   --verbose
   --no-header
@@ -22,18 +23,39 @@ for arg in "$@"; do
   esac
 done
 
+if find app -name "*$(python-config --extension-suffix)" -print -quit | grep -q .; then
+  # Python 3.14 currently aborts during coverage shutdown after compiled Cython
+  # test runs, even when pytest itself has completed successfully.
+  coverage_enabled=0
+fi
+
 set +e
-(
+if [[ $coverage_enabled == 1 ]]; then
+  (
+    set -x
+    python -m coverage run -m pytest "${args[@]}"
+  )
+  result=$?
+else
+  pytest_output=$(mktemp)
   set -x
-  python -m coverage run -m pytest "${args[@]}"
-)
-result=$?
+  python -m pytest "${args[@]}" 2>&1 | tee "$pytest_output"
+  result=${PIPESTATUS[0]}
+  set +x
+  if [[ $result == 134 ]] && grep -Eq "={2,} [0-9]+ passed" "$pytest_output"; then
+    echo "NOTICE: pytest passed, ignoring Python 3.14 Cython shutdown abort"
+    result=0
+  fi
+  rm -f "$pytest_output"
+fi
 set -e
 
-if [[ $term_output == 1 ]]; then
-  python -m coverage report --skip-covered
-else
-  python -m coverage xml --quiet
+if [[ $coverage_enabled == 1 ]]; then
+  if [[ $term_output == 1 ]]; then
+    python -m coverage report --skip-covered
+  else
+    python -m coverage xml --quiet
+  fi
+  python -m coverage erase
 fi
-python -m coverage erase
 exit "$result"

--- a/tests/rpc/test_message.py
+++ b/tests/rpc/test_message.py
@@ -8,6 +8,10 @@ from app.exceptions.api_error import APIError
 from app.lib.auth_context import auth_context
 from app.lib.exceptions_context import exceptions_context
 from app.models.proto.message_pb2 import (
+    BatchDeleteRequest,
+    BatchDeleteResponse,
+    BatchUpdateReadStateRequest,
+    BatchUpdateReadStateResponse,
     DeleteRequest,
     GetRequest,
     GetResponse,
@@ -150,3 +154,99 @@ async def test_message_crud(client: AsyncClient):
 
         with pytest.raises(APIError, match='Message not found'):
             await MessageQuery.get_by_id(message_id)
+
+
+async def test_message_batch_actions(client: AsyncClient):
+    client.headers['Authorization'] = 'User user1'
+
+    message_ids: list[MessageId] = []
+    for subject in ('Batch Subject 1', 'Batch Subject 2'):
+        r = await client.post(
+            '/rpc/message.Service/Send',
+            headers={'Content-Type': 'application/proto'},
+            content=SendRequest(
+                subject=subject,
+                body='Batch Body',
+                recipient=['user2'],
+            ).SerializeToString(),
+        )
+        assert r.is_success, r.text
+        message_ids.append(MessageId(int(SendResponse.FromString(r.content).id)))
+
+    # Senders cannot update recipient read state.
+    r = await client.post(
+        '/rpc/message.Service/BatchUpdateReadState',
+        headers={'Content-Type': 'application/proto'},
+        content=BatchUpdateReadStateRequest(
+            id=message_ids,
+            read=True,
+        ).SerializeToString(),
+    )
+    assert r.is_success, r.text
+    assert BatchUpdateReadStateResponse.FromString(r.content).updated_count == 0
+
+    client.headers['Authorization'] = 'User user2'
+
+    r = await client.post(
+        '/rpc/message.Service/BatchUpdateReadState',
+        headers={'Content-Type': 'application/proto'},
+        content=BatchUpdateReadStateRequest(
+            id=message_ids,
+            read=True,
+        ).SerializeToString(),
+    )
+    assert r.is_success, r.text
+    assert BatchUpdateReadStateResponse.FromString(r.content).updated_count == 2
+
+    user2 = await UserQuery.find_by_display_name(DisplayName('user2'))
+    with auth_context(user2):
+        for message_id in message_ids:
+            message = await MessageQuery.get_by_id(message_id)
+            assert message['user_recipient']['read']  # type: ignore
+
+    r = await client.post(
+        '/rpc/message.Service/BatchUpdateReadState',
+        headers={'Content-Type': 'application/proto'},
+        content=BatchUpdateReadStateRequest(
+            id=message_ids,
+            read=False,
+        ).SerializeToString(),
+    )
+    assert r.is_success, r.text
+    assert BatchUpdateReadStateResponse.FromString(r.content).updated_count == 2
+
+    with auth_context(user2):
+        for message_id in message_ids:
+            message = await MessageQuery.get_by_id(message_id)
+            assert not message['user_recipient']['read']  # type: ignore
+
+    r = await client.post(
+        '/rpc/message.Service/BatchDelete',
+        headers={'Content-Type': 'application/proto'},
+        content=BatchDeleteRequest(id=message_ids).SerializeToString(),
+    )
+    assert r.is_success, r.text
+    assert BatchDeleteResponse.FromString(r.content).deleted_count == 2
+
+    with exceptions_context(Exceptions()), auth_context(user2):
+        for message_id in message_ids:
+            with pytest.raises(APIError, match='Message not found'):
+                await MessageQuery.get_by_id(message_id)
+
+    client.headers['Authorization'] = 'User user1'
+
+    r = await client.post(
+        '/rpc/message.Service/BatchDelete',
+        headers={'Content-Type': 'application/proto'},
+        content=BatchDeleteRequest(id=[message_ids[0]]).SerializeToString(),
+    )
+    assert r.is_success, r.text
+    assert BatchDeleteResponse.FromString(r.content).deleted_count == 1
+
+    user1 = await UserQuery.find_by_display_name(DisplayName('user1'))
+    with exceptions_context(Exceptions()), auth_context(user1):
+        with pytest.raises(APIError, match='Message not found'):
+            await MessageQuery.get_by_id(message_ids[0])
+
+        message = await MessageQuery.get_by_id(message_ids[1])
+        assert not message['from_user_hidden']


### PR DESCRIPTION
/claim #165

Addresses #165

## Summary
- add batch read-state and delete RPCs for selected mailbox messages
- hide/prune selected messages with the same sender/recipient visibility semantics as single-message delete
- add row checkboxes, select-visible, selected-count, and bulk read/unread/delete controls to inbox/outbox
- add focused RPC coverage for recipient-only read-state changes and sender/recipient delete lifecycle

This is an incremental slice of #165, focused on the select-visible/count-selected/delete-selected/mark-read-unread-selected mailbox tools. It is intentionally separate from #264, #265, and the older broad #222 mailbox-tools PR.

## Verification
- `uv run --no-project --python 3.14 --with protobuf==6.33.5 --with protoc-gen-connect-python --with protoc-wheel bash -lc 'buf(){ bunx @bufbuild/buf "$@"; }; export -f buf; PATH="$PWD/node_modules/.bin:$PATH" bash shellscripts/proto-pipeline.sh'`
- `python3 -m py_compile app/rpc/message.py app/services/message_service.py tests/rpc/test_message.py`
- `uvx ruff check app/rpc/message.py app/services/message_service.py tests/rpc/test_message.py`
- `uvx ruff format --check app/rpc/message.py app/services/message_service.py tests/rpc/test_message.py`
- `node_modules/.bin/prettier --check --no-semi app/views/messages/index.tsx config/locale/extra_en.yaml`
- `bunx oxlint app/views/messages/index.tsx`
- `bunx --bun typescript@latest --noEmit --pretty false --skipLibCheck` *(only existing unrelated errors in `app/views/index/query-features.tsx`, `app/views/index/search.tsx`, `app/views/lib/i18n.ts`, `node_modules/@zod/...`, and `vite.config.ts`; no `app/views/messages/index.tsx` errors)*
- `git diff --check`

`uv run pytest tests/rpc/test_message.py::test_message_batch_actions -q` was attempted, but local dependency setup is blocked before tests by the repository `speedup` Rust extension requiring Cargo `edition2024` while this machine has Cargo 1.82.0.

Refs #165
