### PR TITLE
Handle edit_help walkthrough links

### DIFF
--- a/app/views/index/app.tsx
+++ b/app/views/index/app.tsx
@@ -2,6 +2,7 @@ import { routerRoute } from "@index/router"
 import { IndexRouterOutlet } from "@index/router-outlet"
 import { SearchForm } from "@index/search-form"
 import { RightSidebarOutlet } from "@index/sidebar/sidebar-outlet"
+import { isLoggedIn } from "@lib/config"
 import { useDisposeLayoutEffect } from "@lib/dispose-scope"
 import { MapAlertPanel, MapAlerts, pushMapAlert } from "@lib/map/alerts"
 import { initMainMap, mainMap, rightSidebar } from "@lib/map/main-map"
@@ -18,6 +19,11 @@ const IndexPage = () => {
 
   useEffect(() => {
     const searchParams = qsParseAll(location.search)
+    if (isLoggedIn && searchParams.edit_help?.at(-1) === "1") {
+      window.location.replace("/edit#walkthrough=true")
+      return
+    }
+
     const remoteEdit =
       location.pathname === "/edit" && searchParams.editor?.at(-1) === "remote"
     const remoteEditTarget = remoteEdit


### PR DESCRIPTION
## Summary
- redirect logged-in users from `/?edit_help=1` to `/edit#walkthrough=true`
- leave logged-out users unaffected, matching the existing guarded start-mapping links
- use `location.replace()` so the `edit_help` query parameter is removed from browser history

## Notes
- Current-tree replacement for stale/conflicting #212. I can close this if maintainers prefer reviving that PR.

Closes #28

## Testing
- `git diff --check`
- `npx --yes prettier --check app/views/index/app.tsx` (blocked locally: project dependencies are not installed, so Prettier cannot resolve `prettier-plugin-jinja-template`)