### PR TITLE
Implement edit_help walkthrough redirect

### DIFF
--- a/app/views/index/app.tsx
+++ b/app/views/index/app.tsx
@@ -8,6 +8,7 @@ import { SearchForm } from "@index/search-form"
 import { RightSidebarOutlet } from "@index/sidebar"
 import { MapAlertPanel, MapAlerts, pushMapAlert } from "@map/alerts"
 import { initMainMap, mainMap, rightSidebar } from "@map/main-map"
+import { isLoggedIn } from "@utils/config"
 import { useDisposeLayoutEffect } from "@utils/dispose-scope"
 import { qsParseAll } from "@utils/query-string"
 import { render } from "preact"
@@ -21,6 +22,12 @@ const IndexPage = () => {
 
   useEffect(() => {
     const searchParams = qsParseAll(location.search)
+
+    if (isLoggedIn && searchParams.edit_help?.at(-1) === "1") {
+      window.location.replace("/edit#walkthrough=true")
+      return
+    }
+
     const remoteEdit =
       location.pathname === "/edit" && searchParams.editor?.at(-1) === "remote"
     const remoteEditTarget = remoteEdit


### PR DESCRIPTION
## Summary
- redirect logged-in `/?edit_help=1` visits to `/edit#walkthrough=true`
- run the redirect before main map initialization so the index page does not boot unnecessarily
- use `location.replace()` so the original query param is removed and the back button does not loop back into the redirect

Closes #28

## Verification
- `git diff --check`
- Static guard confirmed the redirect uses `isLoggedIn`, checks `edit_help=1`, points at `/edit#walkthrough=true`, and runs before `initMainMap()`

I could not run the full Nix test stack locally because `nix-shell` and `bun` are not installed in this environment.