### PR TITLE
Make Cython profiling opt-in

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,4 +36,8 @@ jobs:
 
       - name: Run tests
         run: |
-          nix-shell --pure --run "run-tests --extended --term"
+          if [ "${{ matrix.implementation }}" = "cython" ]; then
+            nix-shell --pure --run "RUN_TESTS_WITH_COVERAGE=0 run-tests --extended --term"
+          else
+            nix-shell --pure --run "run-tests --extended --term"
+          fi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Run tests
         run: |
           if [ "${{ matrix.implementation }}" = "cython" ]; then
-            nix-shell --pure --run "RUN_TESTS_WITH_COVERAGE=0 run-tests --extended --term"
+            nix-shell --pure --run "RUN_TESTS_WITH_COVERAGE=0 RUN_TESTS_FAST_EXIT=1 run-tests --extended --term"
           else
             nix-shell --pure --run "run-tests --extended --term"
           fi

--- a/shellscripts/cython-build.sh
+++ b/shellscripts/cython-build.sh
@@ -37,8 +37,9 @@ echo "Found ${#files[@]} source files"
 CFLAGS="$(python-config --cflags) $CFLAGS \
   -shared -fPIC"
 CYTHON_DIRECTIVES="overflowcheck=True,embedsignature=True"
+CYTHON_PROFILE_MODE=${CYTHON_ENABLE_PROFILING:-0}
 
-if [[ ${CYTHON_ENABLE_PROFILING:-0} == 1 ]]; then
+if [[ $CYTHON_PROFILE_MODE == 1 ]]; then
   CFLAGS="$CFLAGS \
     -DCYTHON_PROFILE=1 \
     -DCYTHON_USE_SYS_MONITORING=0"
@@ -47,6 +48,7 @@ fi
 
 export CFLAGS
 export CYTHON_DIRECTIVES
+export CYTHON_PROFILE_MODE
 
 LDFLAGS="$(python-config --ldflags) $LDFLAGS"
 export LDFLAGS
@@ -60,11 +62,13 @@ process_file() {
   module_name="${module_name//\//.}" # Replace '/' with '.'
   c_file="${pyfile%.py}.c"
   so_file="${pyfile%.py}$_SUFFIX"
+  mode_stamp="${so_file}.profile-${CYTHON_PROFILE_MODE}"
 
-  # Skip unchanged files
-  if [[ $so_file -nt $pyfile ]]; then
+  if [[ $so_file -nt $pyfile && -f $mode_stamp ]]; then
     return 0
   fi
+
+  rm -f "${so_file}".profile-*
 
   (
     set -x
@@ -80,6 +84,8 @@ process_file() {
     set -x
     $CC $CFLAGS "$c_file" -o "$so_file" $LDFLAGS
   )
+
+  touch "$mode_stamp"
 }
 export -f process_file
 

--- a/shellscripts/cython-build.sh
+++ b/shellscripts/cython-build.sh
@@ -35,10 +35,18 @@ done
 echo "Found ${#files[@]} source files"
 
 CFLAGS="$(python-config --cflags) $CFLAGS \
-  -shared -fPIC \
-  -DCYTHON_PROFILE=1 \
-  -DCYTHON_USE_SYS_MONITORING=0"
+  -shared -fPIC"
+CYTHON_DIRECTIVES="overflowcheck=True,embedsignature=True"
+
+if [[ ${CYTHON_ENABLE_PROFILING:-0} == 1 ]]; then
+  CFLAGS="$CFLAGS \
+    -DCYTHON_PROFILE=1 \
+    -DCYTHON_USE_SYS_MONITORING=0"
+  CYTHON_DIRECTIVES="$CYTHON_DIRECTIVES,profile=True"
+fi
+
 export CFLAGS
+export CYTHON_DIRECTIVES
 
 LDFLAGS="$(python-config --ldflags) $LDFLAGS"
 export LDFLAGS
@@ -62,7 +70,7 @@ process_file() {
     set -x
     cython -3 \
       --annotate \
-      --directive overflowcheck=True,embedsignature=True,profile=True \
+      --directive "$CYTHON_DIRECTIVES" \
       --module-name "$module_name" \
       "$pyfile" -o "$c_file"
   )

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -29,6 +29,21 @@ if [[ $with_coverage == 1 ]]; then
     set -x
     python -m coverage run -m pytest "${args[@]}"
   )
+elif [[ ${RUN_TESTS_FAST_EXIT:-0} == 1 ]]; then
+  (
+    set -x
+    python - "${args[@]}" <<'PY'
+import os
+import sys
+
+import pytest
+
+result = pytest.main(sys.argv[1:])
+sys.stdout.flush()
+sys.stderr.flush()
+os._exit(result)
+PY
+  )
 else
   (
     set -x

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -5,6 +5,7 @@ if [[ ! -S $PC_SOCKET_PATH ]]; then
 fi
 
 term_output=0
+with_coverage=${RUN_TESTS_WITH_COVERAGE:-1}
 args=(
   --verbose
   --no-header
@@ -23,17 +24,26 @@ for arg in "$@"; do
 done
 
 set +e
-(
-  set -x
-  python -m coverage run -m pytest "${args[@]}"
-)
+if [[ $with_coverage == 1 ]]; then
+  (
+    set -x
+    python -m coverage run -m pytest "${args[@]}"
+  )
+else
+  (
+    set -x
+    python -m pytest "${args[@]}"
+  )
+fi
 result=$?
 set -e
 
-if [[ $term_output == 1 ]]; then
-  python -m coverage report --skip-covered
-else
-  python -m coverage xml --quiet
+if [[ $with_coverage == 1 ]]; then
+  if [[ $term_output == 1 ]]; then
+    python -m coverage report --skip-covered
+  else
+    python -m coverage xml --quiet
+  fi
+  python -m coverage erase
 fi
-python -m coverage erase
 exit "$result"


### PR DESCRIPTION
## Summary
- Make Cython profiling hooks opt-in with `CYTHON_ENABLE_PROFILING=1`.
- Add `RUN_TESTS_WITH_COVERAGE=0` for the Cython matrix leg only.
- Add a Cython-only fast-exit test path that returns `pytest.main(...)` after flushing output, avoiding Python finalization.
- Keep coverage and normal interpreter shutdown enabled for the Python matrix jobs.

## Why
The Ubuntu Cython job reaches a passing pytest result, then aborts during Python shutdown with exit code 134. The same failure pattern appears on `main` and on unrelated PR branches, so this looks like CI/runtime finalization rather than an app test failure.

PR iteration notes:
- Removing Cython `profile=True`/`CYTHON_PROFILE` alone still failed with the same shutdown abort.
- Running Cython pytest without coverage still produced `606 passed` and then the same finalization abort.
- The current version preserves pytest's return code and avoids only the failing Cython interpreter teardown path.

## Validation
- `tr -d '\r' < shellscripts/cython-build.sh | bash -n`
- `tr -d '\r' < shellscripts/run-tests.sh | bash -n`
- `git diff --check`

I could not run the full Nix-backed test suite locally from this Windows checkout, so the PR CI is the main validation for the Ubuntu Cython job.