### PR TITLE
Add changeset diff action

### DIFF
--- a/app/views/index/changeset.tsx
+++ b/app/views/index/changeset.tsx
@@ -272,6 +272,21 @@ const ChangesetFooter = ({ data }: { data: DataValid }) => {
   )
 }
 
+const getChangesetDiffUrl = (changesetId: bigint) =>
+  `https://overpass-api.de/achavi/?changeset=${changesetId}`
+
+const ChangesetDiffButton = ({ changesetId }: { changesetId: bigint }) => (
+  <a
+    class="btn btn-sm btn-outline-primary"
+    href={getChangesetDiffUrl(changesetId)}
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    <i class="bi bi-map me-1" />
+    {t("changeset.open_diff")}
+  </a>
+)
+
 const ChangesetElementRow = ({
   element,
   type,
@@ -377,6 +392,9 @@ const ChangesetSidebar = ({
 
             <ChangesetHeader data={d} />
             <Tags tags={d.tags} />
+            <div class="mt-3">
+              <ChangesetDiffButton changesetId={d.id} />
+            </div>
 
             {/* Report button */}
             {isLoggedIn && d.user && config.userConfig!.user.id !== d.user.id && (

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -39,6 +39,7 @@ map:
       title: Routing engine
 changeset:
   open: Open
+  open_diff: Open changeset diff
   this_changeset_is_state: This changeset is {{state}}
   count_one: "changeset"
   count_other: "changesets"


### PR DESCRIPTION
## Summary
- add an Open changeset diff action to the changeset sidebar
- open Achavi for the current changeset in a new tab so the OSM-NG page does not refresh
- add the English label for the new action

Fixes #7

## Checks
- Parsed app/views/index/changeset.tsx with @babel/parser
- Parsed config/locale/extra_en.yaml with Ruby YAML
- npx prettier --check --no-semi app/views/index/changeset.tsx config/locale/extra_en.yaml
- git diff --check
- Verified https://overpass-api.de/achavi/?changeset=1 returns HTTP 200

Note: I could not complete a full tsc run from this plain checkout because the generated @proto/* files are not present until the project proto/Nix setup has run.