### PR TITLE
Reject suspicious Null Island edits

### DIFF
--- a/app/exceptions/diff_mixin.py
+++ b/app/exceptions/diff_mixin.py
@@ -15,9 +15,13 @@ class DiffExceptionsMixin:
         raise NotImplementedError
 
     @abstractmethod
-    def diff_create_bad_id(self, element: 'ElementInit') -> NoReturn:
+    def diff_create_bad_id(self, element: ElementInit) -> NoReturn:
         raise NotImplementedError
 
     @abstractmethod
-    def diff_update_bad_version(self, element: 'ElementInit') -> NoReturn:
+    def diff_null_island(self) -> NoReturn:
+        raise NotImplementedError
+
+    @abstractmethod
+    def diff_update_bad_version(self, element: ElementInit) -> NoReturn:
         raise NotImplementedError

--- a/app/exceptions/note_mixin.py
+++ b/app/exceptions/note_mixin.py
@@ -24,5 +24,9 @@ class NoteExceptionsMixin:
         raise NotImplementedError
 
     @abstractmethod
+    def note_null_island(self) -> NoReturn:
+        raise NotImplementedError
+
+    @abstractmethod
     def notes_query_area_too_big(self) -> NoReturn:
         raise NotImplementedError

--- a/app/exceptions06/diff_mixin.py
+++ b/app/exceptions06/diff_mixin.py
@@ -26,7 +26,7 @@ class DiffExceptions06Mixin(DiffExceptionsMixin):
         )
 
     @override
-    def diff_create_bad_id(self, element: 'ElementInit'):
+    def diff_create_bad_id(self, element: ElementInit):
         type = element_type(element['typed_id'])
         if type == 'node':
             raise APIError(
@@ -47,7 +47,14 @@ class DiffExceptions06Mixin(DiffExceptionsMixin):
             raise NotImplementedError(f'Unsupported element type {type!r}')
 
     @override
-    def diff_update_bad_version(self, element: 'ElementInit'):
+    def diff_null_island(self):
+        raise APIError(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail='Changeset uploads may contain at most one node at Null Island (0,0).',
+        )
+
+    @override
+    def diff_update_bad_version(self, element: ElementInit):
         raise APIError(
             status.HTTP_412_PRECONDITION_FAILED,
             detail=f'Update action requires version >= 1, got {element["version"] - 1}',

--- a/app/exceptions06/note_mixin.py
+++ b/app/exceptions06/note_mixin.py
@@ -25,6 +25,13 @@ class NoteExceptions06Mixin(NoteExceptionsMixin):
         )
 
     @override
+    def note_null_island(self):
+        raise APIError(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail='Creating notes at Null Island (0,0) is not allowed.',
+        )
+
+    @override
     def notes_query_area_too_big(self):
         raise APIError(
             status.HTTP_400_BAD_REQUEST,

--- a/app/services/note_service.py
+++ b/app/services/note_service.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from typing import Any
 
 import cython
+from app.models.proto.note_types import GetCommentsResponse_Comment_Event
 from psycopg.rows import dict_row
 from psycopg.sql import SQL, Composable
 from shapely import Point, get_coordinates
@@ -20,7 +21,6 @@ from app.models.db.note_comment import (
     note_comments_resolve_rich_text,
 )
 from app.models.db.user import user_is_moderator
-from app.models.proto.note_types import GetCommentsResponse_Comment_Event
 from app.models.types import DisplayName, NoteCommentId, NoteId
 from app.queries.nominatim_query import NominatimQuery
 from app.queries.note_comment_query import NoteCommentQuery
@@ -38,6 +38,9 @@ class NoteService:
         point = validate_geometry(Point(lon, lat))
 
         user = auth_user()
+        if point.x == 0 and point.y == 0 and not user_is_moderator(user):
+            raise_for.note_null_island()
+
         if user is not None:
             # Prevent OAuth to create user-authorized note
             scopes = auth_scopes()

--- a/app/services/optimistic_diff/prepare.py
+++ b/app/services/optimistic_diff/prepare.py
@@ -6,6 +6,7 @@ from typing import Final, Literal, TypeAlias, assert_never
 
 import cython
 import numpy as np
+from app.models.proto.shared_types import ElementType
 from psycopg import AsyncConnection
 from shapely import Point, bounds, box
 
@@ -14,6 +15,7 @@ from app.lib.changeset_bounds import extend_changeset_bounds
 from app.lib.exceptions_context import raise_for
 from app.models.db.changeset import Changeset, changeset_increase_size
 from app.models.db.element import Element, ElementInit
+from app.models.db.user import user_is_moderator
 from app.models.element import (
     TYPED_ELEMENT_ID_NODE_MAX,
     TYPED_ELEMENT_ID_NODE_MIN,
@@ -21,7 +23,6 @@ from app.models.element import (
     TYPED_ELEMENT_ID_RELATION_MIN,
     TypedElementId,
 )
-from app.models.proto.shared_types import ElementType
 from app.models.types import SequenceId
 from app.queries.changeset_bounds_query import ChangesetBoundsQuery
 from app.queries.changeset_query import ChangesetQuery
@@ -101,6 +102,21 @@ class OptimisticDiffPrepare:
     Changeset bounding box set of element refs.
     """
 
+    _null_island_node_refs: set[TypedElementId]
+    """
+    Local set of final visible node refs at Null Island.
+    """
+
+    _null_island_check_refs: set[TypedElementId]
+    """
+    Remote node refs that must be loaded before final Null Island validation.
+    """
+
+    _skip_null_island_check: bool
+    """
+    Whether Null Island validation should be skipped for the current user.
+    """
+
     def __init__(self, conn: AsyncConnection, elements: list[ElementInit], /):
         self.conn = conn
         self.apply_elements = []
@@ -112,6 +128,9 @@ class OptimisticDiffPrepare:
         self._reference_override = defaultdict(set)
         self._bbox_points = []
         self._bbox_refs = set()
+        self._null_island_node_refs = set()
+        self._null_island_check_refs = set()
+        self._skip_null_island_check = False
 
     async def prepare(self):
         await self._preload_changeset()
@@ -214,6 +233,9 @@ class OptimisticDiffPrepare:
             num_modify=num_modify,
             num_delete=num_delete,
         )
+        self._collect_null_island_info()
+        self._check_null_island_limit()
+        await self._check_null_island_refs()
 
         async with TaskGroup() as tg:
             tg.create_task(self._update_changeset_bounds())
@@ -437,6 +459,43 @@ class OptimisticDiffPrepare:
             assert point is not None, f'Node {typed_id} point must be set'
             bbox_points.append(point)
 
+    def _collect_null_island_info(self):
+        """Collect final visible Null Island nodes affected by this diff."""
+        if self._skip_null_island_check:
+            return
+
+        self._null_island_node_refs.clear()
+        self._null_island_check_refs.clear()
+
+        element_state: dict[TypedElementId, ElementStateEntry] = self.element_state
+        for entry in element_state.values():
+            element = entry.current
+            if not element['visible']:
+                continue
+
+            type = element_type(element['typed_id'])
+            if type == 'node':
+                if _is_null_island_point(element['point']):
+                    self._null_island_node_refs.add(element['typed_id'])
+                continue
+
+            if type != 'way':
+                continue
+
+            members = element['members']
+            if members is None:
+                continue
+
+            for node_ref in members:
+                member_entry = element_state.get(node_ref)
+                if member_entry is None:
+                    self._null_island_check_refs.add(node_ref)
+                    continue
+
+                member = member_entry.current
+                if member['visible'] and _is_null_island_point(member['point']):
+                    self._null_island_node_refs.add(node_ref)
+
     def _push_bbox_relation_info(
         self,
         prev: ElementInit | None,
@@ -528,9 +587,11 @@ class OptimisticDiffPrepare:
             raise_for.changeset_not_found(changeset_id)
 
         # Check permissions
-        current_user_id = auth_user(required=True)['id']
+        current_user = auth_user(required=True)
+        current_user_id = current_user['id']
         if changeset['user_id'] != current_user_id:
             raise_for.changeset_access_denied()
+        self._skip_null_island_check = user_is_moderator(current_user)
 
         # Check if changeset is closed
         if changeset['closed_at'] is not None:
@@ -612,6 +673,30 @@ class OptimisticDiffPrepare:
                 bounds_arr[:, 3].max(),
             )
 
+    def _check_null_island_limit(self):
+        if not self._skip_null_island_check and len(self._null_island_node_refs) >= 2:
+            raise_for.diff_null_island()
+
+    async def _check_null_island_refs(self):
+        """Load remote way members and enforce the Null Island node limit."""
+        if self._skip_null_island_check or not self._null_island_check_refs:
+            return
+
+        node_refs = list(self._null_island_check_refs - self._null_island_node_refs)
+        if not node_refs:
+            return
+
+        elements = await ElementQuery.find_by_refs(
+            node_refs,
+            at_sequence_id=self.at_sequence_id,
+            limit=None,
+        )
+        for element in elements:
+            if element['visible'] and _is_null_island_point(element['point']):
+                self._null_island_node_refs.add(element['typed_id'])
+
+        self._check_null_island_limit()
+
     async def _check_members_remote(self):
         """Check if the members exist and are visible using the database."""
         elements_check_members_remote = self._elements_check_members_remote
@@ -629,3 +714,7 @@ class OptimisticDiffPrepare:
         hidden_ref = next(iter(hidden_refs))
         parent_typed_id = elements_check_members_remote[hidden_ref]
         raise_for.element_member_not_found(parent_typed_id, hidden_ref)
+
+
+def _is_null_island_point(point: Point | None):
+    return point is not None and point.x == 0 and point.y == 0

--- a/tests/controllers/test_api06_changeset.py
+++ b/tests/controllers/test_api06_changeset.py
@@ -165,6 +165,44 @@ async def test_changeset_upload(client: AsyncClient):
     )
 
 
+async def test_changeset_upload_rejects_multiple_null_island_nodes(
+    client: AsyncClient,
+):
+    client.headers['Authorization'] = 'User user1'
+
+    r = await client.put(
+        '/api/0.6/changeset/create',
+        content=XMLToDict.unparse({
+            'osm': {
+                'changeset': {
+                    'tag': [
+                        {
+                            '@k': 'created_by',
+                            '@v': test_changeset_upload_rejects_multiple_null_island_nodes.__name__,
+                        }
+                    ]
+                }
+            }
+        }),
+    )
+    assert r.is_success, r.text
+    changeset_id = int(r.text)
+
+    r = await client.post(
+        f'/api/0.6/changeset/{changeset_id}/upload',
+        content=XMLToDict.unparse({
+            'osmChange': {
+                'create': [
+                    ('node', {'@id': -1, '@lat': 0, '@lon': 0}),
+                    ('node', {'@id': -2, '@lat': 0, '@lon': 0}),
+                ]
+            }
+        }),
+    )
+
+    assert r.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, r.text
+
+
 @pytest.mark.parametrize('include', [True, False])
 async def test_changeset_with_discussion(client: AsyncClient, include):
     client.headers['Authorization'] = 'User user1'

--- a/tests/controllers/test_api06_note.py
+++ b/tests/controllers/test_api06_note.py
@@ -17,7 +17,7 @@ async def test_note_create_xml(client: AsyncClient):
 
     r = await client.post(
         '/api/0.6/notes',
-        params={'lon': 0, 'lat': 0, 'text': test_note_create_xml.__qualname__},
+        params={'lon': 1, 'lat': 1, 'text': test_note_create_xml.__qualname__},
     )
     assert r.is_success, r.text
     note: dict = XMLToDict.parse(r.content)['osm']['note'][0]
@@ -26,8 +26,8 @@ async def test_note_create_xml(client: AsyncClient):
     assert_model(
         note,
         {
-            '@lat': 0.0,
-            '@lon': 0.0,
+            '@lat': 1.0,
+            '@lon': 1.0,
             'id': PositiveInt,
             'status': 'open',
             'url': str,
@@ -51,7 +51,7 @@ async def test_note_create_json(client: AsyncClient):
 
     r = await client.post(
         '/api/0.6/notes.json',
-        json={'lon': 0, 'lat': 0, 'text': test_note_create_json.__qualname__},
+        json={'lon': 1, 'lat': 1, 'text': test_note_create_json.__qualname__},
     )
     assert r.is_success, r.text
     props = r.json()['properties']
@@ -72,7 +72,7 @@ async def test_note_create_gpx(client: AsyncClient):
 
     r = await client.post(
         '/api/0.6/notes.gpx',
-        params={'lon': 0, 'lat': 0, 'text': test_note_create_gpx.__qualname__},
+        params={'lon': 1, 'lat': 1, 'text': test_note_create_gpx.__qualname__},
     )
     assert r.is_success, r.text
     waypoint: dict = XMLToDict.parse(r.content)['gpx']['wpt']
@@ -80,8 +80,8 @@ async def test_note_create_gpx(client: AsyncClient):
     assert_model(
         waypoint,
         {
-            '@lat': 0.0,
-            '@lon': 0.0,
+            '@lat': 1.0,
+            '@lon': 1.0,
             'time': datetime,
             'name': str,
             'link': dict,
@@ -94,7 +94,7 @@ async def test_note_create_gpx(client: AsyncClient):
 async def test_note_create_anonymous(client: AsyncClient):
     r = await client.post(
         '/api/0.6/notes.json',
-        json={'lon': 0, 'lat': 0, 'text': test_note_create_anonymous.__qualname__},
+        json={'lon': 1, 'lat': 1, 'text': test_note_create_anonymous.__qualname__},
     )
     assert r.is_success, r.text
     props = r.json()['properties']
@@ -116,7 +116,7 @@ async def test_note_crud(client: AsyncClient):
     # Step 1: Create a note
     r = await client.post(
         '/api/0.6/notes.json',
-        json={'lon': 0, 'lat': 0, 'text': test_note_crud.__qualname__},
+        json={'lon': 1, 'lat': 1, 'text': test_note_crud.__qualname__},
     )
     assert r.is_success, r.text
     props = r.json()['properties']
@@ -232,6 +232,36 @@ async def test_note_bad_input(client: AsyncClient, input_data):
     assert r.is_client_error, r.text
 
 
+async def test_note_create_rejects_null_island(client: AsyncClient):
+    client.headers['Authorization'] = 'User user1'
+
+    r = await client.post(
+        '/api/0.6/notes.json',
+        json={
+            'lon': 0,
+            'lat': 0,
+            'text': test_note_create_rejects_null_island.__qualname__,
+        },
+    )
+
+    assert r.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, r.text
+
+
+async def test_note_create_allows_null_island_for_moderator(client: AsyncClient):
+    client.headers['Authorization'] = 'User moderator'
+
+    r = await client.post(
+        '/api/0.6/notes.json',
+        json={
+            'lon': 0,
+            'lat': 0,
+            'text': test_note_create_allows_null_island_for_moderator.__qualname__,
+        },
+    )
+
+    assert r.is_success, r.text
+
+
 async def test_note_query_by_bbox(client: AsyncClient):
     # Create a note at a specific location
     lon = round(uniform(-179, 179), 7)
@@ -264,7 +294,7 @@ async def test_note_search(client: AsyncClient):
     text = f'{test_note_search.__qualname__} {search_text}'
     r = await client.post(
         '/api/0.6/notes.json',
-        json={'lon': 0, 'lat': 0, 'text': text},
+        json={'lon': 1, 'lat': 1, 'text': text},
     )
     assert r.is_success, r.text
 

--- a/tests/controllers/test_oauth2.py
+++ b/tests/controllers/test_oauth2.py
@@ -463,7 +463,7 @@ async def test_access_token_in_form(client: AsyncClient, valid_scope):
     # Attempt to create a note using the token in form data
     r = await client.post(
         '/api/0.6/notes',
-        params={'lon': 0, 'lat': 0, 'text': test_access_token_in_form.__qualname__},
+        params={'lon': 1, 'lat': 1, 'text': test_access_token_in_form.__qualname__},
         data={'access_token': access_token},
     )
 

--- a/tests/middlewares/test_request_body_middleware.py
+++ b/tests/middlewares/test_request_body_middleware.py
@@ -78,7 +78,7 @@ async def test_compressed_json(
 
     # Setup test data
     text = f'{test_compressed_json.__qualname__}: {encoding}'
-    content = orjson.dumps({'lon': 0, 'lat': 0, 'text': text})
+    content = orjson.dumps({'lon': 1, 'lat': 1, 'text': text})
 
     # Execute request with compressed JSON
     r = await client.post(
@@ -166,7 +166,7 @@ async def test_passthrough_unsupported_compression(client: AsyncClient):
 
     # Setup test data
     text = 'unknown compression'
-    content = orjson.dumps({'lon': 0, 'lat': 0, 'text': text})
+    content = orjson.dumps({'lon': 1, 'lat': 1, 'text': text})
 
     # Execute request with unsupported compression header
     r = await client.post(
@@ -207,7 +207,7 @@ async def test_size_limit_after_decompression(
 
     # Create data that's small when compressed but exceeds limits when decompressed
     content = compress(
-        orjson.dumps({'lon': 0, 'lat': 0, 'text': 'A' * REQUEST_BODY_MAX_SIZE})
+        orjson.dumps({'lon': 1, 'lat': 1, 'text': 'A' * REQUEST_BODY_MAX_SIZE})
     )
     assert len(content) < REQUEST_BODY_MAX_SIZE, (
         'Compressed content must be under size limit'

--- a/tests/models/test_note_comment.py
+++ b/tests/models/test_note_comment.py
@@ -10,7 +10,7 @@ async def test_note_comments_resolve_rich_text():
     user = await UserQuery.find_by_display_name(DisplayName('user1'))
     with auth_context(user, frozenset(('web_user',))):
         note_id = await NoteService.create(
-            0, 0, test_note_comments_resolve_rich_text.__qualname__
+            1, 1, test_note_comments_resolve_rich_text.__qualname__
         )
         header = await NoteCommentQuery.find_header(note_id)
         assert header is not None

--- a/tests/services/optimistic_diff/test_create.py
+++ b/tests/services/optimistic_diff/test_create.py
@@ -1,10 +1,10 @@
 import pytest
+from app.models.proto.shared_types import ElementType
 from shapely import Point
 
 from app.lib.user_role_limits import UserRoleLimits
 from app.models.db.element import ElementInit, validate_elements
 from app.models.element import ElementId
-from app.models.proto.shared_types import ElementType
 from app.models.types import ChangesetId
 from app.queries.element_query import ElementQuery
 from app.services.changeset_service import ChangesetService
@@ -94,6 +94,73 @@ async def test_create_multiple_nodes(changeset_id: ChangesetId):
     name_map = {e['tags']['name']: e for e in elements}  # type: ignore
     assert_model(name_map['Node 1'], nodes[0] | {'typed_id': typed_ids[0]})
     assert_model(name_map['Node 2'], nodes[1] | {'typed_id': typed_ids[1]})
+
+
+async def test_create_fails_with_multiple_null_island_nodes(
+    changeset_id: ChangesetId,
+):
+    elements: list[ElementInit] = [
+        {
+            'changeset_id': changeset_id,
+            'typed_id': typed_element_id('node', ElementId(-1)),
+            'version': 1,
+            'visible': True,
+            'tags': {},
+            'point': Point(0, 0),
+            'members': None,
+            'members_roles': None,
+        },
+        {
+            'changeset_id': changeset_id,
+            'typed_id': typed_element_id('node', ElementId(-2)),
+            'version': 1,
+            'visible': True,
+            'tags': {},
+            'point': Point(0, 0),
+            'members': None,
+            'members_roles': None,
+        },
+    ]
+
+    with pytest.raises(Exception):
+        await OptimisticDiff.run(elements)
+
+
+async def test_create_way_fails_with_multiple_null_island_members(
+    changeset_id: ChangesetId,
+):
+    node: ElementInit = {
+        'changeset_id': changeset_id,
+        'typed_id': typed_element_id('node', ElementId(-1)),
+        'version': 1,
+        'visible': True,
+        'tags': {},
+        'point': Point(0, 0),
+        'members': None,
+        'members_roles': None,
+    }
+    node1_ref = (await OptimisticDiff.run([node]))[
+        typed_element_id('node', ElementId(-1))
+    ][0]
+    node2_ref = (
+        await OptimisticDiff.run([
+            node | {'typed_id': typed_element_id('node', ElementId(-2))}
+        ])
+    )[typed_element_id('node', ElementId(-2))][0]
+
+    way: ElementInit = {
+        'changeset_id': changeset_id,
+        'typed_id': typed_element_id('way', ElementId(-1)),
+        'version': 1,
+        'visible': True,
+        'tags': {},
+        'point': None,
+        'members': [node1_ref, node2_ref],
+        'members_roles': None,
+    }
+
+    with pytest.raises(Exception):
+        await OptimisticDiff.run([way])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Fixes #128 by adding a focused Null Island guard for suspicious edit activity while preserving legitimate edge cases.

Implemented behavior:
- Reject non-moderator changeset uploads whose final affected state contains **2 or more visible nodes at (0,0)**.
- Count both directly uploaded nodes and way member nodes, including referenced remote nodes loaded from the database.
- Allow a single visible Null Island node, matching the discussion that one legitimate edit should not be blocked.
- Reject non-moderator note creation exactly at `(0,0)`.
- Allow moderator/admin bypass via the existing `user_is_moderator` helper.

## Why this shape

The issue discussion settled toward blocking "suspicious edits" rather than banning every possible Null Island object. This patch implements that narrower rule:

- `1` Null Island node: allowed
- `2+` visible affected Null Island nodes: rejected
- Notes exactly at `(0,0)`: rejected
- Moderators/admins: bypassed

## Validation

Passed locally:

```bash
python3 -m py_compile app/exceptions/diff_mixin.py app/exceptions06/diff_mixin.py app/exceptions/note_mixin.py app/exceptions06/note_mixin.py app/services/note_service.py app/services/optimistic_diff/prepare.py
git diff --check
uvx ruff check app/exceptions/diff_mixin.py app/exceptions06/diff_mixin.py app/exceptions/note_mixin.py app/exceptions06/note_mixin.py app/services/note_service.py app/services/optimistic_diff/prepare.py tests/controllers/test_api06_changeset.py tests/controllers/test_api06_note.py tests/controllers/test_oauth2.py tests/middlewares/test_request_body_middleware.py tests/models/test_note_comment.py tests/services/optimistic_diff/test_create.py
uvx ruff format --check app/exceptions/diff_mixin.py app/exceptions06/diff_mixin.py app/exceptions/note_mixin.py app/exceptions06/note_mixin.py app/services/note_service.py app/services/optimistic_diff/prepare.py tests/controllers/test_api06_changeset.py tests/controllers/test_api06_note.py tests/controllers/test_oauth2.py tests/middlewares/test_request_body_middleware.py tests/models/test_note_comment.py tests/services/optimistic_diff/test_create.py
```

Targeted pytest was attempted, but the local environment is missing the frontend-generated resource file required during test import:

```text
FileNotFoundError: node_modules/osm-community-index/dist/json/resources.min.json
```

No test assertion failures were reached.
