### PR TITLE
Add changeset diff action

### DIFF
--- a/app/views/index/changeset.tsx
+++ b/app/views/index/changeset.tsx
@@ -210,8 +210,19 @@ const ChangesetComment = ({
 
 const ChangesetFooter = ({ data }: { data: DataValid }) => {
   const changesetIdStr = data.id.toString()
+  const achaviUrl = `https://overpass-api.de/achavi/?changeset=${changesetIdStr}`
   return (
     <div class="section text-center">
+      <a
+        class="btn btn-sm btn-soft mb-2"
+        href={achaviUrl}
+        target="_blank"
+        rel="noreferrer"
+      >
+        <i class="bi bi-code-square me-1" />
+        {t("changeset.open_diff")}
+      </a>
+      <br />
       {data.user && (
         <div class="mb-2">
           {data.prevChangesetId && (

--- a/app/views/index/changeset.tsx
+++ b/app/views/index/changeset.tsx
@@ -217,7 +217,7 @@ const ChangesetFooter = ({ data }: { data: DataValid }) => {
         class="btn btn-sm btn-soft mb-2"
         href={achaviUrl}
         target="_blank"
-        rel="noreferrer"
+        rel="noopener noreferrer"
       >
         <i class="bi bi-code-square me-1" />
         {t("changeset.open_diff")}

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -39,6 +39,7 @@ map:
       title: Routing engine
 changeset:
   open: Open
+  open_diff: Open changeset diff
   this_changeset_is_state: This changeset is {{state}}
   count_one: "changeset"
   count_other: "changesets"


### PR DESCRIPTION
## Summary
- Add an “Open changeset diff” action to the changeset sidebar/footer.
- Open Achavi for the current changeset in a new tab, so the current OSM-NG map page does not refresh.
- Add the English label for the new action.

Closes #7.

## Verification
- `git diff --check`
- `curl -L --max-time 15 -A "Mozilla/5.0" -s "https://overpass-api.de/achavi/?changeset=1" | head -20` confirms the Achavi changeset URL resolves to the viewer HTML.