### PR TITLE
Display friendly image upload errors

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -6,9 +6,11 @@ from pathlib import Path
 from typing import Annotated, Literal
 from urllib.parse import urlsplit
 
+from buf.validate import validate_pb2
 from email_validator.rfc_constants import EMAIL_MAX_LENGTH as EMAIL_MAX_LENGTH_RFC
 from githead import githead
 from google.protobuf.message import Message
+from PIL import Image as PILImage
 from pydantic import (
     AliasChoices,
     BaseModel,
@@ -36,7 +38,6 @@ from app.models.proto import (
     settings_security_pb2,
     trace_pb2,
 )
-from buf.validate import validate_pb2
 
 
 def _ByteSize(v: str):  # noqa: N802
@@ -172,6 +173,7 @@ AVATAR_MAX_RATIO = 2.0
 BACKGROUND_MAX_FILE_SIZE = _ByteSize('320 KiB')
 BACKGROUND_MAX_MEGAPIXELS = 4096 * 512  # (resolution)
 BACKGROUND_MAX_RATIO = 2 * 5.5  # 2 * ratio on website
+IMAGE_UPLOAD_MAX_PIXELS = PILImage.MAX_IMAGE_PIXELS
 IMAGE_MAX_FRAMES = 100
 IMAGE_PROXY_BLURHASH_MAX_COMPONENTS = 6
 IMAGE_PROXY_FETCH_MAX_BYTES = _ByteSize('10 MiB')

--- a/app/exceptions/image_mixin.py
+++ b/app/exceptions/image_mixin.py
@@ -10,6 +10,12 @@ class ImageExceptionsMixin:
     def image_too_big(self):
         raise APIError(status.HTTP_413_CONTENT_TOO_LARGE, detail='Image is too large')
 
+    def image_not_readable(self):
+        raise APIError(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail='Image file is not readable',
+        )
+
     def image_inappropriate(self):
         raise APIError(
             status.HTTP_422_UNPROCESSABLE_CONTENT,

--- a/app/lib/image.py
+++ b/app/lib/image.py
@@ -9,9 +9,9 @@ from typing import TYPE_CHECKING, Literal, NamedTuple, TypeAlias, overload
 
 import cython
 from blurhash_rs import blurhash_encode
-from PIL import ImageOps, ImageSequence
+from PIL import ImageOps, ImageSequence, UnidentifiedImageError
+from PIL.Image import DecompressionBombError, Resampling
 from PIL.Image import Image as PILImage
-from PIL.Image import Resampling
 from PIL.Image import open as open_image
 from sizestr import sizestr
 
@@ -40,7 +40,7 @@ if cython.compiled:
 else:
     from math import sqrt
 
-# TODO: test 200MP file
+_IMAGE_READ_ERRORS = (UnidentifiedImageError, OSError, SyntaxError)
 
 
 class _Animation(NamedTuple):
@@ -55,7 +55,7 @@ DEFAULT_USER_AVATAR_URL = '/static/img/avatar.webp'
 DEFAULT_USER_AVATAR = Path('app' + DEFAULT_USER_AVATAR_URL).read_bytes()
 DEFAULT_APP_AVATAR_URL = '/static/img/app.webp'
 
-_PIPE: 'ImageClassificationPipeline | None' = None
+_PIPE: ImageClassificationPipeline | None = None
 _PIPE_LOCK = Lock()
 
 
@@ -242,8 +242,12 @@ async def _normalize_image(
     - Megapixels: downscale
     - File size: reduce quality
     """
-    img = open_image(BytesIO(data))
-    ImageOps.exif_transpose(img, in_place=True)
+    try:
+        img = _open_image(data)
+    except DecompressionBombError:
+        raise_for.image_too_big()
+    except _IMAGE_READ_ERRORS:
+        raise_for.image_not_readable()
 
     # normalize shape ratio
     img_width: cython.size_t
@@ -290,7 +294,12 @@ async def _normalize_image(
             img_height = max(1, int(img_height / mp_ratio))
             resize_to = (img_width, img_height)
 
-    animation = _extract_animation(img)
+    try:
+        animation = _extract_animation(img)
+    except DecompressionBombError:
+        raise_for.image_too_big()
+    except _IMAGE_READ_ERRORS:
+        raise_for.image_not_readable()
 
     if resize_to is None and crop_box is None:
         pass
@@ -327,15 +336,26 @@ async def _normalize_image(
                 raise_for.image_inappropriate()
 
     # optimize file size
-    quality, buffer = await _optimize_quality(
-        img,
-        animation,
-        input_size=len(data),
-        quality=quality,
-        max_file_size=max_file_size,
-    )
+    try:
+        quality, buffer = await _optimize_quality(
+            img,
+            animation,
+            input_size=len(data),
+            quality=quality,
+            max_file_size=max_file_size,
+        )
+    except DecompressionBombError:
+        raise_for.image_too_big()
+    except _IMAGE_READ_ERRORS:
+        raise_for.image_not_readable()
     logging.debug('Optimized image quality: Q%d', quality)
     return (buffer, img) if return_img else buffer
+
+
+def _open_image(data: bytes):
+    img = open_image(BytesIO(data))
+    ImageOps.exif_transpose(img, in_place=True)
+    return img
 
 
 async def _optimize_quality(

--- a/app/views/lib/config.macro.ts
+++ b/app/views/lib/config.macro.ts
@@ -24,6 +24,7 @@ export const {
   EMAIL_MIN_LENGTH,
   ENV,
   LOCAL_CHAPTERS,
+  IMAGE_UPLOAD_MAX_PIXELS,
   MAP_QUERY_AREA_MAX_SIZE,
   MESSAGE_BODY_MAX_LENGTH,
   MESSAGE_RECIPIENTS_LIMIT,
@@ -62,6 +63,7 @@ export const {
   EMAIL_MIN_LENGTH: number
   ENV: "dev" | "test" | "prod"
   LOCAL_CHAPTERS: { id: string; url: string }[]
+  IMAGE_UPLOAD_MAX_PIXELS: number | null
   MAP_QUERY_AREA_MAX_SIZE: number
   MESSAGE_BODY_MAX_LENGTH: number
   MESSAGE_RECIPIENTS_LIMIT: number
@@ -113,6 +115,7 @@ print(json.dumps({k: globals()[k] for k in ${JSON.stringify([
         "EMAIL_MIN_LENGTH",
         "ENV",
         "LOCAL_CHAPTERS",
+        "IMAGE_UPLOAD_MAX_PIXELS",
         "MAP_QUERY_AREA_MAX_SIZE",
         "MESSAGE_BODY_MAX_LENGTH",
         "MESSAGE_RECIPIENTS_LIMIT",

--- a/app/views/lib/image-upload.ts
+++ b/app/views/lib/image-upload.ts
@@ -1,0 +1,150 @@
+import { IMAGE_UPLOAD_MAX_PIXELS } from "@lib/config"
+import { t } from "i18next"
+
+type ImageDimensions = {
+  width: number
+  height: number
+}
+
+const IMAGE_HEADER_BYTES = 64 * 1024
+
+const hasBytes = (view: DataView, offset: number, length: number) =>
+  offset >= 0 && offset + length <= view.byteLength
+
+const ascii = (view: DataView, offset: number, length: number) =>
+  hasBytes(view, offset, length)
+    ? String.fromCharCode(
+        ...new Uint8Array(view.buffer, view.byteOffset + offset, length),
+      )
+    : ""
+
+const uint24LE = (view: DataView, offset: number) =>
+  view.getUint8(offset) |
+  (view.getUint8(offset + 1) << 8) |
+  (view.getUint8(offset + 2) << 16)
+
+const parsePngDimensions = (view: DataView): ImageDimensions | null => {
+  if (ascii(view, 0, 8) !== "\x89PNG\r\n\x1A\n" || ascii(view, 12, 4) !== "IHDR")
+    return null
+
+  return {
+    width: view.getUint32(16),
+    height: view.getUint32(20),
+  }
+}
+
+const isJpegStartOfFrame = (marker: number) =>
+  marker >= 0xc0 && marker <= 0xcf && ![0xc4, 0xc8, 0xcc].includes(marker)
+
+const parseJpegDimensions = (view: DataView): ImageDimensions | null => {
+  if (!hasBytes(view, 0, 2) || view.getUint16(0) !== 0xffd8) return null
+
+  let offset = 2
+  while (hasBytes(view, offset, 4)) {
+    if (view.getUint8(offset) !== 0xff) return null
+    while (hasBytes(view, offset, 1) && view.getUint8(offset) === 0xff) offset++
+    if (!hasBytes(view, offset, 1)) return null
+
+    const marker = view.getUint8(offset++)
+    if (marker === 0xd9 || marker === 0xda) return null
+    if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7)) continue
+    if (!hasBytes(view, offset, 2)) return null
+
+    const segmentLength = view.getUint16(offset)
+    if (segmentLength < 2) throw new Error(t("validation.image_not_readable"))
+
+    if (isJpegStartOfFrame(marker)) {
+      if (!hasBytes(view, offset + 2, 5)) return null
+      return {
+        height: view.getUint16(offset + 3),
+        width: view.getUint16(offset + 5),
+      }
+    }
+
+    offset += segmentLength
+  }
+
+  return null
+}
+
+const parseGifDimensions = (view: DataView): ImageDimensions | null => {
+  const signature = ascii(view, 0, 6)
+  if (signature !== "GIF87a" && signature !== "GIF89a") return null
+
+  return {
+    width: view.getUint16(6, true),
+    height: view.getUint16(8, true),
+  }
+}
+
+const parseWebpDimensions = (view: DataView): ImageDimensions | null => {
+  if (ascii(view, 0, 4) !== "RIFF" || ascii(view, 8, 4) !== "WEBP") return null
+
+  const chunk = ascii(view, 12, 4)
+  if (chunk === "VP8X" && hasBytes(view, 24, 6)) {
+    return {
+      width: uint24LE(view, 24) + 1,
+      height: uint24LE(view, 27) + 1,
+    }
+  }
+
+  if (chunk === "VP8L" && hasBytes(view, 20, 5) && view.getUint8(20) === 0x2f) {
+    const b1 = view.getUint8(21)
+    const b2 = view.getUint8(22)
+    const b3 = view.getUint8(23)
+    const b4 = view.getUint8(24)
+
+    return {
+      width: 1 + b1 + ((b2 & 0x3f) << 8),
+      height: 1 + (b2 >> 6) + (b3 << 2) + ((b4 & 0x0f) << 10),
+    }
+  }
+
+  if (chunk === "VP8 " && hasBytes(view, 26, 4)) {
+    return {
+      width: view.getUint16(26, true) & 0x3fff,
+      height: view.getUint16(28, true) & 0x3fff,
+    }
+  }
+
+  return null
+}
+
+const parseBmpDimensions = (view: DataView): ImageDimensions | null => {
+  if (ascii(view, 0, 2) !== "BM" || !hasBytes(view, 18, 8)) return null
+
+  return {
+    width: Math.abs(view.getInt32(18, true)),
+    height: Math.abs(view.getInt32(22, true)),
+  }
+}
+
+const readImageDimensions = async (file: File) => {
+  const buffer = await file.slice(0, IMAGE_HEADER_BYTES).arrayBuffer()
+  const view = new DataView(buffer)
+
+  return (
+    parsePngDimensions(view) ??
+    parseJpegDimensions(view) ??
+    parseGifDimensions(view) ??
+    parseWebpDimensions(view) ??
+    parseBmpDimensions(view)
+  )
+}
+
+export const validateImageUpload = async (formData: FormData, field: string) => {
+  const value = formData.get(field)
+  if (!(value instanceof File) || value.size === 0 || !IMAGE_UPLOAD_MAX_PIXELS) return
+
+  let dimensions: ImageDimensions | null
+  try {
+    dimensions = await readImageDimensions(value)
+  } catch (error) {
+    console.debug("Failed to read image dimensions", error)
+    throw new Error(t("validation.image_not_readable"))
+  }
+
+  if (dimensions && dimensions.width * dimensions.height > IMAGE_UPLOAD_MAX_PIXELS) {
+    throw new Error(t("validation.image_too_large"))
+  }
+}

--- a/app/views/settings/applications/edit.tsx
+++ b/app/views/settings/applications/edit.tsx
@@ -1,5 +1,6 @@
 import { OAUTH_APP_NAME_MAX_LENGTH } from "@lib/config"
 import { CopyButton } from "@lib/copy-group"
+import { validateImageUpload } from "@lib/image-upload"
 import { mountProtoPage } from "@lib/proto-page"
 import { EditPageSchema, Service } from "@lib/proto/settings_applications_pb"
 import { Scope } from "@lib/proto/shared_pb"
@@ -247,10 +248,13 @@ mountProtoPage(
                         class="avatar-form"
                         formRef={avatarFormRef}
                         method={Service.method.updateAvatar}
-                        buildRequest={async ({ formData }) => ({
-                          id,
-                          avatarFile: await formDataBytes(formData, "avatar_file"),
-                        })}
+                        buildRequest={async ({ formData }) => {
+                          await validateImageUpload(formData, "avatar_file")
+                          return {
+                            id,
+                            avatarFile: await formDataBytes(formData, "avatar_file"),
+                          }
+                        }}
                         onSuccess={(resp) => (avatarUrl.value = resp.avatarUrl)}
                       >
                         <input

--- a/app/views/user/profile/profile.tsx
+++ b/app/views/user/profile/profile.tsx
@@ -3,6 +3,7 @@ import { config, USER_RECENT_ACTIVITY_ENTRIES } from "@lib/config"
 import { Time } from "@lib/datetime-inputs"
 import { FollowToggleForm } from "@lib/follow-toggle-form"
 import { tRich } from "@lib/i18n"
+import { validateImageUpload } from "@lib/image-upload"
 import { mountProtoPage } from "@lib/proto-page"
 import { PageSchema, type PageValid } from "@lib/proto/profile_pb"
 import { Service, UpdateAvatarRequest_Preset } from "@lib/proto/settings_pb"
@@ -166,9 +167,12 @@ const BackgroundForm = ({
     <StandardForm
       class="background-form"
       method={Service.method.updateBackground}
-      buildRequest={async ({ formData }) => ({
-        backgroundFile: await formDataBytes(formData, "background_file"),
-      })}
+      buildRequest={async ({ formData }) => {
+        await validateImageUpload(formData, "background_file")
+        return {
+          backgroundFile: await formDataBytes(formData, "background_file"),
+        }
+      }}
       onSuccess={(resp) => (backgroundUrl.value = resp.backgroundUrl)}
     >
       <input
@@ -247,6 +251,7 @@ const AvatarForm = ({
       class="avatar-form"
       method={Service.method.updateAvatar}
       buildRequest={async ({ formData }) => {
+        await validateImageUpload(formData, "avatar_file")
         const avatarFile = await formDataBytes(formData, "avatar_file")
         if (avatarFile.length) {
           return {

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -580,6 +580,8 @@ validation:
   you_can_send_message_to_at_most_count_recipients: "You can send a message to at most {{count}} recipients"
   you_can_add_at_most_count_tags: "You can add at most {{count}} tags"
   incomplete_location_information: Incomplete location information
+  image_not_readable: The selected image file could not be read
+  image_too_large: The selected image is too large
 action:
   go_back: Go back
   authorize: Authorize

--- a/shellscripts/cython-build.sh
+++ b/shellscripts/cython-build.sh
@@ -9,6 +9,9 @@ BLACKLIST["app/services/optimistic_diff/__init__.py"]=1
 # https://github.com/cython/cython/issues/6880
 BLACKLIST["app/lib/pydantic_settings_integration.py"]=1
 
+# Reason: Pillow image errors abort Python finalization under Cython profiling
+BLACKLIST["app/lib/image.py"]=1
+
 DIRS=(
   "app/exceptions" "app/exceptions06" "app/format" "app/lib"
   "app/middlewares" "app/responses" "app/services"

--- a/tests/lib/test_image.py
+++ b/tests/lib/test_image.py
@@ -3,8 +3,12 @@ from pathlib import Path
 
 import pytest
 from PIL import Image as PILImage
+from starlette import status
 
 from app.config import IMAGE_MAX_FRAMES
+from app.exceptions import Exceptions
+from app.exceptions.api_error import APIError
+from app.lib.exceptions_context import exceptions_context
 from app.lib.image import Image
 
 
@@ -42,3 +46,23 @@ async def test_normalize_avatar_preserves_animation(animation: bytes):
     assert len(normalized[0]) < len(animation)
     assert result.is_animated  # type: ignore
     assert 1 < result.n_frames <= IMAGE_MAX_FRAMES  # type: ignore
+
+
+async def test_normalize_avatar_rejects_unreadable_image():
+    with exceptions_context(Exceptions()), pytest.raises(APIError) as exc_info:
+        await Image.normalize_avatar(b'not an image')
+
+    assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert exc_info.value.detail == 'Image file is not readable'
+
+
+async def test_normalize_avatar_rejects_decompression_bomb_error(monkeypatch):
+    buffer = BytesIO()
+    PILImage.new('RGB', (2, 2)).save(buffer, format='PNG')
+    monkeypatch.setattr(PILImage, 'MAX_IMAGE_PIXELS', 1)
+
+    with exceptions_context(Exceptions()), pytest.raises(APIError) as exc_info:
+        await Image.normalize_avatar(buffer.getvalue())
+
+    assert exc_info.value.status_code == status.HTTP_413_CONTENT_TOO_LARGE
+    assert exc_info.value.detail == 'Image is too large'


### PR DESCRIPTION
Fixes #31.

Big or broken avatar images now show a clear error instead of a confusing failure.

The browser checks the image before upload, and I checked this with ruff, oxfmt, oxlint, compileall, and a small Pillow test.