### PR TITLE
Support SVG and PDF map exports

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -124,6 +124,8 @@ OSM_REPLICATION_URL = (
 )
 OSM_OLD_REPLICATION_URL = 'https://planet.openstreetmap.org'
 OSRM_URL = 'https://router.project-osrm.org'
+RENDER_EXPORT_TOTP_KEY = SecretStr('')
+RENDER_EXPORT_URL = 'https://render.openstreetmap.org/cgi-bin/export'
 VALHALLA_URL = 'https://valhalla1.openstreetmap.de'
 
 # API and HTTP settings

--- a/app/controllers/web_map.py
+++ b/app/controllers/web_map.py
@@ -1,0 +1,49 @@
+import base64
+import hmac
+import time
+from hashlib import sha1
+from typing import Annotated, Literal
+from urllib.parse import urlencode
+
+from fastapi import APIRouter, Query
+from starlette import status
+from starlette.responses import RedirectResponse
+
+from app.config import RENDER_EXPORT_TOTP_KEY, RENDER_EXPORT_URL
+from app.lib.geo.parse import parse_bbox
+
+router = APIRouter(prefix='/api/web/map')
+
+
+@router.get('/export')
+async def export_map(
+    bbox: Annotated[str, Query(min_length=1)],
+    scale: Annotated[int, Query(gt=0)],
+    map_format: Annotated[Literal['svg', 'pdf'], Query(alias='format')],
+):
+    bounds = parse_bbox(bbox).bounds
+    params = {
+        'bbox': ','.join(str(v) for v in bounds),
+        'scale': str(scale),
+        'format': map_format,
+        'token': _render_export_totp(),
+    }
+    return RedirectResponse(
+        f'{RENDER_EXPORT_URL}?{urlencode(params)}',
+        status.HTTP_303_SEE_OTHER,
+    )
+
+
+def _render_export_totp():
+    secret = RENDER_EXPORT_TOTP_KEY.get_secret_value()
+    if not secret:
+        return ''
+
+    normalized = secret.replace(' ', '').upper()
+    normalized += '=' * (-len(normalized) % 8)
+    key = base64.b32decode(normalized)
+    counter = int(time.time() // 3600)
+    digest = hmac.new(key, counter.to_bytes(8, 'big'), sha1).digest()
+    offset = digest[-1] & 0x0F
+    code = int.from_bytes(digest[offset : offset + 4], 'big') & 0x7FFFFFFF
+    return f'{code % 1_000_000:06d}'

--- a/app/views/index/sidebar/share.tsx
+++ b/app/views/index/sidebar/share.tsx
@@ -4,7 +4,11 @@ import { routerCtx } from "@index/router"
 import { SidebarToggleControl } from "@index/sidebar/_toggle-button"
 import { boundsPadding } from "@map/bounds"
 import { LocationFilterControl } from "@map/controls/location-filter"
-import { exportMapImage } from "@map/export-image"
+import {
+  exportMapImage,
+  getRenderMapExportUrl,
+  type RenderExportFormat,
+} from "@map/export-image"
 import { activeBaseLayerId, addLayerEventHandler } from "@map/layers/layers"
 import { mainMap } from "@map/main-map"
 import { getMarkerIconElement, MARKER_ICON_ANCHOR } from "@map/marker"
@@ -28,11 +32,45 @@ import { Marker } from "maplibre-gl"
 import type { SubmitEventHandler } from "preact"
 import { useRef } from "preact/hooks"
 
+type RasterShareFormat = {
+  kind: "raster"
+  mimeType: string
+  suffix: string
+  label: string
+}
+
+type RenderShareFormat = {
+  kind: "render"
+  mimeType: string
+  suffix: string
+  label: string
+  format: RenderExportFormat
+}
+
+type ShareFormat = RasterShareFormat | RenderShareFormat
+
 const SHARE_FORMATS = [
-  { mimeType: "image/jpeg", suffix: ".jpg", label: "JPEG" },
-  { mimeType: "image/png", suffix: ".png", label: "PNG" },
-  { mimeType: "image/webp", suffix: ".webp", label: "WebP" },
-] as const
+  { kind: "raster", mimeType: "image/jpeg", suffix: ".jpg", label: "JPEG" },
+  { kind: "raster", mimeType: "image/png", suffix: ".png", label: "PNG" },
+  { kind: "raster", mimeType: "image/webp", suffix: ".webp", label: "WebP" },
+  {
+    kind: "render",
+    mimeType: "image/svg+xml",
+    suffix: ".svg",
+    label: "SVG",
+    format: "svg",
+  },
+  {
+    kind: "render",
+    mimeType: "application/pdf",
+    suffix: ".pdf",
+    label: "PDF",
+    format: "pdf",
+  },
+] satisfies readonly ShareFormat[]
+const DEFAULT_SHARE_FORMAT = SHARE_FORMATS[1]!
+const getShareFormat = (mimeType: string) =>
+  SHARE_FORMATS.find((f) => f.mimeType === mimeType) ?? DEFAULT_SHARE_FORMAT
 
 let urlMarker: Marker | null = null
 
@@ -83,10 +121,10 @@ export const ShareSidebar = ({ close }: { close: () => void }) => {
   // payload, avoiding a redundant boolean shadow.
   const shareMarkerLngLat = useSignal<LngLat | null>(null)
 
-  const shareExportFileSuffix = useComputed(
-    () =>
-      SHARE_FORMATS.find((f) => f.mimeType === shareExportFormatStorage.value)!.suffix,
+  const shareExportFormat = useComputed(() =>
+    getShareFormat(shareExportFormatStorage.value),
   )
+  const shareExportFileSuffix = useComputed(() => shareExportFormat.value.suffix)
 
   const shareMapState = useComputed(() => {
     const view = shareView.value
@@ -185,17 +223,26 @@ export const ShareSidebar = ({ close }: { close: () => void }) => {
         ? locationFilterRef.current!.getBounds()
         : null
 
+      const now = new Date()
+      const date = `${formatDate(now, "yyyy-MM-dd", { timeZone: "UTC" })} ${formatDate(now, "HH-mm-ss")}`
+      const exportFormat = getShareFormat(shareExportFormatStorage.value)
+
+      if (exportFormat.kind === "render") {
+        const a = document.createElement("a")
+        a.href = getRenderMapExportUrl(exportFormat.format, map, filterBounds)
+        a.download = `Map ${date}${shareExportFileSuffix.value}`
+        a.click()
+        return
+      }
+
       const blob = await exportMapImage(
-        shareExportFormatStorage.value,
+        exportFormat.mimeType,
         map,
         filterBounds,
         shareMarkerLngLat.peek(),
         withAttribution.value,
       )
       const url = URL.createObjectURL(blob)
-
-      const now = new Date()
-      const date = `${formatDate(now, "yyyy-MM-dd", { timeZone: "UTC" })} ${formatDate(now, "HH-mm-ss")}`
 
       const a = document.createElement("a")
       a.href = url

--- a/app/views/map/export-image.ts
+++ b/app/views/map/export-image.ts
@@ -1,3 +1,5 @@
+import { API_URL } from "@utils/config"
+import { qsEncode } from "@utils/query-string"
 import { t } from "i18next"
 import type {
   GeoJSONSource,
@@ -5,7 +7,7 @@ import type {
   LngLatBounds,
   Map as MaplibreMap,
 } from "maplibre-gl"
-import { boundsIntersect, boundsIntersection } from "./bounds"
+import { boundsIntersect, boundsIntersection, boundsToString } from "./bounds"
 import { loadMapImage } from "./image"
 import {
   addMapLayer,
@@ -35,6 +37,26 @@ layersConfig.set(LAYER_ID, {
 
 // https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob#quality
 const IMAGE_QUALITY = 0.98
+const EARTH_RADIUS = 6378137
+const PRINT_METERS_PER_PIXEL = 1 / (92 * 39.3701)
+const STANDARD_PIXEL_SIZE = 0.00028
+const MAX_RENDER_AREA = 4_000_000 * STANDARD_PIXEL_SIZE ** 2
+const MAX_MERCATOR_LATITUDE = 85.05112878
+
+export type RenderExportFormat = "svg" | "pdf"
+
+export const getRenderMapExportUrl = (
+  format: RenderExportFormat,
+  map: MaplibreMap,
+  filterBounds: LngLatBounds | null,
+) => {
+  const exportBounds = getRenderExportBounds(map, filterBounds)
+  return `${API_URL}/api/web/map/export${qsEncode({
+    bbox: boundsToString(exportBounds, 7),
+    scale: getRenderScale(map, exportBounds).toString(),
+    format,
+  })}`
+}
 
 export const exportMapImage = async (
   mimeType: string,
@@ -151,6 +173,58 @@ export const exportMapImage = async (
       IMAGE_QUALITY,
     )
   })
+}
+
+const getRenderExportBounds = (map: MaplibreMap, filterBounds: LngLatBounds | null) => {
+  const mapBounds = map.getBounds()
+  return filterBounds && boundsIntersect(mapBounds, filterBounds)
+    ? boundsIntersection(mapBounds, filterBounds)
+    : mapBounds
+}
+
+const getRenderScale = (map: MaplibreMap, exportBounds: LngLatBounds) => {
+  const scale = getCurrentMapScale(map)
+  const minScale = getMinRenderScale(exportBounds)
+  return scale < minScale ? roundScale(minScale) : scale
+}
+
+const getCurrentMapScale = (map: MaplibreMap) => {
+  const bounds = map.getBounds().adjustAntiMeridian()
+  const centerLat = bounds.getCenter().lat
+  const halfWorldMeters = EARTH_RADIUS * Math.PI * Math.cos((centerLat * Math.PI) / 180)
+  const meters = (halfWorldMeters * (bounds.getEast() - bounds.getWest())) / 180
+  const canvas = map.getCanvas()
+  const width = canvas.clientWidth || canvas.width / window.devicePixelRatio
+  const pixelsPerMeter = width / meters
+  const scale = Math.round(1 / (pixelsPerMeter * PRINT_METERS_PER_PIXEL))
+  return Number.isFinite(scale) ? Math.max(1, scale) : 1
+}
+
+const getMinRenderScale = (bounds: LngLatBounds) => {
+  const adjusted = bounds.adjustAntiMeridian()
+  const southWest = projectMercator(adjusted.getSouthWest())
+  const northEast = projectMercator(adjusted.getNorthEast())
+  const area = Math.abs(northEast.x - southWest.x) * Math.abs(northEast.y - southWest.y)
+  const scale = Math.floor(Math.sqrt(area / MAX_RENDER_AREA))
+  return Number.isFinite(scale) ? Math.max(1, scale) : 1
+}
+
+const projectMercator = (lngLat: LngLat) => {
+  const lat = Math.max(
+    -MAX_MERCATOR_LATITUDE,
+    Math.min(MAX_MERCATOR_LATITUDE, lngLat.lat),
+  )
+  const lonRad = (lngLat.lng * Math.PI) / 180
+  const latRad = (lat * Math.PI) / 180
+  return {
+    x: EARTH_RADIUS * lonRad,
+    y: EARTH_RADIUS * Math.log(Math.tan(Math.PI / 4 + latRad / 2)),
+  }
+}
+
+const roundScale = (scale: number) => {
+  const precision = 5 * 10 ** (Math.floor(Math.log10(scale)) - 2)
+  return precision * Math.ceil(scale / precision)
 }
 
 /** Calculate the offsets for trimming the exported image */


### PR DESCRIPTION
Closes #36

## Summary
- Add a `/api/web/map/export` route that validates SVG/PDF export requests and redirects them to the configured render export service.
- Restore SVG and PDF as Share sidebar export formats while keeping JPEG/PNG/WebP on the existing canvas export path.
- Compute a render scale from the current map view and raise it for large selected regions to avoid oversized render requests.

## Verification
- `uv run --no-sync python -m py_compile app\controllers\web_map.py app\config.py`
- `uvx ruff check app\controllers\web_map.py`
- `npx organize-imports-cli app\views\map\export-image.ts app\views\index\sidebar\share.tsx --list-different`
- `npx prettier --check --no-semi app\views\index\sidebar\share.tsx app\views\map\export-image.ts`
- `npx esbuild app\views\map\export-image.ts --bundle --format=esm --external:* --outfile=...`
- `npx esbuild app\views\index\sidebar\share.tsx --bundle --format=esm --external:* --outfile=...`

Full `tsc --noEmit` was not run successfully in this checkout because the generated `@proto/*` TypeScript modules are absent until the repo bootstrap/proto pipeline is run.