### PR TITLE
Add login password visibility toggle

### DIFF
--- a/app/views/user/login.tsx
+++ b/app/views/user/login.tsx
@@ -188,66 +188,84 @@ const CredentialsPane = ({
   displayNameInputRef: RefObject<HTMLInputElement>
   passwordInputRef: RefObject<HTMLInputElement>
   rememberInputRef: RefObject<HTMLInputElement>
-}) => (
-  <>
-    <label class="form-label d-block mb-2">
-      {t("sessions.new.email or username")}
-      <TestSiteReminder>
-        <input
-          ref={displayNameInputRef}
-          type="text"
-          class="form-control mt-2"
-          name="display_name_or_email"
-          // oxlint-disable-next-line jsx_a11y/autocomplete-valid
-          autocomplete="username webauthn"
-          autocapitalize="none"
-          required
-        />
-      </TestSiteReminder>
-    </label>
+}) => {
+  const showPassword = useSignal(false)
+  const passwordToggleLabel = () =>
+    showPassword.value ? t("login.hide_password") : t("login.show_password")
 
-    <label class="form-label d-block mb-3">
-      {t("sessions.new.password")}
-      <input
-        ref={passwordInputRef}
-        type="password"
-        class="form-control mt-2"
-        name="password"
-        autocomplete="current-password"
-        required
-      />
-    </label>
-
-    <div class="d-flex justify-content-between align-items-center mx-1 mb-3">
-      <div class="form-check">
-        <label class="form-check-label">
+  return (
+    <>
+      <label class="form-label d-block mb-2">
+        {t("sessions.new.email or username")}
+        <TestSiteReminder>
           <input
-            ref={rememberInputRef}
-            class="form-check-input"
-            type="checkbox"
-            name="remember"
-            value="True"
-            autocomplete="off"
+            ref={displayNameInputRef}
+            type="text"
+            class="form-control mt-2"
+            name="display_name_or_email"
+            // oxlint-disable-next-line jsx_a11y/autocomplete-valid
+            autocomplete="username webauthn"
+            autocapitalize="none"
+            required
           />
-          {t("sessions.new.remember")}
-        </label>
-      </div>
-      <a
-        class="link-primary small"
-        href="/reset-password"
-      >
-        {t("sessions.new.lost password link")}
-      </a>
-    </div>
+        </TestSiteReminder>
+      </label>
 
-    <button
-      class="btn btn-primary w-100 fw-medium"
-      type="submit"
-    >
-      {t("login.sign_in")}
-    </button>
-  </>
-)
+      <label class="form-label d-block mb-3">
+        {t("sessions.new.password")}
+        <div class="input-group mt-2">
+          <input
+            ref={passwordInputRef}
+            type={showPassword.value ? "text" : "password"}
+            class="form-control"
+            name="password"
+            autocomplete="current-password"
+            required
+          />
+          <button
+            class="btn btn-outline-secondary"
+            type="button"
+            aria-label={passwordToggleLabel()}
+            aria-pressed={showPassword.value}
+            title={passwordToggleLabel()}
+            onClick={() => (showPassword.value = !showPassword.value)}
+          >
+            <i class={`bi ${showPassword.value ? "bi-eye-slash" : "bi-eye"}`} />
+          </button>
+        </div>
+      </label>
+
+      <div class="d-flex justify-content-between align-items-center mx-1 mb-3">
+        <div class="form-check">
+          <label class="form-check-label">
+            <input
+              ref={rememberInputRef}
+              class="form-check-input"
+              type="checkbox"
+              name="remember"
+              value="True"
+              autocomplete="off"
+            />
+            {t("sessions.new.remember")}
+          </label>
+        </div>
+        <a
+          class="link-primary small"
+          href="/reset-password"
+        >
+          {t("sessions.new.lost password link")}
+        </a>
+      </div>
+
+      <button
+        class="btn btn-primary w-100 fw-medium"
+        type="submit"
+      >
+        {t("login.sign_in")}
+      </button>
+    </>
+  )
+}
 
 const PasskeyPane = ({
   onRetry,

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -491,6 +491,8 @@ login:
   sign_in: Sign in
   sign_in_with_a_passkey: Sign in with a passkey
   sign_in_with_service: "Sign in with {{service}}"
+  show_password: Show password
+  hide_password: Hide password
 two_fa:
   two_factor_methods: Two-factor methods
   secure_your_account_using_additional_verification_methods: Secure your account using additional verification methods.


### PR DESCRIPTION
## Summary
- Add a password visibility toggle to the shared login credentials pane.
- Keep the existing current-password autocomplete and submit behavior unchanged.
- Add English labels for the toggle's accessible name/title.

## Validation
- `bun install --ignore-scripts`
- `bunx prettier --check --no-semi --single-attribute-per-line app/views/user/login.tsx config/locale/extra_en.yaml`
- `bunx oxlint app/views/user/login.tsx` (passes with existing warning-level a11y findings in this file)
- `git diff --check`

## Notes
- Focused current-main implementation of the show-password usability request from #45.
- `bunx tsc --noEmit --pretty false` could not complete in this plain shell because generated `@proto/*` TypeScript bindings are absent without the repo proto pipeline.

Refs #45