### PR TITLE
Close notes from changeset tags

### DIFF
--- a/app/lib/changeset_note_closures.py
+++ b/app/lib/changeset_note_closures.py
@@ -24,7 +24,11 @@ def _parse_note_ids(value: str | None) -> list[NoteId]:
         if not raw_note_id.isdecimal():
             continue
 
-        note_id = NoteId(int(raw_note_id))
+        note_id_int = int(raw_note_id)
+        if note_id_int <= 0:
+            continue
+
+        note_id = NoteId(note_id_int)
         if note_id in seen:
             continue
 

--- a/app/lib/changeset_note_closures.py
+++ b/app/lib/changeset_note_closures.py
@@ -1,0 +1,34 @@
+from app.models.types import NoteId
+
+
+def parse_changeset_note_closures(tags: dict[str, str]) -> dict[NoteId, str]:
+    note_ids = _parse_note_ids(tags.get('closes:note'))
+    if not note_ids:
+        return {}
+
+    default_comment = tags.get('closes:note:comment', tags.get('comment', ''))
+    return {
+        note_id: tags.get(f'closes:note:{note_id}:comment', default_comment)
+        for note_id in note_ids
+    }
+
+
+def _parse_note_ids(value: str | None) -> list[NoteId]:
+    if not value:
+        return []
+
+    result: list[NoteId] = []
+    seen: set[NoteId] = set()
+    for raw_note_id in value.split(';'):
+        raw_note_id = raw_note_id.strip()
+        if not raw_note_id.isdecimal():
+            continue
+
+        note_id = NoteId(int(raw_note_id))
+        if note_id in seen:
+            continue
+
+        seen.add(note_id)
+        result.append(note_id)
+
+    return result

--- a/app/services/changeset_service.py
+++ b/app/services/changeset_service.py
@@ -8,6 +8,7 @@ from time import monotonic
 
 import cython
 from sentry_sdk.api import start_transaction
+from starlette import status
 
 from app.config import (
     CHANGESET_EMPTY_DELETE_TIMEOUT,
@@ -24,9 +25,11 @@ from app.db import (
     db_lock,
     db_update,
 )
+from app.exceptions.api_error import APIError
 from app.exceptions.context import raise_for
 from app.lib.audit import audit
 from app.lib.auth.context import auth_user
+from app.lib.changeset_note_closures import parse_changeset_note_closures
 from app.lib.http.retry import retry
 from app.lib.telemetry.sentry import (
     SENTRY_CHANGESET_MANAGEMENT_MONITOR,
@@ -38,11 +41,18 @@ from app.models.db.changeset_comment import (
     ChangesetComment,
     changeset_comments_resolve_rich_text,
 )
-from app.models.types import ChangesetCommentId, ChangesetId, DisplayName, UserId
+from app.models.types import (
+    ChangesetCommentId,
+    ChangesetId,
+    DisplayName,
+    NoteId,
+    UserId,
+)
 from app.queries.changeset_query import ChangesetQuery
 from app.queries.user_query import UserQuery
 from app.queries.user_subscription_query import UserSubscriptionQuery
 from app.services.email_service import EmailService
+from app.services.note_service import NoteService
 from app.services.user_subscription_service import UserSubscriptionService
 
 _PROCESS_REQUEST_EVENT = Event()
@@ -108,11 +118,12 @@ class ChangesetService:
     async def close(changeset_id: ChangesetId):
         """Close a changeset."""
         user_id = auth_user(required=True)['id']
+        note_closures: dict[NoteId, str]
 
         async with db(True) as conn:
             row = await db_fetchrow(
                 t"""
-                    SELECT user_id, closed_at
+                    SELECT user_id, closed_at, tags
                     FROM changeset
                     WHERE id = {changeset_id}
                 """,
@@ -124,12 +135,15 @@ class ChangesetService:
 
             changeset_user_id: UserId
             closed_at: datetime | None
-            changeset_user_id, closed_at = row
+            tags: dict[str, str]
+            changeset_user_id, closed_at, tags = row
 
             if changeset_user_id != user_id:
                 raise_for.changeset_access_denied()
             if closed_at is not None:
                 raise_for.changeset_already_closed(changeset_id, closed_at)
+
+            note_closures = parse_changeset_note_closures(tags)
 
             await db_update(
                 'changeset',
@@ -141,6 +155,8 @@ class ChangesetService:
                 conn=conn,
             )
             await audit('close_changeset', conn, extra={'id': changeset_id})
+
+        await _close_changeset_notes(note_closures)
 
     @staticmethod
     @asynccontextmanager
@@ -162,6 +178,19 @@ class ChangesetService:
         _PROCESS_REQUEST_EVENT.set()
         _PROCESS_DONE_EVENT.clear()
         await _PROCESS_DONE_EVENT.wait()
+
+
+async def _close_changeset_notes(note_closures: dict[NoteId, str]):
+    for note_id, comment in note_closures.items():
+        try:
+            await NoteService.comment(note_id, comment, 'closed')
+        except APIError as e:
+            if e.status_code in (
+                status.HTTP_404_NOT_FOUND,
+                status.HTTP_409_CONFLICT,
+            ):
+                continue
+            raise
 
 
 # === Changeset Comments ===

--- a/tests/controllers/test_api06_changeset.py
+++ b/tests/controllers/test_api06_changeset.py
@@ -319,6 +319,62 @@ async def test_changeset_close_twice(client: AsyncClient):
     assert r.status_code == status.HTTP_409_CONFLICT, r.text
 
 
+async def test_changeset_close_closes_tagged_notes(client: AsyncClient):
+    client.headers['Authorization'] = 'User user1'
+
+    first_note_id = await _create_note(
+        client, test_changeset_close_closes_tagged_notes.__qualname__
+    )
+    second_note_id = await _create_note(
+        client, f'{test_changeset_close_closes_tagged_notes.__qualname__} override'
+    )
+    already_closed_note_id = await _create_note(
+        client, f'{test_changeset_close_closes_tagged_notes.__qualname__} closed'
+    )
+
+    r = await client.post(
+        f'/api/0.6/notes/{already_closed_note_id}/close.json',
+        params={'text': 'already closed'},
+    )
+    assert r.is_success, r.text
+
+    r = await client.put(
+        '/api/0.6/changeset/create',
+        content=XMLToDict.unparse({
+            'osm': {
+                'changeset': {
+                    'tag': [
+                        {'@k': 'comment', '@v': 'default close comment'},
+                        {
+                            '@k': 'closes:note',
+                            '@v': f'{first_note_id};bad;{second_note_id};{first_note_id};{already_closed_note_id};0',
+                        },
+                        {
+                            '@k': f'closes:note:{second_note_id}:comment',
+                            '@v': 'second note close comment',
+                        },
+                    ]
+                }
+            }
+        }),
+    )
+    assert r.is_success, r.text
+    changeset_id = int(r.text)
+
+    r = await client.put(f'/api/0.6/changeset/{changeset_id}/close')
+    assert r.is_success, r.text
+
+    await _assert_note_closed(client, first_note_id, 'default close comment')
+    await _assert_note_closed(client, second_note_id, 'second note close comment')
+
+    r = await client.get(f'/api/0.6/notes/{already_closed_note_id}.json')
+    assert r.is_success, r.text
+    props = r.json()['properties']
+    assert props['status'] == 'closed'
+    assert len(props['comments']) == 2
+    assert props['comments'][-1]['text'] == 'already closed'
+
+
 async def test_changesets_not_found(client: AsyncClient):
     r = await client.get('/api/0.6/changeset/0')
     assert r.status_code == status.HTTP_404_NOT_FOUND, r.text
@@ -352,6 +408,29 @@ async def test_changesets_tag_max_length(
         assert r.is_success, r.text
     else:
         assert r.status_code == status.HTTP_400_BAD_REQUEST, r.text
+
+
+async def _create_note(client: AsyncClient, text: str) -> int:
+    r = await client.post(
+        '/api/0.6/notes.json', json={'lon': 0, 'lat': 0, 'text': text}
+    )
+    assert r.is_success, r.text
+    return r.json()['properties']['id']
+
+
+async def _assert_note_closed(client: AsyncClient, note_id: int, close_comment: str):
+    r = await client.get(f'/api/0.6/notes/{note_id}.json')
+    assert r.is_success, r.text
+    props = r.json()['properties']
+    assert_model(props, {'status': 'closed', 'closed_at': str})
+    assert_model(
+        props['comments'][-1],
+        {
+            'user': 'user1',
+            'action': 'closed',
+            'text': close_comment,
+        },
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/lib/test_changeset_note_closures.py
+++ b/tests/lib/test_changeset_note_closures.py
@@ -1,0 +1,30 @@
+from app.lib.changeset_note_closures import parse_changeset_note_closures
+from app.models.types import NoteId
+
+
+def test_parse_changeset_note_closures():
+    assert parse_changeset_note_closures({
+        'comment': 'default comment',
+        'closes:note': ' 12 ;invalid;34;12;0;',
+        'closes:note:34:comment': 'custom comment',
+    }) == {
+        NoteId(12): 'default comment',
+        NoteId(34): 'custom comment',
+        NoteId(0): 'default comment',
+    }
+
+
+def test_parse_changeset_note_closures_shared_override():
+    assert parse_changeset_note_closures({
+        'comment': 'changeset comment',
+        'closes:note': '5;6',
+        'closes:note:comment': 'shared note comment',
+    }) == {
+        NoteId(5): 'shared note comment',
+        NoteId(6): 'shared note comment',
+    }
+
+
+def test_parse_changeset_note_closures_without_comment():
+    assert parse_changeset_note_closures({'closes:note': '7'}) == {NoteId(7): ''}
+    assert parse_changeset_note_closures({'comment': 'unused'}) == {}

--- a/tests/lib/test_changeset_note_closures.py
+++ b/tests/lib/test_changeset_note_closures.py
@@ -10,7 +10,6 @@ def test_parse_changeset_note_closures():
     }) == {
         NoteId(12): 'default comment',
         NoteId(34): 'custom comment',
-        NoteId(0): 'default comment',
     }
 
 


### PR DESCRIPTION
Closes #126
/claim #126

## Summary
- Parse the `closes:note` changeset tag, ignoring invalid and duplicate note ids while preserving the first valid order.
- Use the changeset `comment` as the default closing message, with `closes:note:comment` and `closes:note:<id>:comment` overrides.
- Close referenced notes through `NoteService.comment(..., closed)` so the existing note status, audit, subscription, and notification path is preserved.
- Skip missing, hidden, and already-closed notes without failing the changeset close.
- Add focused parser tests and an API integration test for default comments, per-note overrides, duplicate/invalid ids, missing notes, and already-closed notes.

## Why this version
This keeps the implementation scoped to the feature and tests only. It intentionally does not touch CI workflows, shell scripts, or unrelated files.

## Verification
- `uvx ruff format app/services/changeset_service.py app/lib/changeset_note_closures.py tests/controllers/test_api06_changeset.py tests/lib/test_changeset_note_closures.py`
- `uvx ruff check app/services/changeset_service.py app/lib/changeset_note_closures.py tests/controllers/test_api06_changeset.py tests/lib/test_changeset_note_closures.py`
- `python -m py_compile app/services/changeset_service.py app/lib/changeset_note_closures.py tests/controllers/test_api06_changeset.py tests/lib/test_changeset_note_closures.py`
- Parser smoke test via local Python assertions

I also attempted `uv run pytest tests/lib/test_changeset_note_closures.py -q`, but this Windows environment could not build the native `zid` dependency because Rust/Cargo are unavailable and the temporary rustup install failed while creating an existing `cargo-miri.exe` link.