### PR TITLE
Add OSM software directory

### DIFF
--- a/app/controllers/software.py
+++ b/app/controllers/software.py
@@ -1,0 +1,255 @@
+from typing import Annotated, TypedDict
+
+from fastapi import APIRouter, Query
+
+from app.lib.render_response import render_response
+
+router = APIRouter()
+
+
+class SoftwareEntry(TypedDict):
+    name: str
+    description: str
+    url: str
+    image: str
+    category: str
+    platforms: tuple[str, ...]
+    license: str
+    status: str
+    highlights: tuple[str, ...]
+
+
+class FilterOption(TypedDict):
+    value: str
+    label: str
+
+
+_CATEGORIES: tuple[FilterOption, ...] = (
+    {'value': 'editor', 'label': 'Editors'},
+    {'value': 'mobile', 'label': 'Mobile mapping'},
+    {'value': 'data', 'label': 'Data tools'},
+    {'value': 'quality', 'label': 'Quality assurance'},
+    {'value': 'imagery', 'label': 'Imagery'},
+    {'value': 'mapmaking', 'label': 'Mapmaking'},
+)
+
+_PLATFORMS: tuple[FilterOption, ...] = (
+    {'value': 'web', 'label': 'Web'},
+    {'value': 'desktop', 'label': 'Desktop'},
+    {'value': 'android', 'label': 'Android'},
+    {'value': 'ios', 'label': 'iOS'},
+)
+
+_LICENSES: tuple[FilterOption, ...] = (
+    {'value': 'open-source', 'label': 'Open source'},
+    {'value': 'mixed', 'label': 'Mixed'},
+    {'value': 'proprietary', 'label': 'Proprietary'},
+)
+
+_STATUSES: tuple[FilterOption, ...] = (
+    {'value': 'active', 'label': 'Actively developed'},
+    {'value': 'stable', 'label': 'Stable'},
+    {'value': 'community', 'label': 'Community maintained'},
+)
+
+_FILTER_OPTIONS = {
+    'category': _CATEGORIES,
+    'platform': _PLATFORMS,
+    'license': _LICENSES,
+    'status': _STATUSES,
+}
+
+_FILTER_LABELS = {
+    key: {option['value']: option['label'] for option in options}
+    for key, options in _FILTER_OPTIONS.items()
+}
+
+_SOFTWARE: tuple[SoftwareEntry, ...] = (
+    {
+        'name': 'iD',
+        'description': 'The default browser editor for quick OpenStreetMap edits.',
+        'url': 'https://github.com/openstreetmap/iD',
+        'image': '/static/img/brand/id.webp',
+        'category': 'editor',
+        'platforms': ('web',),
+        'license': 'open-source',
+        'status': 'active',
+        'highlights': ('Beginner friendly', 'Built into osm.org', 'Preset-driven'),
+    },
+    {
+        'name': 'Rapid',
+        'description': 'A modern web editor with assisted mapping and validation tools.',
+        'url': 'https://github.com/facebook/Rapid',
+        'image': '/static/img/brand/rapid.webp',
+        'category': 'editor',
+        'platforms': ('web',),
+        'license': 'open-source',
+        'status': 'active',
+        'highlights': ('Assisted mapping', 'Browser based', 'Validation tools'),
+    },
+    {
+        'name': 'JOSM',
+        'description': 'A powerful desktop editor for detailed and large-scale edits.',
+        'url': 'https://josm.openstreetmap.de/',
+        'image': '/static/img/brand/josm.webp',
+        'category': 'editor',
+        'platforms': ('desktop',),
+        'license': 'open-source',
+        'status': 'stable',
+        'highlights': ('Advanced editing', 'Plugin ecosystem', 'Offline workflows'),
+    },
+    {
+        'name': 'Vespucci',
+        'description': 'A full OpenStreetMap editor for detailed on-device Android edits.',
+        'url': 'https://vespucci.io/',
+        'image': '/static/img/app.svg',
+        'category': 'mobile',
+        'platforms': ('android',),
+        'license': 'open-source',
+        'status': 'active',
+        'highlights': ('Full tag editing', 'Survey workflows', 'Offline support'),
+    },
+    {
+        'name': 'StreetComplete',
+        'description': 'A quest-based Android app for adding missing local details.',
+        'url': 'https://streetcomplete.app/',
+        'image': '/static/img/app.svg',
+        'category': 'mobile',
+        'platforms': ('android',),
+        'license': 'open-source',
+        'status': 'active',
+        'highlights': ('Simple quests', 'On-site surveys', 'No tagging knowledge needed'),
+    },
+    {
+        'name': 'Every Door',
+        'description': 'A mobile editor focused on shops, amenities, entrances, and indoor details.',
+        'url': 'https://every-door.app/',
+        'image': '/static/img/app.svg',
+        'category': 'mobile',
+        'platforms': ('android', 'ios'),
+        'license': 'open-source',
+        'status': 'active',
+        'highlights': ('POI surveys', 'Indoor details', 'Fast field work'),
+    },
+    {
+        'name': 'Overpass Turbo',
+        'description': 'A web query interface for exploring and exporting OpenStreetMap data.',
+        'url': 'https://overpass-turbo.eu/',
+        'image': '/static/img/brand/overpass.webp',
+        'category': 'data',
+        'platforms': ('web',),
+        'license': 'open-source',
+        'status': 'stable',
+        'highlights': ('Overpass QL', 'Map previews', 'Data export'),
+    },
+    {
+        'name': 'Geofabrik Downloads',
+        'description': 'Regional OpenStreetMap extracts for analysis, imports, and offline use.',
+        'url': 'https://download.geofabrik.de/',
+        'image': '/static/img/brand/geofabrik.webp',
+        'category': 'data',
+        'platforms': ('web',),
+        'license': 'mixed',
+        'status': 'stable',
+        'highlights': ('Regional extracts', 'Multiple formats', 'Regular updates'),
+    },
+    {
+        'name': 'OsmCha',
+        'description': 'A review tool for finding, filtering, and triaging suspicious changesets.',
+        'url': 'https://osmcha.org/',
+        'image': '/static/img/app.svg',
+        'category': 'quality',
+        'platforms': ('web',),
+        'license': 'open-source',
+        'status': 'community',
+        'highlights': ('Changeset review', 'Filters', 'Quality signals'),
+    },
+    {
+        'name': 'MapRoulette',
+        'description': 'A tasking platform for small, repeatable OpenStreetMap improvement jobs.',
+        'url': 'https://maproulette.org/',
+        'image': '/static/img/app.svg',
+        'category': 'quality',
+        'platforms': ('web',),
+        'license': 'open-source',
+        'status': 'active',
+        'highlights': ('Task challenges', 'Team workflows', 'Progress tracking'),
+    },
+    {
+        'name': 'uMap',
+        'description': 'A web tool for creating custom maps with OpenStreetMap backgrounds.',
+        'url': 'https://umap.openstreetmap.fr/',
+        'image': '/static/img/app.svg',
+        'category': 'mapmaking',
+        'platforms': ('web',),
+        'license': 'open-source',
+        'status': 'active',
+        'highlights': ('Custom layers', 'Embeds', 'Collaborative maps'),
+    },
+    {
+        'name': 'Mapillary',
+        'description': 'A street-level imagery platform frequently used by mappers during surveys.',
+        'url': 'https://www.mapillary.com/',
+        'image': '/static/img/app.svg',
+        'category': 'imagery',
+        'platforms': ('web', 'android', 'ios'),
+        'license': 'proprietary',
+        'status': 'active',
+        'highlights': ('Street-level imagery', 'Mobile capture', 'Map data signals'),
+    },
+)
+
+
+def _normalize_filter(value: str | None, options: tuple[FilterOption, ...]) -> str | None:
+    if value is None:
+        return None
+    allowed = {option['value'] for option in options}
+    return value if value in allowed else None
+
+
+def _filter_software(
+    *,
+    category: str | None,
+    platform: str | None,
+    license_: str | None,
+    status: str | None,
+) -> tuple[SoftwareEntry, ...]:
+    return tuple(
+        entry
+        for entry in _SOFTWARE
+        if (category is None or entry['category'] == category)
+        and (platform is None or platform in entry['platforms'])
+        and (license_ is None or entry['license'] == license_)
+        and (status is None or entry['status'] == status)
+    )
+
+
+@router.get('/software')
+async def software(
+    category: Annotated[str | None, Query()] = None,
+    platform: Annotated[str | None, Query()] = None,
+    license_: Annotated[str | None, Query(alias='license')] = None,
+    status: Annotated[str | None, Query()] = None,
+):
+    selected = {
+        'category': _normalize_filter(category, _CATEGORIES),
+        'platform': _normalize_filter(platform, _PLATFORMS),
+        'license': _normalize_filter(license_, _LICENSES),
+        'status': _normalize_filter(status, _STATUSES),
+    }
+    entries = _filter_software(
+        category=selected['category'],
+        platform=selected['platform'],
+        license_=selected['license'],
+        status=selected['status'],
+    )
+    return await render_response(
+        'software',
+        {
+            'title_prefix': 'OSM Software |',
+            'entries': entries,
+            'filter_options': _FILTER_OPTIONS,
+            'labels': _FILTER_LABELS,
+            'selected': selected,
+        },
+    )

--- a/app/views/main.scss
+++ b/app/views/main.scss
@@ -122,6 +122,7 @@ $bootstrap-icons-font-hash: "";
 @import "settings/connections";
 @import "settings/nav";
 @import "settings/security";
+@import "software";
 @import "test-site";
 @import "traces/index";
 @import "traces/preview";

--- a/app/views/navbar/navbar-right.tsx
+++ b/app/views/navbar/navbar-right.tsx
@@ -29,6 +29,10 @@ const navLinks = [
     label: t("site.communities.title"),
   },
   {
+    href: "/software",
+    label: "Software",
+  },
+  {
     href: "/copyright",
     label: t("layouts.copyright"),
     rel: "license",

--- a/app/views/software.html.jinja
+++ b/app/views/software.html.jinja
@@ -1,0 +1,114 @@
+{% extends '_base' %}
+
+{% block title_prefix %}{{ title_prefix }}{% endblock %}
+{% block body_class %}software-page{% endblock %}
+
+{% block body %}
+  <div class="content-header">
+    <div class="container">
+      <h1>OSM Software</h1>
+    </div>
+  </div>
+  <div class="content-body">
+    <div class="container">
+      <div class="software-page__intro">
+        <p class="lead">
+          Find editors, mobile apps, data tools, and quality-assurance workflows
+          used across the OpenStreetMap ecosystem.
+        </p>
+      </div>
+
+      <form
+        class="software-page__filters"
+        action="/software"
+        method="get"
+      >
+        {% for name, options in filter_options.items() %}
+          <label class="form-label">
+            <span>{{ name | replace('_', ' ') | title }}</span>
+            <select
+              class="form-select"
+              name="{{ name }}"
+            >
+              <option
+                value=""
+                {% if not selected[name] %}selected{% endif %}
+              >
+                All
+              </option>
+              {% for option in options %}
+                <option
+                  value="{{ option.value }}"
+                  {% if selected[name] == option.value %}selected{% endif %}
+                >
+                  {{ option.label }}
+                </option>
+              {% endfor %}
+            </select>
+          </label>
+        {% endfor %}
+
+        <div class="software-page__filter-actions">
+          <button
+            class="btn btn-primary"
+            type="submit"
+          >
+            Filter
+          </button>
+          <a
+            class="btn btn-light"
+            href="/software"
+          >
+            Reset
+          </a>
+        </div>
+      </form>
+
+      <div class="software-page__result-count">
+        {{ entries | length }} result{% if entries | length != 1 %}s{% endif %}
+      </div>
+
+      <div class="software-page__grid">
+        {% for entry in entries %}
+          <article class="software-page__card">
+            <div class="software-page__card-header">
+              <img
+                src="{{ entry.image }}"
+                alt="{{ t('alt.logo', name=entry.name) }}"
+                loading="lazy"
+              />
+              <div>
+                <h2>
+                  <a href="{{ entry.url }}">{{ entry.name }}</a>
+                </h2>
+                <div class="software-page__meta">
+                  <span>{{ labels.category[entry.category] }}</span>
+                  <span>{{ labels.license[entry.license] }}</span>
+                  <span>{{ labels.status[entry.status] }}</span>
+                </div>
+              </div>
+            </div>
+
+            <p>{{ entry.description }}</p>
+
+            <div class="software-page__platforms">
+              {% for platform in entry.platforms %}
+                <span>{{ labels.platform[platform] }}</span>
+              {% endfor %}
+            </div>
+
+            <ul>
+              {% for highlight in entry.highlights %}
+                <li>{{ highlight }}</li>
+              {% endfor %}
+            </ul>
+          </article>
+        {% else %}
+          <p class="software-page__empty">
+            No software matched the selected filters.
+          </p>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/software.scss
+++ b/app/views/software.scss
@@ -1,0 +1,113 @@
+.software-page {
+  .software-page__intro {
+    max-width: 48rem;
+  }
+
+  .software-page__filters {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+    gap: 1rem;
+    align-items: end;
+    padding: 1rem;
+    margin-bottom: 1rem;
+    border: 1px solid var(--bs-border-color);
+    border-radius: $border-radius;
+    background: var(--bs-tertiary-bg);
+
+    .form-label {
+      margin: 0;
+
+      > span {
+        display: block;
+        margin-bottom: 0.25rem;
+        font-size: 0.875rem;
+        font-weight: 600;
+        color: var(--bs-secondary-color);
+      }
+    }
+  }
+
+  .software-page__filter-actions {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .software-page__result-count {
+    margin-bottom: 1rem;
+    color: var(--bs-secondary-color);
+  }
+
+  .software-page__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 20rem), 1fr));
+    gap: 1rem;
+  }
+
+  .software-page__card {
+    padding: 1rem;
+    border: 1px solid var(--bs-border-color);
+    border-radius: $border-radius;
+    background: var(--bs-body-bg);
+
+    p {
+      margin-bottom: 0.75rem;
+    }
+
+    ul {
+      padding-left: 1.25rem;
+      margin-bottom: 0;
+    }
+  }
+
+  .software-page__card-header {
+    display: flex;
+    gap: 0.875rem;
+    align-items: center;
+    margin-bottom: 0.875rem;
+
+    img {
+      width: 3.25rem;
+      height: 3.25rem;
+      object-fit: contain;
+      padding: 0.375rem;
+      border: 1px solid var(--bs-border-color);
+      border-radius: $border-radius-sm;
+      background: var(--bs-light-bg-subtle);
+    }
+
+    h2 {
+      margin-bottom: 0.25rem;
+      font-size: 1.25rem;
+      line-height: 1.2;
+    }
+  }
+
+  .software-page__meta,
+  .software-page__platforms {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+
+    span {
+      display: inline-flex;
+      align-items: center;
+      min-height: 1.5rem;
+      padding: 0.125rem 0.5rem;
+      border: 1px solid var(--bs-border-color);
+      border-radius: $border-radius-sm;
+      font-size: 0.8125rem;
+      color: var(--bs-secondary-color);
+      background: var(--bs-tertiary-bg);
+    }
+  }
+
+  .software-page__platforms {
+    margin-bottom: 0.75rem;
+  }
+
+  .software-page__empty {
+    padding: 1rem;
+    border: 1px solid var(--bs-border-color);
+    border-radius: $border-radius;
+  }
+}

--- a/tests/controllers/test_software.py
+++ b/tests/controllers/test_software.py
@@ -1,0 +1,41 @@
+from app.controllers.software import (
+    _CATEGORIES,
+    _filter_software,
+    _normalize_filter,
+)
+
+
+def _names(entries):
+    return {entry['name'] for entry in entries}
+
+
+def test_normalize_filter_rejects_unknown_values():
+    assert _normalize_filter('missing', _CATEGORIES) is None
+
+
+def test_filter_software_by_platform_and_license():
+    names = _names(
+        _filter_software(
+            category=None,
+            platform='android',
+            license_='open-source',
+            status=None,
+        )
+    )
+
+    assert 'StreetComplete' in names
+    assert 'Vespucci' in names
+    assert 'Mapillary' not in names
+
+
+def test_filter_software_by_category_and_status():
+    names = _names(
+        _filter_software(
+            category='quality',
+            platform=None,
+            license_=None,
+            status='active',
+        )
+    )
+
+    assert names == {'MapRoulette'}


### PR DESCRIPTION
Resolves #24.

## Summary
- Add a dedicated `/software` page with curated OSM software entries.
- Add server-side filters for category, platform, license, and development status.
- Add a navbar link, local logo/fallback imagery, responsive card styling, and focused filter-helper tests.

## Checks
- `python.exe -m py_compile app/controllers/software.py tests/controllers/test_software.py`
- `git diff --cached --check`

## Not run
- `pytest tests/controllers/test_software.py` because bundled Python in this local environment does not include `pytest`.
- `npm.cmd exec prettier -- --check app/views/software.html.jinja app/views/software.scss app/views/navbar/navbar-right.tsx app/views/main.scss` timed out because this fresh checkout has no `node_modules` installed.