### PR TITLE
Add founder badge logo assets

### DIFF
--- a/resources/founder-badge.svg
+++ b/resources/founder-badge.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">OSM-NG Founder badge</title>
+  <desc id="desc">A founder recognition badge based on the OpenStreetMap-NG folded-map logo, with a compass star, NG monogram, and founder ribbon.</desc>
+  <defs>
+    <linearGradient id="gold" x1="96" y1="48" x2="416" y2="464" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fff3b8"/>
+      <stop offset="0.45" stop-color="#d5a73b"/>
+      <stop offset="1" stop-color="#8e5f13"/>
+    </linearGradient>
+    <linearGradient id="map" x1="92" y1="96" x2="428" y2="416" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#d7f4be"/>
+      <stop offset="0.48" stop-color="#aee38f"/>
+      <stop offset="1" stop-color="#78c66f"/>
+    </linearGradient>
+    <linearGradient id="water" x1="78" y1="322" x2="424" y2="266" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#92c6ef"/>
+      <stop offset="1" stop-color="#447fc4"/>
+    </linearGradient>
+    <linearGradient id="ribbon" x1="78" y1="356" x2="434" y2="430" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1c674c"/>
+      <stop offset="1" stop-color="#0d342e"/>
+    </linearGradient>
+    <filter id="shadow" x="-18%" y="-18%" width="136%" height="136%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#10231c" flood-opacity="0.28"/>
+    </filter>
+    <clipPath id="mapClip">
+      <path d="M92 83c55 13 96-17 155-4 59 13 105-20 171-3l28 151-27 189c-66-17-117 18-180 4-57-14-101 16-159 2L53 266z"/>
+    </clipPath>
+  </defs>
+
+  <circle cx="256" cy="256" r="236" fill="#f8fff2"/>
+  <circle cx="256" cy="256" r="224" fill="url(#gold)"/>
+  <circle cx="256" cy="256" r="206" fill="#f8fff2"/>
+
+  <g filter="url(#shadow)">
+    <g clip-path="url(#mapClip)">
+      <path d="M92 83c55 13 96-17 155-4 59 13 105-20 171-3l28 151-27 189c-66-17-117 18-180 4-57-14-101 16-159 2L53 266z" fill="url(#map)"/>
+      <path d="M83 168c65 20 108-20 175 0 66 19 110-16 173 3" fill="none" stroke="#5e9f63" stroke-width="7" stroke-linecap="round" opacity="0.38"/>
+      <path d="M80 283c69-19 112 17 181-2 68-18 111 15 175-4" fill="none" stroke="#578d59" stroke-width="6" stroke-linecap="round" opacity="0.42"/>
+      <path d="M150 93c20 80-10 139 8 218 9 40 8 72-4 122" fill="none" stroke="#629e67" stroke-width="6" opacity="0.36"/>
+      <path d="M305 76c-13 65 18 121 11 184-6 70 16 114 29 166" fill="none" stroke="#629e67" stroke-width="6" opacity="0.34"/>
+      <path d="M112 132l75 30 40 67 68 19 38 70 72 35" fill="none" stroke="#c45455" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" opacity="0.72"/>
+      <path d="M76 332c73-53 132-58 176-37 44 20 92 22 174-37" fill="none" stroke="url(#water)" stroke-width="11" stroke-linecap="round" opacity="0.7"/>
+    </g>
+    <path d="M92 83c55 13 96-17 155-4 59 13 105-20 171-3l28 151-27 189c-66-17-117 18-180 4-57-14-101 16-159 2L53 266z" fill="none" stroke="#23452f" stroke-width="9" stroke-linejoin="round"/>
+
+    <path d="M256 106l20 46 50 4-38 32 12 49-44-26-44 26 12-49-38-32 50-4z" fill="url(#gold)" stroke="#7c5617" stroke-width="8" stroke-linejoin="round"/>
+    <g font-family="Arial Black, Arial, sans-serif" font-weight="900" text-anchor="middle">
+      <text x="256" y="292" font-size="146" fill="#10231c" stroke="#10231c" stroke-width="18" stroke-linejoin="round">NG</text>
+      <text x="256" y="292" font-size="146" fill="#ffffff">NG</text>
+    </g>
+
+    <path d="M74 356h364l-33 41 33 41H74l33-41z" fill="url(#ribbon)" stroke="#0c2c26" stroke-width="7" stroke-linejoin="round"/>
+    <text x="256" y="414" font-family="Arial, sans-serif" font-size="43" font-weight="800" fill="#fff4c0" text-anchor="middle">FOUNDER</text>
+  </g>
+</svg>

--- a/resources/founder-lockup-dark.svg
+++ b/resources/founder-lockup-dark.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="360" viewBox="0 0 1080 360" role="img" aria-labelledby="title desc">
+  <title id="title">OSM-NG Founder lockup dark</title>
+  <desc id="desc">A dark-background founder recognition lockup pairing the OSM-NG founder badge with an OpenStreetMap-NG Founder wordmark.</desc>
+  <defs>
+    <linearGradient id="gold" x1="64" y1="36" x2="300" y2="324" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fff3b8"/>
+      <stop offset="0.45" stop-color="#d5a73b"/>
+      <stop offset="1" stop-color="#8e5f13"/>
+    </linearGradient>
+    <linearGradient id="map" x1="68" y1="69" x2="302" y2="300" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#d7f4be"/>
+      <stop offset="0.48" stop-color="#aee38f"/>
+      <stop offset="1" stop-color="#78c66f"/>
+    </linearGradient>
+    <linearGradient id="ribbon" x1="58" y1="244" x2="306" y2="296" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1c674c"/>
+      <stop offset="1" stop-color="#0d342e"/>
+    </linearGradient>
+    <filter id="shadow" x="-18%" y="-18%" width="136%" height="136%">
+      <feDropShadow dx="0" dy="8" stdDeviation="9" flood-color="#000000" flood-opacity="0.38"/>
+    </filter>
+    <clipPath id="mapClip">
+      <path d="M67 57c39 10 69-12 112-3 42 10 75-14 123-2l20 109-19 136c-48-12-84 13-130 3-41-10-72 12-114 1L39 191z"/>
+    </clipPath>
+  </defs>
+
+  <rect width="1080" height="360" rx="40" fill="#10231c"/>
+
+  <g filter="url(#shadow)">
+    <circle cx="180" cy="180" r="152" fill="url(#gold)"/>
+    <circle cx="180" cy="180" r="140" fill="#f8fff2"/>
+    <g clip-path="url(#mapClip)">
+      <path d="M67 57c39 10 69-12 112-3 42 10 75-14 123-2l20 109-19 136c-48-12-84 13-130 3-41-10-72 12-114 1L39 191z" fill="url(#map)"/>
+      <path d="M61 118c47 15 77-15 126 0 48 14 79-11 124 2" fill="none" stroke="#5e9f63" stroke-width="5" stroke-linecap="round" opacity="0.38"/>
+      <path d="M58 202c50-13 81 12 130-2 49-13 80 11 126-3" fill="none" stroke="#578d59" stroke-width="4" stroke-linecap="round" opacity="0.42"/>
+      <path d="M108 64c14 58-7 100 6 157 6 29 6 52-3 88" fill="none" stroke="#629e67" stroke-width="4" opacity="0.36"/>
+      <path d="M219 52c-9 47 13 88 8 133-5 51 11 82 21 120" fill="none" stroke="#629e67" stroke-width="4" opacity="0.34"/>
+      <path d="M82 95l54 22 29 48 49 13 27 51 52 25" fill="none" stroke="#c45455" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" opacity="0.72"/>
+      <path d="M55 238c52-38 95-42 127-27 32 15 66 16 125-27" fill="none" stroke="#5f9dd8" stroke-width="8" stroke-linecap="round" opacity="0.7"/>
+    </g>
+    <path d="M67 57c39 10 69-12 112-3 42 10 75-14 123-2l20 109-19 136c-48-12-84 13-130 3-41-10-72 12-114 1L39 191z" fill="none" stroke="#23452f" stroke-width="6" stroke-linejoin="round"/>
+    <path d="M180 74l14 33 36 3-27 23 8 35-31-19-31 19 8-35-27-23 36-3z" fill="url(#gold)" stroke="#7c5617" stroke-width="5" stroke-linejoin="round"/>
+    <g font-family="Arial Black, Arial, sans-serif" font-weight="900" text-anchor="middle">
+      <text x="180" y="211" font-size="104" fill="#10231c" stroke="#10231c" stroke-width="13" stroke-linejoin="round">NG</text>
+      <text x="180" y="211" font-size="104" fill="#ffffff">NG</text>
+    </g>
+    <path d="M51 251h258l-23 29 23 29H51l23-29z" fill="url(#ribbon)" stroke="#0c2c26" stroke-width="5" stroke-linejoin="round"/>
+    <text x="180" y="292" font-family="Arial, sans-serif" font-size="31" font-weight="800" fill="#fff4c0" text-anchor="middle">FOUNDER</text>
+  </g>
+
+  <g font-family="Arial, sans-serif">
+    <text x="400" y="140" font-size="58" font-weight="800" fill="#f3fff6">OpenStreetMap-NG</text>
+    <text x="400" y="220" font-size="86" font-weight="900" fill="#bfecc7">Founder</text>
+    <path d="M404 248h462" stroke="#d5a73b" stroke-width="8" stroke-linecap="round"/>
+    <text x="400" y="294" font-size="27" font-weight="700" fill="#bdd0c2">Contributor recognition badge</text>
+  </g>
+</svg>

--- a/resources/founder-lockup.svg
+++ b/resources/founder-lockup.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="360" viewBox="0 0 1080 360" role="img" aria-labelledby="title desc">
+  <title id="title">OSM-NG Founder lockup</title>
+  <desc id="desc">A light-background founder recognition lockup pairing the OSM-NG founder badge with an OpenStreetMap-NG Founder wordmark.</desc>
+  <defs>
+    <linearGradient id="gold" x1="64" y1="36" x2="300" y2="324" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fff3b8"/>
+      <stop offset="0.45" stop-color="#d5a73b"/>
+      <stop offset="1" stop-color="#8e5f13"/>
+    </linearGradient>
+    <linearGradient id="map" x1="68" y1="69" x2="302" y2="300" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#d7f4be"/>
+      <stop offset="0.48" stop-color="#aee38f"/>
+      <stop offset="1" stop-color="#78c66f"/>
+    </linearGradient>
+    <linearGradient id="ribbon" x1="58" y1="244" x2="306" y2="296" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1c674c"/>
+      <stop offset="1" stop-color="#0d342e"/>
+    </linearGradient>
+    <filter id="shadow" x="-18%" y="-18%" width="136%" height="136%">
+      <feDropShadow dx="0" dy="8" stdDeviation="9" flood-color="#10231c" flood-opacity="0.2"/>
+    </filter>
+    <clipPath id="mapClip">
+      <path d="M67 57c39 10 69-12 112-3 42 10 75-14 123-2l20 109-19 136c-48-12-84 13-130 3-41-10-72 12-114 1L39 191z"/>
+    </clipPath>
+  </defs>
+
+  <rect width="1080" height="360" rx="40" fill="#ffffff"/>
+
+  <g filter="url(#shadow)">
+    <circle cx="180" cy="180" r="152" fill="url(#gold)"/>
+    <circle cx="180" cy="180" r="140" fill="#f8fff2"/>
+    <g clip-path="url(#mapClip)">
+      <path d="M67 57c39 10 69-12 112-3 42 10 75-14 123-2l20 109-19 136c-48-12-84 13-130 3-41-10-72 12-114 1L39 191z" fill="url(#map)"/>
+      <path d="M61 118c47 15 77-15 126 0 48 14 79-11 124 2" fill="none" stroke="#5e9f63" stroke-width="5" stroke-linecap="round" opacity="0.38"/>
+      <path d="M58 202c50-13 81 12 130-2 49-13 80 11 126-3" fill="none" stroke="#578d59" stroke-width="4" stroke-linecap="round" opacity="0.42"/>
+      <path d="M108 64c14 58-7 100 6 157 6 29 6 52-3 88" fill="none" stroke="#629e67" stroke-width="4" opacity="0.36"/>
+      <path d="M219 52c-9 47 13 88 8 133-5 51 11 82 21 120" fill="none" stroke="#629e67" stroke-width="4" opacity="0.34"/>
+      <path d="M82 95l54 22 29 48 49 13 27 51 52 25" fill="none" stroke="#c45455" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" opacity="0.72"/>
+      <path d="M55 238c52-38 95-42 127-27 32 15 66 16 125-27" fill="none" stroke="#5f9dd8" stroke-width="8" stroke-linecap="round" opacity="0.7"/>
+    </g>
+    <path d="M67 57c39 10 69-12 112-3 42 10 75-14 123-2l20 109-19 136c-48-12-84 13-130 3-41-10-72 12-114 1L39 191z" fill="none" stroke="#23452f" stroke-width="6" stroke-linejoin="round"/>
+    <path d="M180 74l14 33 36 3-27 23 8 35-31-19-31 19 8-35-27-23 36-3z" fill="url(#gold)" stroke="#7c5617" stroke-width="5" stroke-linejoin="round"/>
+    <g font-family="Arial Black, Arial, sans-serif" font-weight="900" text-anchor="middle">
+      <text x="180" y="211" font-size="104" fill="#10231c" stroke="#10231c" stroke-width="13" stroke-linejoin="round">NG</text>
+      <text x="180" y="211" font-size="104" fill="#ffffff">NG</text>
+    </g>
+    <path d="M51 251h258l-23 29 23 29H51l23-29z" fill="url(#ribbon)" stroke="#0c2c26" stroke-width="5" stroke-linejoin="round"/>
+    <text x="180" y="292" font-family="Arial, sans-serif" font-size="31" font-weight="800" fill="#fff4c0" text-anchor="middle">FOUNDER</text>
+  </g>
+
+  <g font-family="Arial, sans-serif">
+    <text x="400" y="140" font-size="58" font-weight="800" fill="#203428">OpenStreetMap-NG</text>
+    <text x="400" y="220" font-size="86" font-weight="900" fill="#16513d">Founder</text>
+    <path d="M404 248h462" stroke="#d5a73b" stroke-width="8" stroke-linecap="round"/>
+    <text x="400" y="294" font-size="27" font-weight="700" fill="#5b6f63">Contributor recognition badge</text>
+  </g>
+</svg>


### PR DESCRIPTION
Addresses #114.

This adds an alternate Founder badge direction for the OSM-NG contributor incentives page:

- `resources/founder-badge.svg`: square Founder badge
- `resources/founder-lockup.svg`: light-background lockup
- `resources/founder-lockup-dark.svg`: dark-background lockup

Design notes:

- keeps the folded-map + NG visual language from the existing OSM-NG mark
- uses singular "Founder" to match the contributor incentives wording
- ships as pure SVG so the assets can be versioned and scaled cleanly

Verification:

- parsed all three SVG files as XML
- ran `git diff --check`
- generated local Quick Look previews for the SVG assets

No payout or payment details are included here; those can be handled privately after maintainer acceptance if needed.