### PR TITLE
Reject suspicious null island changesets

### DIFF
--- a/app/exceptions/api06.py
+++ b/app/exceptions/api06.py
@@ -194,6 +194,13 @@ class Exceptions06(Exceptions):
             detail=f'Update action requires version >= 1, got {element["version"] - 1}',
         )
 
+    @override
+    def diff_suspicious_null_island_edit(self):
+        raise APIError(
+            status.HTTP_412_PRECONDITION_FAILED,
+            detail='Changeset upload rejected: multiple nodes are located at null island (0,0).',
+        )
+
     # --- element ---
     @override
     def element_not_found(

--- a/app/exceptions/default.py
+++ b/app/exceptions/default.py
@@ -135,6 +135,9 @@ class Exceptions:
     def diff_update_bad_version(self, element: ElementInit) -> NoReturn:
         raise NotImplementedError
 
+    def diff_suspicious_null_island_edit(self) -> NoReturn:
+        raise NotImplementedError
+
     # --- element ---
     def element_not_found(
         self, element_ref: TypedElementId | tuple[TypedElementId, int]

--- a/app/services/optimistic_diff/prepare.py
+++ b/app/services/optimistic_diff/prepare.py
@@ -30,6 +30,11 @@ from speedup import element_id, element_type, split_typed_element_id
 OSMChangeAction: TypeAlias = Literal['create', 'modify', 'delete']
 
 
+def _is_null_island_node(element: ElementInit):
+    point = element['point']
+    return element['visible'] and point is not None and point.x == 0 and point.y == 0
+
+
 @dataclass(kw_only=True, slots=True)
 class ElementStateEntry:
     remote: Final[Element | None]
@@ -100,6 +105,11 @@ class OptimisticDiffPrepare:
     Changeset bounding box set of element refs.
     """
 
+    _null_island_candidate_refs: set[TypedElementId]
+    """
+    Node refs touched directly or through changed ways; checked after local state settles.
+    """
+
     def __init__(self, conn: AsyncConnection, elements: list[ElementInit], /):
         self.conn = conn
         self.apply_elements = []
@@ -111,6 +121,7 @@ class OptimisticDiffPrepare:
         self._reference_override = defaultdict(set)
         self._bbox_points = []
         self._bbox_refs = set()
+        self._null_island_candidate_refs = set()
 
     async def prepare(self):
         await self._preload_changeset()
@@ -191,6 +202,8 @@ class OptimisticDiffPrepare:
                 logging.debug('Optimistic skipping delete for %s (is used)', typed_id)
                 continue
 
+            self._push_null_island_candidate(element, type)
+
             # Mark unassigned members
             if (members_arr := element.get('members_arr')) is not None:
                 indices = np.nonzero(members_arr & (1 << 59))[0]
@@ -216,6 +229,7 @@ class OptimisticDiffPrepare:
 
         async with TaskGroup() as tg:
             tg.create_task(self._update_changeset_bounds())
+            tg.create_task(self._check_null_island_edits())
             tg.create_task(self._check_members_remote())
 
     async def _preload_elements_state(self):
@@ -512,6 +526,60 @@ class OptimisticDiffPrepare:
                     point = entry.current.get('point')
                     assert point is not None, f'Node {node_typed_id} point must be set'
                     bbox_points.append(point)
+
+    def _push_null_island_candidate(
+        self, element: ElementInit, element_type: ElementType
+    ):
+        """Track visible nodes affected by this upload for null island validation."""
+        if not element['visible']:
+            return
+
+        if element_type == 'node':
+            self._null_island_candidate_refs.add(element['typed_id'])
+        elif element_type == 'way':
+            if members := element['members']:
+                self._null_island_candidate_refs.update(members)
+        elif element_type == 'relation':
+            return
+        else:
+            assert_never(element_type)
+
+    async def _check_null_island_edits(self):
+        """Reject uploads that touch multiple distinct visible nodes at (0, 0)."""
+        candidate_refs = self._null_island_candidate_refs
+        if len(candidate_refs) < 2:
+            return
+
+        null_island_refs: set[TypedElementId] = set()
+        remote_refs: list[TypedElementId] = []
+
+        for typed_id in candidate_refs:
+            entry = self.element_state.get(typed_id)
+            if entry is None:
+                # Negative/unassigned refs are handled by member validation; they cannot
+                # be resolved from the database.
+                if not (typed_id & (1 << 59)):
+                    remote_refs.append(typed_id)
+                continue
+
+            if _is_null_island_node(entry.current):
+                null_island_refs.add(typed_id)
+                if len(null_island_refs) >= 2:
+                    raise_for.diff_suspicious_null_island_edit()
+
+        if not remote_refs:
+            return
+
+        remote_elements = await ElementQuery.find_by_refs(
+            remote_refs,
+            at_sequence_id=self.at_sequence_id,
+            limit=len(remote_refs),
+        )
+        for element in remote_elements:
+            if _is_null_island_node(element):
+                null_island_refs.add(element['typed_id'])
+                if len(null_island_refs) >= 2:
+                    raise_for.diff_suspicious_null_island_edit()
 
     async def _preload_changeset(self):
         """Lock and load changeset state from the database."""

--- a/tests/controllers/test_api06_changeset.py
+++ b/tests/controllers/test_api06_changeset.py
@@ -165,6 +165,42 @@ async def test_changeset_upload(client: AsyncClient):
     )
 
 
+async def test_changeset_upload_rejects_multiple_null_island_nodes(client: AsyncClient):
+    client.headers['Authorization'] = 'User user1'
+
+    r = await client.put(
+        '/api/0.6/changeset/create',
+        content=XMLToDict.unparse({
+            'osm': {
+                'changeset': {
+                    'tag': [
+                        {
+                            '@k': 'created_by',
+                            '@v': test_changeset_upload_rejects_multiple_null_island_nodes.__name__,
+                        }
+                    ]
+                }
+            }
+        }),
+    )
+    assert r.is_success, r.text
+    changeset_id = int(r.text)
+
+    r = await client.post(
+        f'/api/0.6/changeset/{changeset_id}/upload',
+        content=XMLToDict.unparse({
+            'osmChange': {
+                'create': [
+                    ('node', {'@id': -1, '@lat': 0, '@lon': 0}),
+                    ('node', {'@id': -2, '@lat': 0, '@lon': 0}),
+                ]
+            }
+        }),
+    )
+    assert r.status_code == status.HTTP_412_PRECONDITION_FAILED, r.text
+    assert 'null island' in r.text
+
+
 @pytest.mark.parametrize('include', [True, False])
 async def test_changeset_with_discussion(client: AsyncClient, include):
     client.headers['Authorization'] = 'User user1'


### PR DESCRIPTION
Closes #128.

## Summary
- Reject changeset uploads that leave two or more distinct visible nodes at exact null island coordinates (0,0).
- Count nodes touched directly and nodes referenced by changed ways, including existing remote refs loaded at the upload sequence.
- Keep single null island node edits valid.

## Validation
- `uvx ruff check app/exceptions/default.py app/exceptions/api06.py app/services/optimistic_diff/prepare.py tests/controllers/test_api06_changeset.py`
- `uvx ruff format --check app/exceptions/default.py app/exceptions/api06.py app/services/optimistic_diff/prepare.py tests/controllers/test_api06_changeset.py`
- `PYTHONPATH=. .venv/bin/python -m py_compile app/exceptions/default.py app/exceptions/api06.py app/services/optimistic_diff/prepare.py tests/controllers/test_api06_changeset.py`
- Attempted `PYTHONPATH=. .venv/bin/python -m pytest tests/controllers/test_api06_changeset.py::test_changeset_upload_rejects_multiple_null_island_nodes -q`; local run reaches app startup but cannot acquire a Postgres test DB connection (`psycopg_pool.PoolTimeout`).