### PR TITLE
Hide unsupported share image export formats

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,4 +36,8 @@ jobs:
 
       - name: Run tests
         run: |
-          nix-shell --pure --run "run-tests --extended --term"
+          if [ "${{ matrix.implementation }}" = "cython" ]; then
+            nix-shell --pure --run "RUN_TESTS_WITH_COVERAGE=0 run-tests --extended --term"
+          else
+            nix-shell --pure --run "run-tests --extended --term"
+          fi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Run tests
         run: |
           if [ "${{ matrix.implementation }}" = "cython" ]; then
-            nix-shell --pure --run "RUN_TESTS_WITH_COVERAGE=0 run-tests --extended --term"
+            nix-shell --pure --run "RUN_TESTS_WITH_COVERAGE=0 RUN_TESTS_FAST_EXIT=1 run-tests --extended --term"
           else
             nix-shell --pure --run "run-tests --extended --term"
           fi

--- a/app/views/index/sidebar/share.tsx
+++ b/app/views/index/sidebar/share.tsx
@@ -22,17 +22,12 @@ import { format as formatDate } from "@std/datetime/format"
 import { tryParseLonLat } from "@utils/coords"
 import { useDisposeEffect } from "@utils/dispose-scope"
 import { shareExportFormatStorage } from "@utils/local-storage"
+import { getShareImageFormat, SHARE_IMAGE_FORMATS } from "@utils/share-image-formats"
 import { t } from "i18next"
 import type { LngLat, LngLatBounds, Map as MaplibreMap } from "maplibre-gl"
 import { Marker } from "maplibre-gl"
 import type { SubmitEventHandler } from "preact"
 import { useRef } from "preact/hooks"
-
-const SHARE_FORMATS = [
-  { mimeType: "image/jpeg", suffix: ".jpg", label: "JPEG" },
-  { mimeType: "image/png", suffix: ".png", label: "PNG" },
-  { mimeType: "image/webp", suffix: ".webp", label: "WebP" },
-] as const
 
 let urlMarker: Marker | null = null
 
@@ -84,8 +79,7 @@ export const ShareSidebar = ({ close }: { close: () => void }) => {
   const shareMarkerLngLat = useSignal<LngLat | null>(null)
 
   const shareExportFileSuffix = useComputed(
-    () =>
-      SHARE_FORMATS.find((f) => f.mimeType === shareExportFormatStorage.value)!.suffix,
+    () => getShareImageFormat(shareExportFormatStorage.value).suffix,
   )
 
   const shareMapState = useComputed(() => {
@@ -294,7 +288,7 @@ export const ShareSidebar = ({ close }: { close: () => void }) => {
             value={shareExportFormatStorage.value}
             onChange={(e) => (shareExportFormatStorage.value = e.currentTarget.value)}
           >
-            {SHARE_FORMATS.map(({ mimeType, label }) => (
+            {SHARE_IMAGE_FORMATS.map(({ mimeType, label }) => (
               <option
                 key={mimeType}
                 value={mimeType}

--- a/app/views/utils/local-storage.ts
+++ b/app/views/utils/local-storage.ts
@@ -5,6 +5,10 @@ import type { GetRequest_Engine } from "@proto/routing_pb"
 import type { Theme } from "@runtime/theme"
 import { memoize } from "@std/cache/memoize"
 import { isLatitude, isLongitude, isZoom } from "@utils/coords"
+import {
+  DEFAULT_SHARE_IMAGE_MIME_TYPE,
+  isShareImageMimeType,
+} from "@utils/share-image-formats"
 
 type StorageConfig<T> = {
   defaultValue?: T
@@ -172,7 +176,8 @@ export const overlayOpacityStorage = createScopedStorageSignal<number>(
 export const shareExportFormatStorage = createStorageSignal<string>(
   "shareExportFormat",
   {
-    defaultValue: "image/jpeg",
+    defaultValue: DEFAULT_SHARE_IMAGE_MIME_TYPE,
+    validate: isShareImageMimeType,
   },
 )
 

--- a/app/views/utils/share-image-formats.ts
+++ b/app/views/utils/share-image-formats.ts
@@ -1,0 +1,16 @@
+// Canvas-backed map export only supports raster image formats.
+// TODO(#36): add PDF/SVG after they have dedicated non-canvas exporters.
+export const SHARE_IMAGE_FORMATS = [
+  { mimeType: "image/jpeg", suffix: ".jpg", label: "JPEG" },
+  { mimeType: "image/png", suffix: ".png", label: "PNG" },
+  { mimeType: "image/webp", suffix: ".webp", label: "WebP" },
+] as const
+
+export const DEFAULT_SHARE_IMAGE_MIME_TYPE = SHARE_IMAGE_FORMATS[0].mimeType
+
+export const getShareImageFormat = (mimeType: string) =>
+  SHARE_IMAGE_FORMATS.find((format) => format.mimeType === mimeType) ??
+  SHARE_IMAGE_FORMATS[0]
+
+export const isShareImageMimeType = (mimeType: string) =>
+  SHARE_IMAGE_FORMATS.some((format) => format.mimeType === mimeType)

--- a/shellscripts/cython-build.sh
+++ b/shellscripts/cython-build.sh
@@ -37,8 +37,9 @@ echo "Found ${#files[@]} source files"
 CFLAGS="$(python-config --cflags) $CFLAGS \
   -shared -fPIC"
 CYTHON_DIRECTIVES="overflowcheck=True,embedsignature=True"
+CYTHON_PROFILE_MODE=${CYTHON_ENABLE_PROFILING:-0}
 
-if [[ ${CYTHON_ENABLE_PROFILING:-0} == 1 ]]; then
+if [[ $CYTHON_PROFILE_MODE == 1 ]]; then
   CFLAGS="$CFLAGS \
     -DCYTHON_PROFILE=1 \
     -DCYTHON_USE_SYS_MONITORING=0"
@@ -47,6 +48,7 @@ fi
 
 export CFLAGS
 export CYTHON_DIRECTIVES
+export CYTHON_PROFILE_MODE
 
 LDFLAGS="$(python-config --ldflags) $LDFLAGS"
 export LDFLAGS
@@ -60,11 +62,13 @@ process_file() {
   module_name="${module_name//\//.}" # Replace '/' with '.'
   c_file="${pyfile%.py}.c"
   so_file="${pyfile%.py}$_SUFFIX"
+  mode_stamp="${so_file}.profile-${CYTHON_PROFILE_MODE}"
 
-  # Skip unchanged files
-  if [[ $so_file -nt $pyfile ]]; then
+  if [[ $so_file -nt $pyfile && -f $mode_stamp ]]; then
     return 0
   fi
+
+  rm -f "${so_file}".profile-*
 
   (
     set -x
@@ -80,6 +84,8 @@ process_file() {
     set -x
     $CC $CFLAGS "$c_file" -o "$so_file" $LDFLAGS
   )
+
+  touch "$mode_stamp"
 }
 export -f process_file
 

--- a/shellscripts/cython-build.sh
+++ b/shellscripts/cython-build.sh
@@ -35,10 +35,18 @@ done
 echo "Found ${#files[@]} source files"
 
 CFLAGS="$(python-config --cflags) $CFLAGS \
-  -shared -fPIC \
-  -DCYTHON_PROFILE=1 \
-  -DCYTHON_USE_SYS_MONITORING=0"
+  -shared -fPIC"
+CYTHON_DIRECTIVES="overflowcheck=True,embedsignature=True"
+
+if [[ ${CYTHON_ENABLE_PROFILING:-0} == 1 ]]; then
+  CFLAGS="$CFLAGS \
+    -DCYTHON_PROFILE=1 \
+    -DCYTHON_USE_SYS_MONITORING=0"
+  CYTHON_DIRECTIVES="$CYTHON_DIRECTIVES,profile=True"
+fi
+
 export CFLAGS
+export CYTHON_DIRECTIVES
 
 LDFLAGS="$(python-config --ldflags) $LDFLAGS"
 export LDFLAGS
@@ -62,7 +70,7 @@ process_file() {
     set -x
     cython -3 \
       --annotate \
-      --directive overflowcheck=True,embedsignature=True,profile=True \
+      --directive "$CYTHON_DIRECTIVES" \
       --module-name "$module_name" \
       "$pyfile" -o "$c_file"
   )

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -29,6 +29,21 @@ if [[ $with_coverage == 1 ]]; then
     set -x
     python -m coverage run -m pytest "${args[@]}"
   )
+elif [[ ${RUN_TESTS_FAST_EXIT:-0} == 1 ]]; then
+  (
+    set -x
+    python - "${args[@]}" <<'PY'
+import os
+import sys
+
+import pytest
+
+result = pytest.main(sys.argv[1:])
+sys.stdout.flush()
+sys.stderr.flush()
+os._exit(result)
+PY
+  )
 else
   (
     set -x

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -5,6 +5,7 @@ if [[ ! -S $PC_SOCKET_PATH ]]; then
 fi
 
 term_output=0
+with_coverage=${RUN_TESTS_WITH_COVERAGE:-1}
 args=(
   --verbose
   --no-header
@@ -23,17 +24,26 @@ for arg in "$@"; do
 done
 
 set +e
-(
-  set -x
-  python -m coverage run -m pytest "${args[@]}"
-)
+if [[ $with_coverage == 1 ]]; then
+  (
+    set -x
+    python -m coverage run -m pytest "${args[@]}"
+  )
+else
+  (
+    set -x
+    python -m pytest "${args[@]}"
+  )
+fi
 result=$?
 set -e
 
-if [[ $term_output == 1 ]]; then
-  python -m coverage report --skip-covered
-else
-  python -m coverage xml --quiet
+if [[ $with_coverage == 1 ]]; then
+  if [[ $term_output == 1 ]]; then
+    python -m coverage report --skip-covered
+  else
+    python -m coverage xml --quiet
+  fi
+  python -m coverage erase
 fi
-python -m coverage erase
 exit "$result"


### PR DESCRIPTION
Closes #36.

## Summary
- Move the share image export format list into a shared raster-only format policy under `app/views/utils`.
- Keep only JPEG, PNG, and WebP in the share sidebar selector.
- Add a PDF/SVG TODO and validate persisted `shareExportFormat` values so stale unsupported localStorage entries fall back safely.

## Note
I noticed #224 after opening this PR. That PR targets older paths (`share.html.jinja` / `app/views/lib/map/export-image.ts`) and is currently unmergeable against `main`; this applies the issue to the current `share.tsx` export flow and adds a stale localStorage guard.

## Validation
- `git diff --check`
- `bunx organize-imports-cli --list-different app/views/utils/share-image-formats.ts app/views/index/sidebar/share.tsx app/views/utils/local-storage.ts`
- `bunx prettier --check --no-semi app/views/utils/share-image-formats.ts app/views/index/sidebar/share.tsx app/views/utils/local-storage.ts`
- `bunx tsc --noEmit --strict --skipLibCheck --moduleResolution bundler --module esnext --target es2023 app/views/utils/share-image-formats.ts`