### PR TITLE
Add hybrid aerial map layer

### DIFF
--- a/app/views/index/sidebar/layers.tsx
+++ b/app/views/index/sidebar/layers.tsx
@@ -25,6 +25,7 @@ import {
   GPS_LAYER_ID,
   HOT_LAYER_ID,
   hasMapLayer,
+  HYBRID_AERIAL_LAYER_ID,
   type LayerId,
   LIBERTY_LAYER_ID,
   NOTES_LAYER_ID,
@@ -50,6 +51,7 @@ const BASE_LAYERS = new Set([
   TRACESTRACKTOPO_LAYER_ID,
   LIBERTY_LAYER_ID,
   HOT_LAYER_ID,
+  HYBRID_AERIAL_LAYER_ID,
 ])
 
 const OVERLAY_LAYERS = new Set([
@@ -63,6 +65,7 @@ const OVERLAY_LAYERS = new Set([
 // Avoids "Too many active WebGL context even after destroyed".
 const LAYER_THUMBNAILS = new Map<LayerId, string>([
   [AERIAL_LAYER_ID, "/static/img/layer/aerial.webp"],
+  [HYBRID_AERIAL_LAYER_ID, "/static/img/layer/aerial.webp"],
 ])
 
 type Minimap =
@@ -389,6 +392,7 @@ export const LayersSidebar = ({ close }: { close: () => void }) => {
                   </>
                 )}
                 {layerId === HOT_LAYER_ID && t("javascripts.map.base.hot")}
+                {layerId === HYBRID_AERIAL_LAYER_ID && t("map.layers.hybrid_aerial")}
               </ListLayerTile>
             ))}
           </ul>

--- a/app/views/lib/map/layers/layers.ts
+++ b/app/views/lib/map/layers/layers.ts
@@ -31,6 +31,7 @@ export const CYCLEMAP_LAYER_ID = "cyclemap" as LayerId
 export const TRANSPORTMAP_LAYER_ID = "transportmap" as LayerId
 export const TRACESTRACKTOPO_LAYER_ID = "tracestracktopo" as LayerId
 export const HOT_LAYER_ID = "hot" as LayerId
+export const HYBRID_AERIAL_LAYER_ID = "hybrid-aerial" as LayerId
 
 const LIBERTY_LAYER_CODE = "L" as LayerCode
 const CYCLOSM_LAYER_CODE = "Y" as LayerCode
@@ -38,6 +39,7 @@ const CYCLEMAP_LAYER_CODE = "C" as LayerCode
 const TRANSPORTMAP_LAYER_CODE = "T" as LayerCode
 const TRACESTRACKTOPO_LAYER_CODE = "P" as LayerCode
 const HOT_LAYER_CODE = "H" as LayerCode
+const HYBRID_AERIAL_LAYER_CODE = "I" as LayerCode
 
 export const AERIAL_LAYER_ID = "aerial" as LayerId
 export const NOTES_LAYER_ID = "notes" as LayerId
@@ -92,6 +94,40 @@ const hotosmCredit = t("javascripts.map.hotosm_credit", {
 // https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/0
 const aerialEsriCredit =
   "Esri, Maxar, Earthstar Geographics, and the GIS User Community"
+const hybridAerialCredit = `${aerialEsriCredit}. ${copyright}. ${terms}`
+const cloneStyleSources = (sources: typeof libertyStyle.sources) => {
+  const result = {} as typeof libertyStyle.sources
+  for (const sourceId in sources) {
+    if (!Object.hasOwn(sources, sourceId)) continue
+    const id = sourceId as keyof typeof libertyStyle.sources
+    result[id] = { ...sources[id] }
+  }
+  return result
+}
+const hybridAerialStyle = {
+  ...libertyStyle,
+  sources: {
+    aerial: {
+      type: "raster",
+      maxzoom: 23,
+      tiles: [
+        "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+      ],
+      tileSize: 256,
+    },
+    ...cloneStyleSources(libertyStyle.sources),
+  },
+  layers: [
+    {
+      id: "aerial",
+      type: "raster",
+      source: "aerial",
+    },
+    ...libertyStyle.layers.filter(
+      (layer) => layer.type === "line" || layer.type === "symbol",
+    ),
+  ],
+} as StyleSpecification
 
 export const emptyFeatureCollection: FeatureCollection = {
   type: "FeatureCollection",
@@ -213,6 +249,16 @@ layersConfig.set(HOT_LAYER_ID, {
   },
   isBaseLayer: true,
   layerCode: HOT_LAYER_CODE,
+})
+
+layersConfig.set(HYBRID_AERIAL_LAYER_ID, {
+  specification: {
+    type: "vector",
+    attribution: hybridAerialCredit,
+  },
+  vectorStyle: hybridAerialStyle,
+  isBaseLayer: true,
+  layerCode: HYBRID_AERIAL_LAYER_CODE,
 })
 
 // Overlay layers

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -9,6 +9,7 @@ map:
   zoom_out_to_see_the_world_in_3d: Zoom out to see the world in 3D
   layers:
     esri_world_imagery: Esri World Imagery
+    hybrid_aerial: Hybrid aerial
     liberty: Liberty
     vector: Vector
   overlays:


### PR DESCRIPTION
Closes #182.

Adds a Hybrid aerial base layer that uses Esri World Imagery as the background and overlays Liberty line/symbol layers for roads, boundaries, and labels. This keeps the imagery visible while still showing map context.

Also adds the layer to the sidebar picker with a stable layer code.

Validation:
- `npx bun x oxfmt --check app/views/lib/map/layers/layers.ts app/views/index/sidebar/layers.tsx`
- `npx bun x oxlint app/views/lib/map/layers/layers.ts app/views/index/sidebar/layers.tsx`
- `git diff --check`
- Local sanity check confirmed the hybrid style starts with the aerial raster layer and only overlays Liberty line/symbol layers.