### PR TITLE
Add changeset diff viewer link

### DIFF
--- a/app/views/index/changeset.tsx
+++ b/app/views/index/changeset.tsx
@@ -50,6 +50,8 @@ const focusPaint: FocusLayerPaint = {
   "line-width": 3,
 }
 
+const ACHAVI_URL = "https://overpass-api.de/achavi/?changeset="
+
 export const ChangesetStats = ({
   numCreate,
   numModify,
@@ -121,6 +123,18 @@ const ChangesetHeader = ({ data }: { data: DataValid }) => {
     </div>
   )
 }
+
+const ChangesetDiffLink = ({ id }: { id: bigint }) => (
+  <a
+    class="btn btn-sm btn-soft w-100 mb-3"
+    href={`${ACHAVI_URL}${id}`}
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    <i class="bi bi-signpost-split me-1-5" />
+    {t("changeset.open_changeset_diff")}
+  </a>
+)
 
 const SubscriptionForm = ({
   changesetId,
@@ -377,6 +391,7 @@ const ChangesetSidebar = ({
 
             <ChangesetHeader data={d} />
             <Tags tags={d.tags} />
+            <ChangesetDiffLink id={d.id} />
 
             {/* Report button */}
             {isLoggedIn && d.user && config.userConfig!.user.id !== d.user.id && (

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -39,6 +39,7 @@ map:
       title: Routing engine
 changeset:
   open: Open
+  open_changeset_diff: Open changeset diff
   this_changeset_is_state: This changeset is {{state}}
   count_one: "changeset"
   count_other: "changesets"


### PR DESCRIPTION
## Summary
- add an Open changeset diff action to the changeset sidebar
- point the action at Achavi using the current changeset id
- open the viewer in a new tab so the OSM-NG changeset page does not refresh

Closes #7

## Verification
- `git diff --check`
- Static guard confirmed the Achavi URL, `target="_blank"`, `rel="noopener noreferrer"`, and placement after the changeset tags

I could not run the full Nix/Bun test stack locally because `nix-shell` and `bun` are not installed in this environment.