### PR TITLE
Add founders compass badge assets

### DIFF
--- a/resources/founders-compass-badge.svg
+++ b/resources/founders-compass-badge.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">OpenStreetMap-NG Founder badge</title>
+  <desc id="desc">A folded map badge with an NG monogram, compass point, and Founder ribbon.</desc>
+  <defs>
+    <linearGradient id="map" x1="80" x2="432" y1="96" y2="416" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#d9f4b6"/>
+      <stop offset=".55" stop-color="#bde7a3"/>
+      <stop offset="1" stop-color="#93d28a"/>
+    </linearGradient>
+    <linearGradient id="gold" x1="160" x2="352" y1="120" y2="392" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffe68a"/>
+      <stop offset=".5" stop-color="#f5b942"/>
+      <stop offset="1" stop-color="#b97816"/>
+    </linearGradient>
+    <filter id="soft-shadow" x="-18%" y="-18%" width="136%" height="136%">
+      <feDropShadow dx="0" dy="12" stdDeviation="12" flood-color="#16351f" flood-opacity=".26"/>
+    </filter>
+  </defs>
+
+  <rect width="512" height="512" rx="112" fill="#f5f7ef"/>
+  <g filter="url(#soft-shadow)">
+    <path fill="url(#map)" d="M71 117 185 91l75 23 85-24 96 34-16 268-105 29-75-21-87 23-89-31 19-137Z"/>
+    <path fill="#fff" opacity=".18" d="m185 91 75 23-14 286-88 23Zm160-1 96 34-121 297-75-21Z"/>
+    <path fill="none" stroke="#80a873" stroke-linecap="round" stroke-width="4" opacity=".5" d="M102 173c58-16 91 18 140 6 58-14 83-59 160-33M93 263c60 24 105-10 156 8 50 18 84 61 158 43M130 355c44-28 92-14 131 4 45 20 86 15 126-18"/>
+    <path fill="none" stroke="#668bd0" stroke-linecap="round" stroke-width="7" opacity=".55" d="M100 319c47-17 72-73 115-77 48-5 74 48 126 41 33-4 52-29 80-31"/>
+    <path fill="none" stroke="#b45b68" stroke-linecap="round" stroke-linejoin="round" stroke-width="7" opacity=".62" d="m120 137 61 39-35 42 65 33-19 54 71 42 56-31 58 42"/>
+  </g>
+
+  <circle cx="256" cy="253" r="155" fill="#ffffff" opacity=".62"/>
+  <circle cx="256" cy="253" r="139" fill="none" stroke="url(#gold)" stroke-width="18"/>
+  <path fill="url(#gold)" d="m256 69 24 58 60 9-43 42 10 60-51-28-51 28 10-60-43-42 60-9Z"/>
+
+  <text x="256" y="285" fill="#ffffff" stroke="#101512" stroke-linejoin="round" stroke-width="14" font-family="Inter, Arial, sans-serif" font-size="126" font-weight="900" letter-spacing="0" text-anchor="middle">NG</text>
+  <text x="256" y="285" fill="#ffffff" font-family="Inter, Arial, sans-serif" font-size="126" font-weight="900" letter-spacing="0" text-anchor="middle">NG</text>
+
+  <path fill="#213a2b" d="M116 345h280l-28 70H144Z"/>
+  <path fill="#f6c95c" d="M143 364h226v31H143Z"/>
+  <text x="256" y="386" fill="#213a2b" font-family="Inter, Arial, sans-serif" font-size="25" font-weight="800" letter-spacing="0" text-anchor="middle">FOUNDER</text>
+</svg>

--- a/resources/founders-compass-wordmark-dark.svg
+++ b/resources/founders-compass-wordmark-dark.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="320" viewBox="0 0 1120 320" role="img" aria-labelledby="title desc">
+  <title id="title">OpenStreetMap-NG Founder wordmark dark</title>
+  <desc id="desc">Dark Founder wordmark with a compact folded map and compass badge.</desc>
+  <defs>
+    <linearGradient id="map" x1="32" x2="260" y1="38" y2="286" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#d9f4b6"/>
+      <stop offset=".6" stop-color="#bde7a3"/>
+      <stop offset="1" stop-color="#8fce86"/>
+    </linearGradient>
+    <linearGradient id="gold" x1="82" x2="238" y1="34" y2="294" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffe68a"/>
+      <stop offset=".52" stop-color="#f5b942"/>
+      <stop offset="1" stop-color="#b97816"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1120" height="320" rx="56" fill="#17231b"/>
+  <g transform="translate(34 34)">
+    <path fill="url(#map)" d="M13 49 78 34l48 14 50-15 63 20-11 162-62 17-46-13-55 15-55-19 12-82Z"/>
+    <path fill="none" stroke="#6d9b64" stroke-linecap="round" stroke-width="3" opacity=".5" d="M36 82c32-9 54 11 83 4 32-8 49-35 93-18M26 141c36 15 63-7 95 5 31 12 51 36 95 27M49 200c29-18 59-8 84 2 28 12 54 8 79-11"/>
+    <path fill="none" stroke="#668bd0" stroke-linecap="round" stroke-width="5" opacity=".55" d="M30 177c28-10 43-43 70-46 31-3 47 29 80 25 21-3 33-17 51-18"/>
+    <circle cx="126" cy="136" r="92" fill="#fff" opacity=".66"/>
+    <circle cx="126" cy="136" r="78" fill="none" stroke="url(#gold)" stroke-width="13"/>
+    <path fill="url(#gold)" d="m126 23 15 36 38 6-27 27 6 38-32-18-32 18 6-38-27-27 38-6Z"/>
+    <text x="126" y="157" fill="#fff" stroke="#101512" stroke-linejoin="round" stroke-width="9" font-family="Inter, Arial, sans-serif" font-size="70" font-weight="900" letter-spacing="0" text-anchor="middle">NG</text>
+    <text x="126" y="157" fill="#fff" font-family="Inter, Arial, sans-serif" font-size="70" font-weight="900" letter-spacing="0" text-anchor="middle">NG</text>
+  </g>
+
+  <text x="330" y="130" fill="#f5fbef" font-family="Inter, Arial, sans-serif" font-size="70" font-weight="850" letter-spacing="0">OpenStreetMap-NG</text>
+  <text x="331" y="204" fill="#ffd267" font-family="Inter, Arial, sans-serif" font-size="64" font-weight="800" letter-spacing="0">Founder</text>
+  <path fill="#f2bd45" d="M330 226h389v12H330Z"/>
+  <text x="330" y="272" fill="#b9c9bb" font-family="Inter, Arial, sans-serif" font-size="29" font-weight="600" letter-spacing="0">Community recognition badge</text>
+</svg>

--- a/resources/founders-compass-wordmark.svg
+++ b/resources/founders-compass-wordmark.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="320" viewBox="0 0 1120 320" role="img" aria-labelledby="title desc">
+  <title id="title">OpenStreetMap-NG Founder wordmark</title>
+  <desc id="desc">Founder wordmark with a compact folded map and compass badge.</desc>
+  <defs>
+    <linearGradient id="map" x1="32" x2="260" y1="38" y2="286" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#d9f4b6"/>
+      <stop offset=".6" stop-color="#bde7a3"/>
+      <stop offset="1" stop-color="#8fce86"/>
+    </linearGradient>
+    <linearGradient id="gold" x1="82" x2="238" y1="34" y2="294" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffe68a"/>
+      <stop offset=".52" stop-color="#f5b942"/>
+      <stop offset="1" stop-color="#b97816"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1120" height="320" rx="56" fill="#f8faf5"/>
+  <g transform="translate(34 34)">
+    <path fill="url(#map)" d="M13 49 78 34l48 14 50-15 63 20-11 162-62 17-46-13-55 15-55-19 12-82Z"/>
+    <path fill="none" stroke="#6d9b64" stroke-linecap="round" stroke-width="3" opacity=".5" d="M36 82c32-9 54 11 83 4 32-8 49-35 93-18M26 141c36 15 63-7 95 5 31 12 51 36 95 27M49 200c29-18 59-8 84 2 28 12 54 8 79-11"/>
+    <path fill="none" stroke="#668bd0" stroke-linecap="round" stroke-width="5" opacity=".55" d="M30 177c28-10 43-43 70-46 31-3 47 29 80 25 21-3 33-17 51-18"/>
+    <circle cx="126" cy="136" r="92" fill="#fff" opacity=".66"/>
+    <circle cx="126" cy="136" r="78" fill="none" stroke="url(#gold)" stroke-width="13"/>
+    <path fill="url(#gold)" d="m126 23 15 36 38 6-27 27 6 38-32-18-32 18 6-38-27-27 38-6Z"/>
+    <text x="126" y="157" fill="#fff" stroke="#101512" stroke-linejoin="round" stroke-width="9" font-family="Inter, Arial, sans-serif" font-size="70" font-weight="900" letter-spacing="0" text-anchor="middle">NG</text>
+    <text x="126" y="157" fill="#fff" font-family="Inter, Arial, sans-serif" font-size="70" font-weight="900" letter-spacing="0" text-anchor="middle">NG</text>
+  </g>
+
+  <text x="330" y="130" fill="#183323" font-family="Inter, Arial, sans-serif" font-size="70" font-weight="850" letter-spacing="0">OpenStreetMap-NG</text>
+  <text x="331" y="204" fill="#7c5a10" font-family="Inter, Arial, sans-serif" font-size="64" font-weight="800" letter-spacing="0">Founder</text>
+  <path fill="#f2bd45" d="M330 226h389v12H330Z"/>
+  <text x="330" y="272" fill="#536356" font-family="Inter, Arial, sans-serif" font-size="29" font-weight="600" letter-spacing="0">Community recognition badge</text>
+</svg>


### PR DESCRIPTION
## Summary
- add a square founders compass badge based on the existing folded-map + NG visual language
- add light and dark wordmark variants for profile or recognition contexts
- use a compass/star and ribbon direction so this remains distinct from the compact badge and seal alternatives already proposed

Addresses #114.

## Previews

| Badge | Light wordmark | Dark wordmark |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/TBSKR/openstreetmap-ng/codex/founders-compass-badge/resources/founders-compass-badge.svg" width="180" alt="Founders compass badge"> | <img src="https://raw.githubusercontent.com/TBSKR/openstreetmap-ng/codex/founders-compass-badge/resources/founders-compass-wordmark.svg" width="320" alt="Founders compass wordmark"> | <img src="https://raw.githubusercontent.com/TBSKR/openstreetmap-ng/codex/founders-compass-badge/resources/founders-compass-wordmark-dark.svg" width="320" alt="Founders compass wordmark dark"> |

## Validation
- XML parsed all three SVG files with Python ElementTree
- Quick Look generated thumbnails for all three SVG files
- git diff --check

If this direction is selected for the listed bounty, payout can be coordinated after acceptance through the project-supported methods; no payment details are included in the repo.