### PR TITLE
[closed] Add osm-ng hashtag to new notes

### DIFF
--- a/app/services/note_service.py
+++ b/app/services/note_service.py
@@ -28,11 +28,21 @@ from app.services.user_subscription_service import UserSubscriptionService
 from app.validators.geometry import validate_geometry
 
 
+NOTE_CREATE_HASHTAG = '#osm-ng'
+
+
+def note_body_with_create_hashtag(text: str):
+    if NOTE_CREATE_HASHTAG in text:
+        return text
+    return f'{text}\n\n{NOTE_CREATE_HASHTAG}'
+
+
 class NoteService:
     @staticmethod
     async def create(lon: float, lat: float, text: str) -> NoteId:
         """Create a note and return its id."""
         point = validate_geometry(Point(lon, lat))
+        text = note_body_with_create_hashtag(text)
 
         user = auth_user()
         if user is not None:

--- a/tests/models/test_note_comment.py
+++ b/tests/models/test_note_comment.py
@@ -3,7 +3,7 @@ from app.models.db.note_comment import note_comments_resolve_rich_text
 from app.models.types import DisplayName
 from app.queries.note_query import NoteCommentQuery
 from app.queries.user_query import UserQuery
-from app.services.note_service import NoteService
+from app.services.note_service import NOTE_CREATE_HASHTAG, NoteService
 
 
 async def test_note_comments_resolve_rich_text():
@@ -21,3 +21,26 @@ async def test_note_comments_resolve_rich_text():
         assert header is not None
         assert header['event'] == 'opened'
         assert header['body_rich_hash'] is not None
+
+
+async def test_note_create_appends_hashtag():
+    user = await UserQuery.find_by_display_name(DisplayName('user1'))
+    with auth_context(user, frozenset(('web_user',))):
+        note_id = await NoteService.create(0, 0, 'A missing bench')
+
+    header = await NoteCommentQuery.find_header(note_id)
+    assert header is not None
+    assert header['event'] == 'opened'
+    assert header['body'] == f'A missing bench\n\n{NOTE_CREATE_HASHTAG}'
+
+
+async def test_note_create_does_not_duplicate_hashtag():
+    user = await UserQuery.find_by_display_name(DisplayName('user1'))
+    body = f'A missing bench\n\n{NOTE_CREATE_HASHTAG}'
+    with auth_context(user, frozenset(('web_user',))):
+        note_id = await NoteService.create(0, 0, body)
+
+    header = await NoteCommentQuery.find_header(note_id)
+    assert header is not None
+    assert header['event'] == 'opened'
+    assert header['body'] == body


### PR DESCRIPTION
## Summary
- Append `#osm-ng` to newly created note bodies.
- Avoid duplicating the hashtag when the note text already contains it.
- Add model-level tests for the new note creation behavior.

Fixes #76

## Validation
- `git diff --check`
- Not run: full project tests locally because this environment does not have `uv`, `pytest`, or `nix` installed.

## Status
Closing this draft because there are already active PRs for the same bounty (#219 and #251), including a claimed implementation. I do not want to add noise or compete with an existing contributor for the same issue.