### PR TITLE
Reject changesets with multiple null island nodes

### DIFF
--- a/app/exceptions/api06.py
+++ b/app/exceptions/api06.py
@@ -194,6 +194,13 @@ class Exceptions06(Exceptions):
             detail=f'Update action requires version >= 1, got {element["version"] - 1}',
         )
 
+    @override
+    def diff_multiple_null_island_nodes(self, count: int):
+        raise APIError(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f'Changeset contains {count} nodes at the null island (0, 0).',
+        )
+
     # --- element ---
     @override
     def element_not_found(

--- a/app/exceptions/default.py
+++ b/app/exceptions/default.py
@@ -135,6 +135,9 @@ class Exceptions:
     def diff_update_bad_version(self, element: ElementInit) -> NoReturn:
         raise NotImplementedError
 
+    def diff_multiple_null_island_nodes(self, count: int) -> NoReturn:
+        raise NotImplementedError
+
     # --- element ---
     def element_not_found(
         self, element_ref: TypedElementId | tuple[TypedElementId, int]

--- a/app/services/optimistic_diff/prepare.py
+++ b/app/services/optimistic_diff/prepare.py
@@ -6,6 +6,7 @@ from typing import Final, Literal, TypeAlias, assert_never
 
 import cython
 import numpy as np
+from app.models.proto.shared_types import ElementType
 from psycopg import AsyncConnection
 from shapely import Point, bounds, box
 
@@ -14,6 +15,7 @@ from app.lib.auth.context import auth_user
 from app.lib.geo.changeset_bounds import extend_changeset_bounds
 from app.models.db.changeset import Changeset, changeset_increase_size
 from app.models.db.element import Element, ElementInit
+from app.models.db.user import user_is_moderator
 from app.models.element import (
     TYPED_ELEMENT_ID_NODE_MAX,
     TYPED_ELEMENT_ID_NODE_MIN,
@@ -21,7 +23,6 @@ from app.models.element import (
     TYPED_ELEMENT_ID_RELATION_MIN,
     TypedElementId,
 )
-from app.models.proto.shared_types import ElementType
 from app.models.types import SequenceId
 from app.queries.changeset_query import ChangesetBoundsQuery, ChangesetQuery
 from app.queries.element_query import ElementQuery
@@ -207,6 +208,17 @@ class OptimisticDiffPrepare:
                 )
             else:
                 entry.current = element
+
+        if not user_is_moderator(auth_user()):
+            null_island_nodes: cython.size_t = sum(
+                1
+                for element in apply_elements
+                if element['point'] is not None
+                and element['point'].x == 0.0
+                and element['point'].y == 0.0
+            )
+            if null_island_nodes >= 2:
+                raise_for.diff_multiple_null_island_nodes(null_island_nodes)
 
         self._update_changeset_size(
             num_create=num_create,

--- a/tests/services/optimistic_diff/test_create.py
+++ b/tests/services/optimistic_diff/test_create.py
@@ -1,10 +1,12 @@
 import pytest
+from app.models.proto.shared_types import ElementType
 from shapely import Point
+from starlette import status
 
+from app.exceptions.api_error import APIError
 from app.lib.auth.user_limits import UserRoleLimits
 from app.models.db.element import ElementInit, validate_elements
 from app.models.element import ElementId
-from app.models.proto.shared_types import ElementType
 from app.models.types import ChangesetId
 from app.queries.element_query import ElementQuery
 from app.services.changeset_service import ChangesetService
@@ -94,6 +96,40 @@ async def test_create_multiple_nodes(changeset_id: ChangesetId):
     name_map = {e['tags']['name']: e for e in elements}  # type: ignore
     assert_model(name_map['Node 1'], nodes[0] | {'typed_id': typed_ids[0]})
     assert_model(name_map['Node 2'], nodes[1] | {'typed_id': typed_ids[1]})
+
+
+async def test_create_fails_with_multiple_null_island_nodes(
+    changeset_id: ChangesetId,
+):
+    # Arrange
+    nodes: list[ElementInit] = [
+        {
+            'changeset_id': changeset_id,
+            'typed_id': typed_element_id('node', ElementId(-1)),
+            'version': 1,
+            'visible': True,
+            'tags': {},
+            'point': Point(0, 0),
+            'members': None,
+            'members_roles': None,
+        },
+        {
+            'changeset_id': changeset_id,
+            'typed_id': typed_element_id('node', ElementId(-2)),
+            'version': 1,
+            'visible': True,
+            'tags': {},
+            'point': Point(0, 0),
+            'members': None,
+            'members_roles': None,
+        },
+    ]
+
+    # Act & Assert
+    with pytest.raises(APIError) as exc_info:
+        await OptimisticDiff.run(nodes)
+    assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert 'null island' in exc_info.value.detail
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #128

## Summary
- Reject optimistic diff uploads from non-moderators when the resulting changeset contains 2 or more nodes at exactly `(0, 0)`.
- Keep single null-island node edits valid, matching the discussion around legitimate existing objects.
- Add an API 0.6 error response and a focused regression test for the multi-node rejection case.

## Verification
- `uvx ruff check app/exceptions/default.py app/exceptions/api06.py app/services/optimistic_diff/prepare.py tests/services/optimistic_diff/test_create.py`
- `python3 -m py_compile app/exceptions/default.py app/exceptions/api06.py app/services/optimistic_diff/prepare.py tests/services/optimistic_diff/test_create.py`
- `git diff --check`

## Notes
- I attempted `uv run pytest tests/services/optimistic_diff/test_create.py::test_create_fails_with_multiple_null_island_nodes -q`, but dependency resolution fails on this macOS x86_64 environment because `torch==2.11.0` has no compatible wheel for the current platform. The targeted regression test is included for CI to run in the supported project environment.