### PR TITLE
Reject repeated null island edits

### DIFF
--- a/app/exceptions/api06.py
+++ b/app/exceptions/api06.py
@@ -194,6 +194,14 @@ class Exceptions06(Exceptions):
             detail=f'Update action requires version >= 1, got {element["version"] - 1}',
         )
 
+    @override
+    def diff_null_island(self, count: int):
+        raise APIError(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f'Changeset contains {count} nodes at the null island (0, 0). '
+            'This is typically caused by a software bug in the editor.',
+        )
+
     # --- element ---
     @override
     def element_not_found(
@@ -350,6 +358,14 @@ class Exceptions06(Exceptions):
     def note_open(self, note_id: NoteId):
         raise APIError(
             status.HTTP_409_CONFLICT, detail=f'The note {note_id} is already open'
+        )
+
+    @override
+    def note_null_island(self):
+        raise APIError(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail='Creating notes at the null island (0, 0) is not allowed. '
+            'This is typically caused by a software bug.',
         )
 
     @override

--- a/app/exceptions/default.py
+++ b/app/exceptions/default.py
@@ -135,6 +135,9 @@ class Exceptions:
     def diff_update_bad_version(self, element: ElementInit) -> NoReturn:
         raise NotImplementedError
 
+    def diff_null_island(self, count: int) -> NoReturn:
+        raise NotImplementedError
+
     # --- element ---
     def element_not_found(
         self, element_ref: TypedElementId | tuple[TypedElementId, int]
@@ -218,6 +221,9 @@ class Exceptions:
         raise NotImplementedError
 
     def note_open(self, note_id: NoteId) -> NoReturn:
+        raise NotImplementedError
+
+    def note_null_island(self) -> NoReturn:
         raise NotImplementedError
 
     def notes_query_area_too_big(self) -> NoReturn:

--- a/app/services/note_service.py
+++ b/app/services/note_service.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from typing import Any
 
 import cython
+from app.models.proto.note_types import GetCommentsResponse_Comment_Event
 from shapely import Point, get_coordinates
 
 from app.db import db, db_fetchone, db_insert, db_update
@@ -18,7 +19,6 @@ from app.models.db.note_comment import (
     note_comments_resolve_rich_text,
 )
 from app.models.db.user import user_is_moderator
-from app.models.proto.note_types import GetCommentsResponse_Comment_Event
 from app.models.types import DisplayName, NoteCommentId, NoteId
 from app.queries.nominatim_query import NominatimQuery
 from app.queries.note_query import NoteCommentQuery
@@ -35,6 +35,9 @@ class NoteService:
         point = validate_geometry(Point(lon, lat))
 
         user = auth_user()
+        if point.x == 0.0 and point.y == 0.0 and not user_is_moderator(user):
+            raise_for.note_null_island()
+
         if user is not None:
             # Prevent OAuth to create user-authorized note
             scopes = auth_scopes()

--- a/app/services/optimistic_diff/prepare.py
+++ b/app/services/optimistic_diff/prepare.py
@@ -6,6 +6,7 @@ from typing import Final, Literal, TypeAlias, assert_never
 
 import cython
 import numpy as np
+from app.models.proto.shared_types import ElementType
 from psycopg import AsyncConnection
 from shapely import Point, bounds, box
 
@@ -14,6 +15,7 @@ from app.lib.auth.context import auth_user
 from app.lib.geo.changeset_bounds import extend_changeset_bounds
 from app.models.db.changeset import Changeset, changeset_increase_size
 from app.models.db.element import Element, ElementInit
+from app.models.db.user import user_is_moderator
 from app.models.element import (
     TYPED_ELEMENT_ID_NODE_MAX,
     TYPED_ELEMENT_ID_NODE_MIN,
@@ -21,7 +23,6 @@ from app.models.element import (
     TYPED_ELEMENT_ID_RELATION_MIN,
     TypedElementId,
 )
-from app.models.proto.shared_types import ElementType
 from app.models.types import SequenceId
 from app.queries.changeset_query import ChangesetBoundsQuery, ChangesetQuery
 from app.queries.element_query import ElementQuery
@@ -207,6 +208,16 @@ class OptimisticDiffPrepare:
                 )
             else:
                 entry.current = element
+
+        if not user_is_moderator(auth_user()):
+            null_island_count: cython.size_t = 0
+            for element in apply_elements:
+                point = element.get('point')
+                if point is not None and point.x == 0.0 and point.y == 0.0:
+                    null_island_count += 1
+
+            if null_island_count >= 2:
+                raise_for.diff_null_island(null_island_count)
 
         self._update_changeset_size(
             num_create=num_create,

--- a/tests/controllers/test_api06_changeset.py
+++ b/tests/controllers/test_api06_changeset.py
@@ -165,6 +165,45 @@ async def test_changeset_upload(client: AsyncClient):
     )
 
 
+async def test_changeset_upload_rejects_multiple_null_island_nodes(
+    client: AsyncClient,
+):
+    client.headers['Authorization'] = 'User user1'
+
+    r = await client.put(
+        '/api/0.6/changeset/create',
+        content=XMLToDict.unparse({
+            'osm': {
+                'changeset': {
+                    'tag': [
+                        {
+                            '@k': 'created_by',
+                            '@v': test_changeset_upload_rejects_multiple_null_island_nodes.__name__,
+                        }
+                    ]
+                }
+            }
+        }),
+    )
+    assert r.is_success, r.text
+    changeset_id = int(r.text)
+
+    r = await client.post(
+        f'/api/0.6/changeset/{changeset_id}/upload',
+        content=XMLToDict.unparse({
+            'osmChange': {
+                'create': [
+                    ('node', {'@id': -1, '@lat': 0, '@lon': 0}),
+                    ('node', {'@id': -2, '@lat': 0, '@lon': 0}),
+                ]
+            }
+        }),
+    )
+
+    assert r.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, r.text
+    assert 'null island' in r.json()['detail']
+
+
 @pytest.mark.parametrize('include', [True, False])
 async def test_changeset_with_discussion(client: AsyncClient, include):
     client.headers['Authorization'] = 'User user1'

--- a/tests/controllers/test_api06_note.py
+++ b/tests/controllers/test_api06_note.py
@@ -17,7 +17,7 @@ async def test_note_create_xml(client: AsyncClient):
 
     r = await client.post(
         '/api/0.6/notes',
-        params={'lon': 0, 'lat': 0, 'text': test_note_create_xml.__qualname__},
+        params={'lon': 1, 'lat': 1, 'text': test_note_create_xml.__qualname__},
     )
     assert r.is_success, r.text
     note: dict = XMLToDict.parse(r.content)['osm']['note'][0]
@@ -26,8 +26,8 @@ async def test_note_create_xml(client: AsyncClient):
     assert_model(
         note,
         {
-            '@lat': 0.0,
-            '@lon': 0.0,
+            '@lat': 1.0,
+            '@lon': 1.0,
             'id': PositiveInt,
             'status': 'open',
             'url': str,
@@ -51,7 +51,7 @@ async def test_note_create_json(client: AsyncClient):
 
     r = await client.post(
         '/api/0.6/notes.json',
-        json={'lon': 0, 'lat': 0, 'text': test_note_create_json.__qualname__},
+        json={'lon': 1, 'lat': 1, 'text': test_note_create_json.__qualname__},
     )
     assert r.is_success, r.text
     props = r.json()['properties']
@@ -72,7 +72,7 @@ async def test_note_create_gpx(client: AsyncClient):
 
     r = await client.post(
         '/api/0.6/notes.gpx',
-        params={'lon': 0, 'lat': 0, 'text': test_note_create_gpx.__qualname__},
+        params={'lon': 1, 'lat': 1, 'text': test_note_create_gpx.__qualname__},
     )
     assert r.is_success, r.text
     waypoint: dict = XMLToDict.parse(r.content)['gpx']['wpt']
@@ -80,8 +80,8 @@ async def test_note_create_gpx(client: AsyncClient):
     assert_model(
         waypoint,
         {
-            '@lat': 0.0,
-            '@lon': 0.0,
+            '@lat': 1.0,
+            '@lon': 1.0,
             'time': datetime,
             'name': str,
             'link': dict,
@@ -94,7 +94,7 @@ async def test_note_create_gpx(client: AsyncClient):
 async def test_note_create_anonymous(client: AsyncClient):
     r = await client.post(
         '/api/0.6/notes.json',
-        json={'lon': 0, 'lat': 0, 'text': test_note_create_anonymous.__qualname__},
+        json={'lon': 1, 'lat': 1, 'text': test_note_create_anonymous.__qualname__},
     )
     assert r.is_success, r.text
     props = r.json()['properties']
@@ -110,13 +110,54 @@ async def test_note_create_anonymous(client: AsyncClient):
     assert 'user' not in props['comments'][0]
 
 
+async def test_note_create_null_island_rejected(client: AsyncClient):
+    client.headers['Authorization'] = 'User user1'
+
+    r = await client.post(
+        '/api/0.6/notes.json',
+        json={
+            'lon': 0,
+            'lat': 0,
+            'text': test_note_create_null_island_rejected.__qualname__,
+        },
+    )
+
+    assert r.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, r.text
+    assert 'null island' in r.json()['detail']
+
+
+async def test_note_create_null_island_allows_moderator(client: AsyncClient):
+    client.headers['Authorization'] = 'User moderator'
+
+    r = await client.post(
+        '/api/0.6/notes.json',
+        json={
+            'lon': 0,
+            'lat': 0,
+            'text': test_note_create_null_island_allows_moderator.__qualname__,
+        },
+    )
+
+    assert r.is_success, r.text
+    props = r.json()['properties']
+    assert_model(props, {'status': 'open', 'comments': Len(1, 1)})
+    assert_model(
+        props['comments'][0],
+        {
+            'user': 'moderator',
+            'action': 'opened',
+            'text': test_note_create_null_island_allows_moderator.__qualname__,
+        },
+    )
+
+
 async def test_note_crud(client: AsyncClient):
     client.headers['Authorization'] = 'User user1'
 
     # Step 1: Create a note
     r = await client.post(
         '/api/0.6/notes.json',
-        json={'lon': 0, 'lat': 0, 'text': test_note_crud.__qualname__},
+        json={'lon': 1, 'lat': 1, 'text': test_note_crud.__qualname__},
     )
     assert r.is_success, r.text
     props = r.json()['properties']
@@ -224,7 +265,7 @@ async def test_note_crud(client: AsyncClient):
     [
         {'lon': 181, 'lat': 0, 'text': 'Invalid longitude'},
         {'lon': 0, 'lat': 91, 'text': 'Invalid latitude'},
-        {'lon': 0, 'lat': 0, 'text': ''},
+        {'lon': 1, 'lat': 1, 'text': ''},
     ],
 )
 async def test_note_bad_input(client: AsyncClient, input_data):
@@ -264,7 +305,7 @@ async def test_note_search(client: AsyncClient):
     text = f'{test_note_search.__qualname__} {search_text}'
     r = await client.post(
         '/api/0.6/notes.json',
-        json={'lon': 0, 'lat': 0, 'text': text},
+        json={'lon': 1, 'lat': 1, 'text': text},
     )
     assert r.is_success, r.text
 

--- a/tests/controllers/test_oauth2.py
+++ b/tests/controllers/test_oauth2.py
@@ -463,7 +463,7 @@ async def test_access_token_in_form(client: AsyncClient, valid_scope):
     # Attempt to create a note using the token in form data
     r = await client.post(
         '/api/0.6/notes',
-        params={'lon': 0, 'lat': 0, 'text': test_access_token_in_form.__qualname__},
+        params={'lon': 1, 'lat': 1, 'text': test_access_token_in_form.__qualname__},
         data={'access_token': access_token},
     )
 

--- a/tests/middlewares/test_request_body_middleware.py
+++ b/tests/middlewares/test_request_body_middleware.py
@@ -78,7 +78,7 @@ async def test_compressed_json(
 
     # Setup test data
     text = f'{test_compressed_json.__qualname__}: {encoding}'
-    content = orjson.dumps({'lon': 0, 'lat': 0, 'text': text})
+    content = orjson.dumps({'lon': 1, 'lat': 1, 'text': text})
 
     # Execute request with compressed JSON
     r = await client.post(
@@ -166,7 +166,7 @@ async def test_passthrough_unsupported_compression(client: AsyncClient):
 
     # Setup test data
     text = 'unknown compression'
-    content = orjson.dumps({'lon': 0, 'lat': 0, 'text': text})
+    content = orjson.dumps({'lon': 1, 'lat': 1, 'text': text})
 
     # Execute request with unsupported compression header
     r = await client.post(
@@ -207,7 +207,7 @@ async def test_size_limit_after_decompression(
 
     # Create data that's small when compressed but exceeds limits when decompressed
     content = compress(
-        orjson.dumps({'lon': 0, 'lat': 0, 'text': 'A' * REQUEST_BODY_MAX_SIZE})
+        orjson.dumps({'lon': 1, 'lat': 1, 'text': 'A' * REQUEST_BODY_MAX_SIZE})
     )
     assert len(content) < REQUEST_BODY_MAX_SIZE, (
         'Compressed content must be under size limit'

--- a/tests/models/test_note_comment.py
+++ b/tests/models/test_note_comment.py
@@ -10,7 +10,7 @@ async def test_note_comments_resolve_rich_text():
     user = await UserQuery.find_by_display_name(DisplayName('user1'))
     with auth_context(user, frozenset(('web_user',))):
         note_id = await NoteService.create(
-            0, 0, test_note_comments_resolve_rich_text.__qualname__
+            1, 1, test_note_comments_resolve_rich_text.__qualname__
         )
         header = await NoteCommentQuery.find_header(note_id)
         assert header is not None


### PR DESCRIPTION
Closes #128.

This is a current-base pass for the null-island guard discussed in the issue.

What changed
- Reject non-moderator note creation at `(0, 0)` with a 422 response.
- Reject non-moderator changeset uploads that contain two or more nodes at `(0, 0)`.
- Keep moderator/admin bypasses in place for cleanup and exceptional cases.
- Move existing note tests off synthetic `(0, 0)` coordinates so the new guard is covered intentionally.

Verification
- `UV_NATIVE_TLS=true uvx ruff check app/exceptions/diff_mixin.py app/exceptions/note_mixin.py app/exceptions06/diff_mixin.py app/exceptions06/note_mixin.py app/services/note_service.py app/services/optimistic_diff/prepare.py tests/controllers/test_api06_note.py tests/controllers/test_api06_changeset.py tests/controllers/test_oauth2.py tests/middlewares/test_request_body_middleware.py tests/models/test_note_comment.py`
- `UV_NATIVE_TLS=true uvx ruff format --check app/exceptions/diff_mixin.py app/exceptions/note_mixin.py app/exceptions06/diff_mixin.py app/exceptions06/note_mixin.py app/services/note_service.py app/services/optimistic_diff/prepare.py tests/controllers/test_api06_note.py tests/controllers/test_api06_changeset.py tests/controllers/test_oauth2.py tests/middlewares/test_request_body_middleware.py tests/models/test_note_comment.py`
- `.venv\Scripts\python.exe -m py_compile app/exceptions/diff_mixin.py app/exceptions/note_mixin.py app/exceptions06/diff_mixin.py app/exceptions06/note_mixin.py app/services/note_service.py app/services/optimistic_diff/prepare.py tests/controllers/test_api06_note.py tests/controllers/test_api06_changeset.py tests/controllers/test_oauth2.py tests/middlewares/test_request_body_middleware.py tests/models/test_note_comment.py`
- `git diff --check`

I could not run the targeted pytest command locally. The plain shell Python is 3.11 and cannot parse the repo's Python 3.14 type-alias syntax; `uv` could create a Python 3.14 venv after enabling native TLS, but dependency sync stopped while building `zid==1.5.0` on Windows with a maturin/rustup OpenSSL_Applink error, so `pytest` was not installed in that venv.