### PR TITLE
Compress trace uploads after response path

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -60,6 +60,7 @@ from app.services.email_service import EmailService
 from app.services.image_proxy_service import ImageProxyService
 from app.services.system_app_service import SystemAppService
 from app.services.test_service import TestService
+from app.services.trace_upload_compression import TraceUploadCompressionService
 
 
 # HACK: Execute sync functions directly without threadpool
@@ -111,6 +112,7 @@ async def lifespan(_):
             EmailService.context(),
             ChangesetService.context(),
             ElementSpatialService.context(),
+            TraceUploadCompressionService.context(),
         ):
             # freeze uncollected gc objects for improved performance
             gc.collect()

--- a/app/services/trace_service.py
+++ b/app/services/trace_service.py
@@ -1,4 +1,5 @@
 import logging
+from asyncio import get_running_loop
 from typing import Any
 
 from fastapi import UploadFile
@@ -23,6 +24,7 @@ from app.models.db.trace import (
 from app.models.proto.trace_types import Visibility
 from app.models.types import StorageKey, TraceId
 from app.queries.trace_query import TraceQuery
+from app.services.trace_upload_compression import compress_trace_upload
 
 
 class TraceService:
@@ -78,12 +80,10 @@ class TraceService:
         }
         trace_init = TraceInitValidator.validate_python(trace_init)
 
-        # Save the compressed file after validation to avoid unnecessary work
-        result = await TraceFile.compress(file)
-        trace_init['file_id'] = await TRACE_STORAGE.save(
-            result.data, result.suffix, result.metadata
-        )
-        logging.debug('Saved compressed trace file %r', trace_init['file_id'])
+        # Save the file after validation to avoid unnecessary work. Compression is
+        # scheduled after the trace row is created to keep uploads responsive.
+        trace_init['file_id'] = await TRACE_STORAGE.save(file, '')
+        logging.debug('Saved trace file %r', trace_init['file_id'])
 
         try:
             # Insert into database
@@ -110,6 +110,10 @@ class TraceService:
                         'tags': trace_init['tags'],
                         'visibility': trace_init['visibility'],
                     },
+                )
+
+                get_running_loop().create_task(  # noqa: RUF006
+                    compress_trace_upload(trace_id, trace_init['file_id'], file)
                 )
                 return trace_id
 

--- a/app/services/trace_service.py
+++ b/app/services/trace_service.py
@@ -1,5 +1,4 @@
 import logging
-from asyncio import get_running_loop
 from typing import Any
 
 from fastapi import UploadFile
@@ -24,7 +23,7 @@ from app.models.db.trace import (
 from app.models.proto.trace_types import Visibility
 from app.models.types import StorageKey, TraceId
 from app.queries.trace_query import TraceQuery
-from app.services.trace_upload_compression import compress_trace_upload
+from app.services.trace_upload_compression import TraceUploadCompressionService
 
 
 class TraceService:
@@ -112,8 +111,10 @@ class TraceService:
                     },
                 )
 
-                get_running_loop().create_task(  # noqa: RUF006
-                    compress_trace_upload(trace_id, trace_init['file_id'], file)
+                TraceUploadCompressionService.schedule(
+                    trace_id,
+                    trace_init['file_id'],
+                    file,
                 )
                 return trace_id
 

--- a/app/services/trace_upload_compression.py
+++ b/app/services/trace_upload_compression.py
@@ -1,0 +1,47 @@
+import logging
+
+from sentry_sdk import capture_exception
+
+from app.db import db_update
+from app.lib.io.trace_file import TraceFile
+from app.lib.storage import TRACE_STORAGE
+from app.models.types import StorageKey, TraceId
+
+
+async def compress_trace_upload(
+    trace_id: TraceId,
+    old_file_id: StorageKey,
+    file: bytes,
+):
+    """Compress a trace upload and atomically replace the stored file reference."""
+    compressed_file_id: StorageKey | None = None
+    try:
+        result = await TraceFile.compress(file)
+        compressed_file_id = await TRACE_STORAGE.save(
+            result.data, result.suffix, result.metadata
+        )
+        logging.debug('Saved compressed trace file %r', compressed_file_id)
+
+        rowcount = await db_update(
+            'trace',
+            {'file_id': compressed_file_id},
+            where={'id': trace_id, 'file_id': old_file_id},
+        )
+
+        if rowcount:
+            await TRACE_STORAGE.delete(old_file_id)
+        else:
+            await TRACE_STORAGE.delete(compressed_file_id)
+
+    except Exception as e:
+        logging.exception('Failed to compress trace file %r', old_file_id)
+        capture_exception(e)
+        if compressed_file_id is not None:
+            try:
+                await TRACE_STORAGE.delete(compressed_file_id)
+            except Exception as cleanup_error:
+                logging.exception(
+                    'Failed to clean up compressed trace file %r',
+                    compressed_file_id,
+                )
+                capture_exception(cleanup_error)

--- a/app/services/trace_upload_compression.py
+++ b/app/services/trace_upload_compression.py
@@ -1,6 +1,6 @@
 import logging
 from asyncio import TaskGroup, get_running_loop
-from contextlib import asynccontextmanager
+from types import TracebackType
 
 from sentry_sdk import capture_exception
 
@@ -12,17 +12,36 @@ from app.models.types import StorageKey, TraceId
 _COMPRESSION_TG: TaskGroup | None = None
 
 
+class _CompressionContext:
+    def __init__(self):
+        self._tg = TaskGroup()
+
+    async def __aenter__(self):
+        global _COMPRESSION_TG
+        await self._tg.__aenter__()
+        _COMPRESSION_TG = self._tg
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ):
+        global _COMPRESSION_TG
+        try:
+            for task in self._tg._tasks:  # noqa: SLF001
+                task.cancel()
+            return await self._tg.__aexit__(exc_type, exc, tb)
+        finally:
+            _COMPRESSION_TG = None
+
+
 class TraceUploadCompressionService:
     @staticmethod
-    @asynccontextmanager
-    async def context():
+    def context():
         """Context manager for trace upload compression tasks."""
-        global _COMPRESSION_TG
-        async with (_COMPRESSION_TG := TaskGroup()):  # pyright: ignore[reportConstantRedefinition]
-            yield
-            for task in _COMPRESSION_TG._tasks:  # noqa: SLF001
-                task.cancel()
-        _COMPRESSION_TG = None
+        return _CompressionContext()
 
     @staticmethod
     def schedule(trace_id: TraceId, old_file_id: StorageKey, file: bytes):

--- a/app/services/trace_upload_compression.py
+++ b/app/services/trace_upload_compression.py
@@ -1,4 +1,6 @@
 import logging
+from asyncio import TaskGroup, get_running_loop
+from contextlib import asynccontextmanager
 
 from sentry_sdk import capture_exception
 
@@ -6,6 +8,32 @@ from app.db import db_update
 from app.lib.io.trace_file import TraceFile
 from app.lib.storage import TRACE_STORAGE
 from app.models.types import StorageKey, TraceId
+
+_COMPRESSION_TG: TaskGroup | None = None
+
+
+class TraceUploadCompressionService:
+    @staticmethod
+    @asynccontextmanager
+    async def context():
+        """Context manager for trace upload compression tasks."""
+        global _COMPRESSION_TG
+        async with (_COMPRESSION_TG := TaskGroup()):  # pyright: ignore[reportConstantRedefinition]
+            yield
+            for task in _COMPRESSION_TG._tasks:  # noqa: SLF001
+                task.cancel()
+        _COMPRESSION_TG = None
+
+    @staticmethod
+    def schedule(trace_id: TraceId, old_file_id: StorageKey, file: bytes):
+        """Schedule trace upload compression without blocking the response."""
+        if _COMPRESSION_TG is None:
+            get_running_loop().create_task(  # noqa: RUF006
+                compress_trace_upload(trace_id, old_file_id, file)
+            )
+            return
+
+        _COMPRESSION_TG.create_task(compress_trace_upload(trace_id, old_file_id, file))
 
 
 async def compress_trace_upload(

--- a/tests/services/test_trace_service.py
+++ b/tests/services/test_trace_service.py
@@ -1,0 +1,91 @@
+from types import SimpleNamespace
+
+from app.models.types import StorageKey, TraceId
+from app.services import trace_upload_compression
+
+
+async def test_compress_trace_upload_swaps_file_reference(monkeypatch):
+    saved: list[tuple[bytes, str, dict[str, str] | None]] = []
+    deleted: list[StorageKey] = []
+    updates: list[tuple[str, dict, dict]] = []
+
+    class Storage:
+        async def save(
+            self,
+            data: bytes,
+            suffix: str,
+            metadata: dict[str, str] | None = None,
+        ):
+            saved.append((data, suffix, metadata))
+            return StorageKey(f'compressed{suffix}')
+
+        async def delete(self, key: StorageKey):
+            deleted.append(key)
+
+    async def compress(file: bytes):
+        assert file == b'original'
+        return SimpleNamespace(
+            data=b'compressed',
+            suffix='.zst',
+            metadata={'zstd_level': '22'},
+        )
+
+    async def db_update(table: str, values: dict, where: dict):
+        updates.append((table, values, where))
+        return 1
+
+    monkeypatch.setattr(trace_upload_compression.TraceFile, 'compress', compress)
+    monkeypatch.setattr(trace_upload_compression, 'TRACE_STORAGE', Storage())
+    monkeypatch.setattr(trace_upload_compression, 'db_update', db_update)
+
+    await trace_upload_compression.compress_trace_upload(
+        TraceId(1),
+        StorageKey('original'),
+        b'original',
+    )
+
+    assert saved == [(b'compressed', '.zst', {'zstd_level': '22'})]
+    assert updates == [
+        (
+            'trace',
+            {'file_id': StorageKey('compressed.zst')},
+            {'id': TraceId(1), 'file_id': StorageKey('original')},
+        )
+    ]
+    assert deleted == [StorageKey('original')]
+
+
+async def test_compress_trace_upload_deletes_compressed_file_if_trace_changed(
+    monkeypatch,
+):
+    deleted: list[StorageKey] = []
+
+    class Storage:
+        async def save(
+            self,
+            data: bytes,
+            suffix: str,
+            metadata: dict[str, str] | None = None,
+        ):
+            return StorageKey(f'compressed{suffix}')
+
+        async def delete(self, key: StorageKey):
+            deleted.append(key)
+
+    async def compress(_: bytes):
+        return SimpleNamespace(data=b'compressed', suffix='.zst', metadata={})
+
+    async def db_update(table: str, values: dict, where: dict):
+        return 0
+
+    monkeypatch.setattr(trace_upload_compression.TraceFile, 'compress', compress)
+    monkeypatch.setattr(trace_upload_compression, 'TRACE_STORAGE', Storage())
+    monkeypatch.setattr(trace_upload_compression, 'db_update', db_update)
+
+    await trace_upload_compression.compress_trace_upload(
+        TraceId(1),
+        StorageKey('original'),
+        b'original',
+    )
+
+    assert deleted == [StorageKey('compressed.zst')]


### PR DESCRIPTION
Fixes #100

This keeps trace upload validation and row creation on the request path, but moves the expensive zstd recompression/storage swap into a background task after the trace row is inserted.

Changes:
- Save the validated original trace file immediately so upload can return without waiting on zstd level-22 compression.
- Schedule a background compression task after the trace row is created.
- Store the compressed file, atomically swap `trace.file_id` only if it still points to the original upload, then delete the superseded file.
- Delete the newly-compressed file if the trace was changed/deleted before the background task completes.
- Add focused tests for the successful swap and stale-row cleanup paths.

Verification:
- `pytest --confcutdir=tests/services tests/services/test_trace_service.py` -> 2 passed
- `pytest --confcutdir=tests/lib tests/lib/test_trace_file.py` -> 1 passed

Local setup notes:
- The fresh clone needed generated protobuf/locale assets before imports would work locally.
- Homebrew `protoc` generated newer Python protobuf stubs than the repo-pinned runtime, so I ran the focused tests with the local venv protobuf runtime bumped only for verification. No generated files or dependency metadata are included in this PR.

/claim #100
