### PR TITLE
Recompress trace files in the background

### DIFF
--- a/app/lib/io/trace_file.py
+++ b/app/lib/io/trace_file.py
@@ -32,11 +32,17 @@ class _CompressResult(NamedTuple):
 
 
 _ZSTD_SUFFIX = '.zst'
-_ZSTD_METADATA: dict[str, str] = {'zstd_level': str(TRACE_FILE_COMPRESS_ZSTD_LEVEL)}
-_ZSTD_OPTIONS: dict[int, int] = {
-    zstd.CompressionParameter.compression_level: TRACE_FILE_COMPRESS_ZSTD_LEVEL,
-    zstd.CompressionParameter.nb_workers: TRACE_FILE_COMPRESS_ZSTD_THREADS,
-}
+
+
+def _zstd_metadata(level: int) -> dict[str, str]:
+    return {'zstd_level': str(level)}
+
+
+def _zstd_options(level: int) -> dict[int, int]:
+    return {
+        zstd.CompressionParameter.compression_level: level,
+        zstd.CompressionParameter.nb_workers: TRACE_FILE_COMPRESS_ZSTD_THREADS,
+    }
 
 
 class TraceFile:
@@ -75,15 +81,15 @@ class TraceFile:
         raise_for.trace_file_archive_too_deep()
 
     @staticmethod
-    async def compress(buffer: bytes):
+    async def compress(buffer: bytes, *, level: int = TRACE_FILE_COMPRESS_ZSTD_LEVEL):
         """Compress the trace file buffer. Returns the compressed buffer and the file name suffix."""
         result = await to_thread(
             zstd.compress,
             buffer,
-            options=_ZSTD_OPTIONS,
+            options=_zstd_options(level),
         )
         logging.debug('Trace file zstd-compressed size is %s', sizestr(len(result)))
-        return _CompressResult(result, _ZSTD_SUFFIX, _ZSTD_METADATA)
+        return _CompressResult(result, _ZSTD_SUFFIX, _zstd_metadata(level))
 
     @staticmethod
     def decompress_if_needed(buffer: bytes, file_id: StorageKey):

--- a/app/main.py
+++ b/app/main.py
@@ -60,6 +60,7 @@ from app.services.email_service import EmailService
 from app.services.image_proxy_service import ImageProxyService
 from app.services.system_app_service import SystemAppService
 from app.services.test_service import TestService
+from app.services.trace_service import TraceService
 
 
 # HACK: Execute sync functions directly without threadpool
@@ -111,6 +112,7 @@ async def lifespan(_):
             EmailService.context(),
             ChangesetService.context(),
             ElementSpatialService.context(),
+            TraceService.context(),
         ):
             # freeze uncollected gc objects for improved performance
             gc.collect()

--- a/app/services/trace_service.py
+++ b/app/services/trace_service.py
@@ -1,9 +1,11 @@
 import logging
+from asyncio import TaskGroup
+from contextlib import asynccontextmanager
 from typing import Any
 
 from fastapi import UploadFile
 
-from app.config import TRACE_FILE_UPLOAD_MAX_SIZE
+from app.config import ENV, TRACE_FILE_UPLOAD_MAX_SIZE
 from app.db import db, db_delete, db_fetchval, db_insert, db_update
 from app.exceptions.context import raise_for
 from app.format.gpx import FormatGPX
@@ -24,8 +26,20 @@ from app.models.proto.trace_types import Visibility
 from app.models.types import StorageKey, TraceId
 from app.queries.trace_query import TraceQuery
 
+_TRACE_RECOMPRESS_ZSTD_LEVEL = 22
+_RECOMPRESSION_TG: TaskGroup
+
 
 class TraceService:
+    @asynccontextmanager
+    @staticmethod
+    async def context():
+        global _RECOMPRESSION_TG
+        async with (_RECOMPRESSION_TG := TaskGroup()):  # pyright: ignore[reportConstantRedefinition]
+            yield
+            for t in _RECOMPRESSION_TG._tasks:  # noqa: SLF001
+                t.cancel()
+
     @staticmethod
     async def upload(
         file: UploadFile | bytes,
@@ -111,12 +125,18 @@ class TraceService:
                         'visibility': trace_init['visibility'],
                     },
                 )
-                return trace_id
 
         except Exception:
             # Clean up trace file on error
             await TRACE_STORAGE.delete(trace_init['file_id'])
             raise
+        else:
+            task = _recompress_trace_file(trace_id, file, trace_init['file_id'])
+            if ENV == 'test':
+                await task
+            else:
+                _RECOMPRESSION_TG.create_task(task)
+            return trace_id
 
     @staticmethod
     async def update(
@@ -191,3 +211,54 @@ class TraceService:
 
         # After successful delete, also remove the file
         await TRACE_STORAGE.delete(file_id)
+
+
+async def _recompress_trace_file(
+    trace_id: TraceId,
+    file: bytes,
+    old_file_id: StorageKey,
+):
+    """Recompress a trace file in the background and swap it in if still current."""
+    new_file_id: StorageKey | None = None
+    swapped = False
+
+    try:
+        result = await TraceFile.compress(file, level=_TRACE_RECOMPRESS_ZSTD_LEVEL)
+        new_file_id = await TRACE_STORAGE.save(
+            result.data, result.suffix, result.metadata
+        )
+
+        rowcount = await db_update(
+            'trace',
+            {'file_id': new_file_id},
+            where={'id': trace_id, 'file_id': old_file_id},
+        )
+
+        if not rowcount:
+            await TRACE_STORAGE.delete(new_file_id)
+            logging.debug(
+                'Skipped trace %r recompression swap; file_id changed from %r',
+                trace_id,
+                old_file_id,
+            )
+            return
+
+        swapped = True
+        await TRACE_STORAGE.delete(old_file_id)
+        logging.debug(
+            'Recompressed trace %r file %r to %r',
+            trace_id,
+            old_file_id,
+            new_file_id,
+        )
+
+    except Exception:
+        if new_file_id is not None and not swapped:
+            try:
+                await TRACE_STORAGE.delete(new_file_id)
+            except Exception:
+                logging.exception(
+                    'Failed to clean up recompressed trace file %r', new_file_id
+                )
+
+        logging.exception('Trace %r background recompression failed', trace_id)

--- a/tests/lib/test_trace_file.py
+++ b/tests/lib/test_trace_file.py
@@ -1,3 +1,4 @@
+from app.lib.io import trace_file
 from app.lib.io.trace_file import TraceFile
 from app.models.types import StorageKey
 
@@ -9,3 +10,10 @@ async def test_trace_file_compression():
         == b'hello'
     )
     assert TraceFile.decompress_if_needed(result.data, StorageKey('test')) != b'hello'
+
+
+def test_trace_file_compression_level_metadata():
+    options = trace_file._zstd_options(22)  # noqa: SLF001
+
+    assert options[trace_file.zstd.CompressionParameter.compression_level] == 22
+    assert trace_file._zstd_metadata(22) == {'zstd_level': '22'}  # noqa: SLF001

--- a/tests/services/test_trace_service.py
+++ b/tests/services/test_trace_service.py
@@ -1,0 +1,66 @@
+from types import SimpleNamespace
+
+from app.services import trace_service
+
+
+async def test_recompress_trace_file_swaps_and_deletes_old(monkeypatch):
+    saved: list[tuple[bytes, str, dict[str, str]]] = []
+    deleted: list[str] = []
+    updates: list[tuple[dict[str, str], dict[str, object]]] = []
+
+    class Storage:
+        async def save(self, data: bytes, suffix: str, metadata: dict[str, str]):
+            saved.append((data, suffix, metadata))
+            return 'new.zst'
+
+        async def delete(self, key: str):
+            deleted.append(key)
+
+    async def compress(file: bytes, *, level: int):
+        assert file == b'gpx'
+        assert level == 22
+        return SimpleNamespace(
+            data=b'compressed',
+            suffix='.zst',
+            metadata={'zstd_level': '22'},
+        )
+
+    async def db_update(table, values, *, where):
+        assert table == 'trace'
+        updates.append((values, where))
+        return 1
+
+    monkeypatch.setattr(trace_service, 'TRACE_STORAGE', Storage())
+    monkeypatch.setattr(trace_service.TraceFile, 'compress', compress)
+    monkeypatch.setattr(trace_service, 'db_update', db_update)
+
+    await trace_service._recompress_trace_file(1, b'gpx', 'old.zst')  # noqa: SLF001
+
+    assert saved == [(b'compressed', '.zst', {'zstd_level': '22'})]
+    assert updates == [({'file_id': 'new.zst'}, {'id': 1, 'file_id': 'old.zst'})]
+    assert deleted == ['old.zst']
+
+
+async def test_recompress_trace_file_discards_new_file_when_trace_changed(monkeypatch):
+    deleted: list[str] = []
+
+    class Storage:
+        async def save(self, data: bytes, suffix: str, metadata: dict[str, str]):
+            return 'new.zst'
+
+        async def delete(self, key: str):
+            deleted.append(key)
+
+    async def compress(file: bytes, *, level: int):
+        return SimpleNamespace(data=b'compressed', suffix='.zst', metadata={})
+
+    async def db_update(table, values, *, where):
+        return 0
+
+    monkeypatch.setattr(trace_service, 'TRACE_STORAGE', Storage())
+    monkeypatch.setattr(trace_service.TraceFile, 'compress', compress)
+    monkeypatch.setattr(trace_service, 'db_update', db_update)
+
+    await trace_service._recompress_trace_file(1, b'gpx', 'old.zst')  # noqa: SLF001
+
+    assert deleted == ['new.zst']


### PR DESCRIPTION
## Summary
- keep trace uploads responsive by saving the initial level-6 zstd file as before
- start a guarded background recompression at zstd level 22 after the trace row commits
- swap the trace file_id only if it still points to the original file, then clean up stale storage
- add focused tests for compression metadata and recompression swap/cleanup behavior

Fixes #100

## Verification
- uvx ruff check app/lib/io/trace_file.py app/services/trace_service.py tests/lib/test_trace_file.py tests/services/test_trace_service.py
- uvx ruff format --check app/lib/io/trace_file.py app/services/trace_service.py tests/lib/test_trace_file.py tests/services/test_trace_service.py
- ENV=test SECRET=test-secret APP_URL=http://localhost:8000 SMTP_HOST=localhost SMTP_PORT=25 SMTP_USER=test@example.com SMTP_PASS=test POSTGRES_URL=postgresql://localhost/test DUCKDB_MEMORY_LIMIT=128MB MAGIC_LIBRARY=/opt/homebrew/opt/libmagic/lib/libmagic.dylib RUSTC_BOOTSTRAP=1 PYTHONPATH=. uv run pytest --noconftest tests/lib/test_trace_file.py tests/services/test_trace_service.py -q

Note: I used --noconftest for the new isolated unit test because the repo-level conftest starts the full app lifespan and requires local database/runtime services that are unrelated to this helper.