### PR TITLE
Add founders route shield assets

### DIFF
--- a/resources/founders-route-shield.svg
+++ b/resources/founders-route-shield.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">OpenStreetMap-NG Founders route shield badge</title>
+  <desc id="desc">A green folded-map shield with the NG mark, a gold route line, and a Founders ribbon.</desc>
+  <defs>
+    <linearGradient id="map" x1="96" x2="416" y1="80" y2="432" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#dff4bd"/>
+      <stop offset="0.48" stop-color="#b9e69d"/>
+      <stop offset="1" stop-color="#8fd184"/>
+    </linearGradient>
+    <linearGradient id="gold" x1="128" x2="384" y1="104" y2="432" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fff1a7"/>
+      <stop offset="0.5" stop-color="#d7a936"/>
+      <stop offset="1" stop-color="#93691b"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="150%">
+      <feDropShadow dx="0" dy="12" stdDeviation="12" flood-color="#000" flood-opacity="0.28"/>
+    </filter>
+    <clipPath id="shield-clip">
+      <path d="M256 34 424 101l-26 213c-11 87-69 137-142 165-73-28-131-78-142-165L88 101Z"/>
+    </clipPath>
+  </defs>
+
+  <path fill="#102016" d="M256 20 446 96l-29 224c-14 105-88 159-161 186-73-27-147-81-161-186L66 96Z" filter="url(#shadow)"/>
+  <path fill="url(#gold)" d="M256 31 430 101l-27 216c-12 91-75 143-147 170-72-27-135-79-147-170L82 101Z"/>
+  <path fill="#102016" d="M256 54 405 113l-24 196c-10 77-62 121-125 145-63-24-115-68-125-145l-24-196Z"/>
+
+  <g clip-path="url(#shield-clip)">
+    <path fill="url(#map)" d="M107 74h298l43 283-192 111L64 357Z"/>
+    <path fill="#cceea8" d="m91 121 126-40 67 73-53 72-122 7Z" opacity="0.85"/>
+    <path fill="#a6dc8b" d="m272 86 163 42-15 114-101-34-72 29-31-85Z" opacity="0.75"/>
+    <path fill="#d7f2b6" d="m82 263 149-37 76 69-23 145-159-64Z" opacity="0.72"/>
+    <path fill="#93ce82" d="m310 278 126-29 22 99-107 70-74-25Z" opacity="0.7"/>
+    <path fill="none" stroke="#86a66d" stroke-width="5" d="M86 180c54 12 84-42 140-18 45 20 63 65 115 44 35-14 58-1 91 22" opacity="0.42"/>
+    <path fill="none" stroke="#9e6b63" stroke-width="5" d="m101 251 84 36 30 78 74 18 39-57 93 13" opacity="0.5"/>
+    <path fill="none" stroke="#80a9d8" stroke-width="7" d="M77 350c70-20 126-74 196-70 66 4 107 61 179 50" opacity="0.5"/>
+  </g>
+
+  <path fill="none" stroke="#0b1a11" stroke-linecap="round" stroke-linejoin="round" stroke-width="18" d="m151 340 74-81 57 34 86-118"/>
+  <path fill="none" stroke="url(#gold)" stroke-linecap="round" stroke-linejoin="round" stroke-width="10" d="m151 340 74-81 57 34 86-118"/>
+  <g fill="#fff8d6" stroke="#0b1a11" stroke-width="7">
+    <circle cx="151" cy="340" r="16"/>
+    <circle cx="225" cy="259" r="14"/>
+    <circle cx="282" cy="293" r="14"/>
+    <circle cx="368" cy="175" r="16"/>
+  </g>
+  <path fill="url(#gold)" stroke="#0b1a11" stroke-width="8" stroke-linejoin="round" d="m368 118 14 32 35 3-27 23 8 34-30-18-30 18 8-34-27-23 35-3Z"/>
+
+  <text x="256" y="277" text-anchor="middle" font-family="Arial Black, Arial, sans-serif" font-size="148" font-weight="900" fill="#fff" stroke="#0b0b0b" stroke-linejoin="round" stroke-width="12">NG</text>
+  <path fill="#0f2419" stroke="url(#gold)" stroke-width="7" d="M102 354h308l-25 70H127Z"/>
+  <text x="256" y="401" text-anchor="middle" font-family="Arial, sans-serif" font-size="39" font-weight="800" letter-spacing="3.2" fill="#fff7d7">FOUNDERS</text>
+</svg>

--- a/resources/founders-route-wordmark-dark.svg
+++ b/resources/founders-route-wordmark-dark.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 320" role="img" aria-labelledby="title desc">
+  <title id="title">OpenStreetMap-NG Founders route wordmark dark</title>
+  <desc id="desc">A dark horizontal wordmark pairing the Founders route shield with OpenStreetMap-NG Founders text.</desc>
+  <defs>
+    <linearGradient id="map" x1="42" x2="246" y1="37" y2="283" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#dff4bd"/>
+      <stop offset="0.48" stop-color="#b9e69d"/>
+      <stop offset="1" stop-color="#8fd184"/>
+    </linearGradient>
+    <linearGradient id="gold" x1="40" x2="246" y1="36" y2="288" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fff1a7"/>
+      <stop offset="0.5" stop-color="#d7a936"/>
+      <stop offset="1" stop-color="#93691b"/>
+    </linearGradient>
+    <clipPath id="shield-clip">
+      <path d="M144 20 252 63l-17 136c-8 58-46 91-91 109-45-18-83-51-91-109L36 63Z"/>
+    </clipPath>
+  </defs>
+
+  <rect width="960" height="320" rx="42" fill="#0f1c16"/>
+  <path fill="url(#gold)" d="M144 16 262 63l-18 142c-9 66-53 101-100 119-47-18-91-53-100-119L26 63Z"/>
+  <path fill="#102016" d="M144 31 245 70l-16 130c-7 51-41 81-85 98-44-17-78-47-85-98L43 70Z"/>
+  <g clip-path="url(#shield-clip)">
+    <path fill="url(#map)" d="M43 42h202l29 185-130 73L14 227Z"/>
+    <path fill="#cceea8" d="m32 75 86-24 45 44-36 46-83 5Z" opacity="0.85"/>
+    <path fill="#a6dc8b" d="m154 54 111 27-10 74-69-22-49 19-21-55Z" opacity="0.75"/>
+    <path fill="#d7f2b6" d="m26 168 101-24 52 45-16 94-108-42Z" opacity="0.72"/>
+    <path fill="none" stroke="#80a9d8" stroke-width="5" d="M22 223c47-13 84-48 132-45 45 2 73 39 122 32" opacity="0.5"/>
+  </g>
+  <path fill="none" stroke="#0b1a11" stroke-linecap="round" stroke-linejoin="round" stroke-width="11" d="m74 216 48-52 37 22 55-76"/>
+  <path fill="none" stroke="url(#gold)" stroke-linecap="round" stroke-linejoin="round" stroke-width="6" d="m74 216 48-52 37 22 55-76"/>
+  <text x="144" y="178" text-anchor="middle" font-family="Arial Black, Arial, sans-serif" font-size="82" font-weight="900" fill="#fff" stroke="#0b0b0b" stroke-linejoin="round" stroke-width="7">NG</text>
+  <text x="318" y="134" font-family="Arial Black, Arial, sans-serif" font-size="56" font-weight="900" fill="#f6f7ef">OpenStreetMap-NG</text>
+  <text x="319" y="199" font-family="Arial, sans-serif" font-size="64" font-weight="800" letter-spacing="1.5" fill="#efc75e">Founders</text>
+  <path fill="#efc75e" d="M322 223h438v8H322Z"/>
+  <text x="322" y="269" font-family="Arial, sans-serif" font-size="26" font-weight="700" letter-spacing="2.8" fill="#b8d2a8">EARLY CONTRIBUTORS ROUTE MARK</text>
+</svg>

--- a/resources/founders-route-wordmark.svg
+++ b/resources/founders-route-wordmark.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 320" role="img" aria-labelledby="title desc">
+  <title id="title">OpenStreetMap-NG Founders route wordmark</title>
+  <desc id="desc">A horizontal wordmark pairing the Founders route shield with OpenStreetMap-NG Founders text.</desc>
+  <defs>
+    <linearGradient id="map" x1="42" x2="246" y1="37" y2="283" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#dff4bd"/>
+      <stop offset="0.48" stop-color="#b9e69d"/>
+      <stop offset="1" stop-color="#8fd184"/>
+    </linearGradient>
+    <linearGradient id="gold" x1="40" x2="246" y1="36" y2="288" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fff1a7"/>
+      <stop offset="0.5" stop-color="#d7a936"/>
+      <stop offset="1" stop-color="#93691b"/>
+    </linearGradient>
+    <clipPath id="shield-clip">
+      <path d="M144 20 252 63l-17 136c-8 58-46 91-91 109-45-18-83-51-91-109L36 63Z"/>
+    </clipPath>
+  </defs>
+
+  <rect width="960" height="320" rx="42" fill="#f8fbf4"/>
+  <path fill="url(#gold)" d="M144 16 262 63l-18 142c-9 66-53 101-100 119-47-18-91-53-100-119L26 63Z"/>
+  <path fill="#102016" d="M144 31 245 70l-16 130c-7 51-41 81-85 98-44-17-78-47-85-98L43 70Z"/>
+  <g clip-path="url(#shield-clip)">
+    <path fill="url(#map)" d="M43 42h202l29 185-130 73L14 227Z"/>
+    <path fill="#cceea8" d="m32 75 86-24 45 44-36 46-83 5Z" opacity="0.85"/>
+    <path fill="#a6dc8b" d="m154 54 111 27-10 74-69-22-49 19-21-55Z" opacity="0.75"/>
+    <path fill="#d7f2b6" d="m26 168 101-24 52 45-16 94-108-42Z" opacity="0.72"/>
+    <path fill="none" stroke="#80a9d8" stroke-width="5" d="M22 223c47-13 84-48 132-45 45 2 73 39 122 32" opacity="0.5"/>
+  </g>
+  <path fill="none" stroke="#0b1a11" stroke-linecap="round" stroke-linejoin="round" stroke-width="11" d="m74 216 48-52 37 22 55-76"/>
+  <path fill="none" stroke="url(#gold)" stroke-linecap="round" stroke-linejoin="round" stroke-width="6" d="m74 216 48-52 37 22 55-76"/>
+  <text x="144" y="178" text-anchor="middle" font-family="Arial Black, Arial, sans-serif" font-size="82" font-weight="900" fill="#fff" stroke="#0b0b0b" stroke-linejoin="round" stroke-width="7">NG</text>
+  <text x="318" y="134" font-family="Arial Black, Arial, sans-serif" font-size="56" font-weight="900" fill="#142016">OpenStreetMap-NG</text>
+  <text x="319" y="199" font-family="Arial, sans-serif" font-size="64" font-weight="800" letter-spacing="1.5" fill="#a6781d">Founders</text>
+  <path fill="#a6781d" d="M322 223h438v8H322Z"/>
+  <text x="322" y="269" font-family="Arial, sans-serif" font-size="26" font-weight="700" letter-spacing="2.8" fill="#466047">EARLY CONTRIBUTORS ROUTE MARK</text>
+</svg>


### PR DESCRIPTION
## Summary
- add a distinct route-shield direction for the OpenStreetMap-NG Founders logo
- keep the design grounded in the existing folded-map + NG visual language
- include badge, light wordmark, and dark wordmark SVG variants for review

For #114.

## Previews

| Badge | Light wordmark | Dark wordmark |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/alexgduarte/openstreetmap-ng/codex/founders-route-shield/resources/founders-route-shield.svg" width="180" alt="Founders route shield badge"> | <img src="https://raw.githubusercontent.com/alexgduarte/openstreetmap-ng/codex/founders-route-shield/resources/founders-route-wordmark.svg" width="320" alt="Founders route wordmark"> | <img src="https://raw.githubusercontent.com/alexgduarte/openstreetmap-ng/codex/founders-route-shield/resources/founders-route-wordmark-dark.svg" width="320" alt="Founders route wordmark dark"> |

## Validation
- XML parsed all three SVG files with Python ElementTree
- Quick Look generated thumbnails for all three SVG files
- git diff --check

If this direction is selected for the listed bounty, payout can be coordinated through the project-supported methods after acceptance; no payment details are included in the repository.