### PR TITLE
Reject null island node edits

### DIFF
--- a/app/format/api06_element.py
+++ b/app/format/api06_element.py
@@ -181,7 +181,7 @@ class Element06Mixin:
             else:
                 raise_for.diff_unsupported_action(action)
 
-        return result
+        return validate_elements(result)
 
 
 @cython.cfunc

--- a/app/models/db/element.py
+++ b/app/models/db/element.py
@@ -92,6 +92,10 @@ def _validate_node(element: ElementInit):
     element['members'] = None
     element['members_roles'] = None
 
+    point = element['point']
+    if element['visible'] and point is not None and point.x == 0 and point.y == 0:
+        raise ValueError('Nodes cannot be placed at 0,0')
+
 
 @cython.cfunc
 def _validate_way(element: ElementInit):

--- a/tests/controllers/test_api06_changeset.py
+++ b/tests/controllers/test_api06_changeset.py
@@ -132,7 +132,7 @@ async def test_changeset_upload(client: AsyncClient):
         content=XMLToDict.unparse({
             'osmChange': {
                 'create': [
-                    ('node', {'@id': -1, '@lat': 0, '@lon': 0}),
+                    ('node', {'@id': -1, '@lat': 2, '@lon': 1}),
                     ('way', {'@id': -1, 'nd': [{'@ref': -1}]}),
                 ]
             }
@@ -157,12 +157,51 @@ async def test_changeset_upload(client: AsyncClient):
             '@updated_at': datetime,
             '@closed_at': datetime,
             '@changes_count': 2,
-            '@min_lat': 0.0,
-            '@max_lat': 0.0,
-            '@min_lon': 0.0,
-            '@max_lon': 0.0,
+            '@min_lat': 2.0,
+            '@max_lat': 2.0,
+            '@min_lon': 1.0,
+            '@max_lon': 1.0,
         },
     )
+
+
+async def test_changeset_upload_rejects_null_island_node(client: AsyncClient):
+    client.headers['Authorization'] = 'User user1'
+
+    r = await client.put(
+        '/api/0.6/changeset/create',
+        content=XMLToDict.unparse({
+            'osm': {
+                'changeset': {
+                    'tag': [
+                        {
+                            '@k': 'created_by',
+                            '@v': (
+                                test_changeset_upload_rejects_null_island_node.__name__
+                            ),
+                        }
+                    ]
+                }
+            }
+        }),
+    )
+    assert r.is_success, r.text
+    changeset_id = int(r.text)
+
+    r = await client.post(
+        f'/api/0.6/changeset/{changeset_id}/upload',
+        content=XMLToDict.unparse({
+            'osmChange': {
+                'create': [
+                    ('node', {'@id': -1, '@lat': 0, '@lon': 0}),
+                    ('way', {'@id': -1, 'nd': [{'@ref': -1}]}),
+                ]
+            }
+        }),
+    )
+
+    assert r.status_code == status.HTTP_400_BAD_REQUEST, r.text
+    assert '0,0' in r.text
 
 
 @pytest.mark.parametrize('include', [True, False])
@@ -285,7 +324,7 @@ async def test_changeset_upload_closed(client: AsyncClient):
     r = await client.post(
         f'/api/0.6/changeset/{changeset_id}/upload',
         content=XMLToDict.unparse({
-            'osmChange': {'create': [('node', {'@id': -1, '@lat': 0, '@lon': 0})]}
+            'osmChange': {'create': [('node', {'@id': -1, '@lat': 2, '@lon': 1})]}
         }),
     )
     assert r.status_code == status.HTTP_409_CONFLICT, r.text


### PR DESCRIPTION
Fixes #128

## Summary
- Reject visible nodes located at lon/lat `0,0`
- Run `osmChange` upload decoding through `validate_elements()`, matching normal element decode validation
- Add regression coverage for a diff upload that creates a null-island node referenced by a way

## Verification
- `python -m py_compile app\models\db\element.py app\format\api06_element.py tests\controllers\test_api06_changeset.py`
- `git diff --check`

## Notes
I could not run the full pytest target locally because this environment does not have the repo’s Python 3.14/uv test environment available.
