### PR TITLE
Implement edit help tutorial redirect

### DIFF
--- a/app/controllers/index.py
+++ b/app/controllers/index.py
@@ -50,7 +50,9 @@ router = APIRouter()
 @router.get('/relation/{_:int}/history')
 @router.get('/relation/{_:int}/history/{__:int}')
 @router.get('/distance')
-async def index():
+async def index(edit_help: Annotated[bool, Query()] = False):
+    if edit_help and auth_user() is not None:
+        return RedirectResponse('/edit#walkthrough=true', status.HTTP_303_SEE_OTHER)
     return await render_response('index/index')
 
 

--- a/tests/controllers/test_index.py
+++ b/tests/controllers/test_index.py
@@ -1,0 +1,18 @@
+from httpx import AsyncClient
+from starlette import status
+
+
+async def test_edit_help_redirects_authenticated_users(client: AsyncClient):
+    client.headers['Authorization'] = 'User user1'
+
+    r = await client.get('/?edit_help=1', follow_redirects=False)
+
+    assert r.status_code == status.HTTP_303_SEE_OTHER, r.text
+    assert r.headers['Location'] == '/edit#walkthrough=true'
+
+
+async def test_edit_help_does_not_redirect_guests(client: AsyncClient):
+    r = await client.get('/?edit_help=1', follow_redirects=False)
+
+    assert r.is_success, r.text
+    assert 'Location' not in r.headers


### PR DESCRIPTION
Closes #28.

Summary:
- Redirect logged-in `?edit_help=1` requests to the embedded iD editor walkthrough.
- Keep anonymous visitors on the normal index flow.
- Add controller coverage for both paths.

Validation:
- `uvx ruff check app/controllers/index.py tests/controllers/test_index.py`
- `uvx ruff format --check app/controllers/index.py tests/controllers/test_index.py`
- `PYTHONPATH=. .venv/bin/python -m py_compile app/controllers/index.py tests/controllers/test_index.py`
- `PATH="$PWD/node_modules/.bin:$PATH" basedpyright app/controllers/index.py tests/controllers/test_index.py`
- `pytest tests/controllers/test_index.py` did not complete locally because the Nix/test-service environment variables were not available.
