### PR TITLE
Validate map image export formats

### DIFF
--- a/app/views/index/sidebar/share.tsx
+++ b/app/views/index/sidebar/share.tsx
@@ -4,6 +4,7 @@ import { routerCtx } from "@index/router"
 import { SidebarToggleControl } from "@index/sidebar/_toggle-button"
 import { boundsPadding } from "@map/bounds"
 import { LocationFilterControl } from "@map/controls/location-filter"
+import { IMAGE_EXPORT_FORMATS, isImageExportMimeType } from "@map/export-format"
 import { exportMapImage } from "@map/export-image"
 import { activeBaseLayerId, addLayerEventHandler } from "@map/layers/layers"
 import { mainMap } from "@map/main-map"
@@ -27,12 +28,6 @@ import type { LngLat, LngLatBounds, Map as MaplibreMap } from "maplibre-gl"
 import { Marker } from "maplibre-gl"
 import type { SubmitEventHandler } from "preact"
 import { useRef } from "preact/hooks"
-
-const SHARE_FORMATS = [
-  { mimeType: "image/jpeg", suffix: ".jpg", label: "JPEG" },
-  { mimeType: "image/png", suffix: ".png", label: "PNG" },
-  { mimeType: "image/webp", suffix: ".webp", label: "WebP" },
-] as const
 
 let urlMarker: Marker | null = null
 
@@ -85,7 +80,8 @@ export const ShareSidebar = ({ close }: { close: () => void }) => {
 
   const shareExportFileSuffix = useComputed(
     () =>
-      SHARE_FORMATS.find((f) => f.mimeType === shareExportFormatStorage.value)!.suffix,
+      IMAGE_EXPORT_FORMATS.find((f) => f.mimeType === shareExportFormatStorage.value)!
+        .suffix,
   )
 
   const shareMapState = useComputed(() => {
@@ -292,9 +288,12 @@ export const ShareSidebar = ({ close }: { close: () => void }) => {
           <select
             class="form-select format-select mt-2"
             value={shareExportFormatStorage.value}
-            onChange={(e) => (shareExportFormatStorage.value = e.currentTarget.value)}
+            onChange={(e) => {
+              const { value } = e.currentTarget
+              if (isImageExportMimeType(value)) shareExportFormatStorage.value = value
+            }}
           >
-            {SHARE_FORMATS.map(({ mimeType, label }) => (
+            {IMAGE_EXPORT_FORMATS.map(({ mimeType, label }) => (
               <option
                 key={mimeType}
                 value={mimeType}

--- a/app/views/map/export-format.ts
+++ b/app/views/map/export-format.ts
@@ -1,0 +1,12 @@
+// TODO: Add PDF/SVG only with a non-canvas/vector export path.
+export const IMAGE_EXPORT_FORMATS = [
+  { mimeType: "image/jpeg", suffix: ".jpg", label: "JPEG" },
+  { mimeType: "image/png", suffix: ".png", label: "PNG" },
+  { mimeType: "image/webp", suffix: ".webp", label: "WebP" },
+] as const
+
+export type ImageExportMimeType = (typeof IMAGE_EXPORT_FORMATS)[number]["mimeType"]
+
+export const isImageExportMimeType = (value: unknown): value is ImageExportMimeType =>
+  typeof value === "string" &&
+  IMAGE_EXPORT_FORMATS.some((format) => format.mimeType === value)

--- a/app/views/map/export-image.ts
+++ b/app/views/map/export-image.ts
@@ -6,6 +6,7 @@ import type {
   Map as MaplibreMap,
 } from "maplibre-gl"
 import { boundsIntersect, boundsIntersection } from "./bounds"
+import type { ImageExportMimeType } from "./export-format"
 import { loadMapImage } from "./image"
 import {
   addMapLayer,
@@ -37,7 +38,7 @@ layersConfig.set(LAYER_ID, {
 const IMAGE_QUALITY = 0.98
 
 export const exportMapImage = async (
-  mimeType: string,
+  mimeType: ImageExportMimeType,
   map: MaplibreMap,
   filterBounds: LngLatBounds | null,
   markerLngLat: LngLat | null,

--- a/app/views/utils/local-storage.ts
+++ b/app/views/utils/local-storage.ts
@@ -1,3 +1,4 @@
+import { isImageExportMimeType, type ImageExportMimeType } from "@map/export-format"
 import type { LayerId } from "@map/layers/layers"
 import type { MapState } from "@map/state"
 import { effect, type Signal, signal } from "@preact/signals"
@@ -169,10 +170,11 @@ export const overlayOpacityStorage = createScopedStorageSignal<number>(
   },
 )
 
-export const shareExportFormatStorage = createStorageSignal<string>(
+export const shareExportFormatStorage = createStorageSignal<ImageExportMimeType>(
   "shareExportFormat",
   {
     defaultValue: "image/jpeg",
+    validate: isImageExportMimeType,
   },
 )
 


### PR DESCRIPTION
Addresses openstreetmap-ng/openstreetmap-ng#36

## Summary
- Move supported canvas export formats into a shared JPEG/PNG/WebP list.
- Validate persisted share export format values so stale unsupported MIME types fall back to JPEG.
- Type `exportMapImage` so only supported raster export MIME types can be passed.
- Leave a TODO for future PDF/SVG support via a non-canvas/vector export path.

## Testing
- `node_modules\.bin\prettier.exe --check --no-semi app\views\map\export-format.ts app\views\utils\local-storage.ts app\views\index\sidebar\share.tsx app\views\map\export-image.ts`
- `git diff --check`
- `node_modules\.bin\vite.exe build` fails in this local shell because generated `app/views/proto/*_pb` files are missing; those are normally produced by the repo `proto-pipeline`/nix environment.