### PR TITLE
Add changeset diff link

### DIFF
--- a/app/views/index/changeset.tsx
+++ b/app/views/index/changeset.tsx
@@ -74,6 +74,9 @@ const getChangesetElementsTitle = (type: ElementType) => {
   return (count: string) => t("browse.changeset.relation", { count })
 }
 
+const getChangesetDiffUrl = (changesetId: bigint) =>
+  `https://overpass-api.de/achavi/?changeset=${changesetId}`
+
 const ChangesetHeader = ({ data }: { data: DataValid }) => {
   const isOpen = !data.closedAt
   return (
@@ -377,6 +380,16 @@ const ChangesetSidebar = ({
 
             <ChangesetHeader data={d} />
             <Tags tags={d.tags} />
+
+            <a
+              class="btn btn-sm btn-primary w-100 mt-3"
+              href={getChangesetDiffUrl(d.id)}
+              target="_blank"
+              rel="noopener"
+            >
+              <i class="bi bi-box-arrow-up-right me-1" />
+              {t("changeset.open_diff_view")}
+            </a>
 
             {/* Report button */}
             {isLoggedIn && d.user && config.userConfig!.user.id !== d.user.id && (

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -39,6 +39,7 @@ map:
       title: Routing engine
 changeset:
   open: Open
+  open_diff_view: Open changeset diff
   this_changeset_is_state: This changeset is {{state}}
   count_one: "changeset"
   count_other: "changesets"


### PR DESCRIPTION
Closes #7.

## Summary
- add an “Open changeset diff” action to the changeset sidebar
- open the Achavi changeset viewer in a new tab with the current changeset id
- add the English label for the new action

## Verification
- `./node_modules/.bin/prettier --check --no-semi app/views/index/changeset.tsx config/locale/extra_en.yaml`
- `git diff --check`
- `curl -L --fail -A "Mozilla/5.0" https://overpass-api.de/achavi/?changeset=18986223`

Not run: full `tsc`/test suite, because this sandbox lacks the project Nix shell/proto pipeline and generated `app/views/proto/*` files.