### PR TITLE
feat: implement edit_help=1 tutorial tooltip

### DIFF
--- a/app/views/navbar/navbar-left.tsx
+++ b/app/views/navbar/navbar-left.tsx
@@ -2,6 +2,7 @@ import { RemoteEditButton } from "@index/remote-edit"
 import { routerRemoteEditTarget } from "@index/router"
 import { useSignalEffect } from "@preact/signals"
 import { assertNever } from "@std/assert/unstable-never"
+import { isLoggedIn } from "@utils/config"
 import { useDisposeEffect } from "@utils/dispose-scope"
 import { type Editor, preferredEditorStorage } from "@utils/local-storage"
 import { qsEncode } from "@utils/query-string"
@@ -105,6 +106,41 @@ const NavbarLeft = () => {
       tooltip.hide()
     }
   })
+
+  // Effect: show edit_help tooltip when edit_help=1 query param is present
+  useEffect(() => {
+    if (!isLoggedIn) return
+
+    const params = new URLSearchParams(window.location.search)
+    if (params.get("edit_help") !== "1") return
+
+    const editLink = dropdownRootRef.current?.querySelector<HTMLElement>(".edit-link.default")
+    if (!editLink || editDisabled.value) return
+
+    const editHelpTooltip = new Tooltip(editLink, {
+      title: t("javascripts.site.edit_help"),
+      placement: "bottom",
+    })
+    editHelpTooltip.show()
+
+    const onClick = () => {
+      editHelpTooltip.hide()
+      editHelpTooltip.dispose()
+
+      // Remove edit_help from URL without page reload
+      params.delete("edit_help")
+      const newSearch = params.toString()
+      const newUrl = `${window.location.pathname}${newSearch ? "?" + newSearch : ""}${window.location.hash}`
+      window.history.replaceState(null, "", newUrl)
+    }
+
+    document.body.addEventListener("click", onClick, { once: true })
+
+    return () => {
+      document.body.removeEventListener("click", onClick)
+      editHelpTooltip.dispose()
+    }
+  }, [])
 
   const onSelectEditor = (editor: Editor) => {
     if (rememberChoiceRef.current!.checked) {

--- a/config/locale/download/en.yaml
+++ b/config/locale/download/en.yaml
@@ -3267,10 +3267,12 @@ en:
       tracestrack: Tracestrack
       hotosm_credit: Tiles style by %{hotosm_link} hosted by %{osm_france_link}
       hotosm_name: Humanitarian OpenStreetMap Team
-    site:
-      edit_tooltip: Edit the map
-      edit_disabled_tooltip: Zoom in to edit the map
-      createnote_tooltip: Add a note to the map
+ site:
+ edit_tooltip: Edit the map
+ edit_disabled_tooltip: Zoom in to edit the map
+ edit_help: Move the map and zoom in on a location you want to edit, then click
+ here.
+ createnote_tooltip: Add a note to the map
       createnote_disabled_tooltip: Zoom in to add a note to the map
       map_notes_zoom_in_tooltip: Zoom in to see map notes
       map_data_zoom_in_tooltip: Zoom in to see map data
@@ -3282,11 +3284,9 @@ en:
         comment: Comment
         subscribe: Subscribe
         unsubscribe: Unsubscribe
-        hide_comment: hide
-        unhide_comment: unhide
-    edit_help: Move the map and zoom in on a location you want to edit, then click
-      here.
-    directions:
+ hide_comment: hide
+ unhide_comment: unhide
+ directions:
       ascend: Ascend
       engines:
         fossgis_osrm_bike: Bicycle (OSRM)


### PR DESCRIPTION
## Summary

Implements the edit_help=1 tutorial feature matching the original OpenStreetMap website behavior.

### How it works
When a logged-in user navigates to `/?edit_help=1`:
1. A Bootstrap tooltip appears on the **Edit** button with the message: _"Move the map and zoom in on a location you want to edit, then click here."_
2. Clicking anywhere on the page dismisses the tooltip
3. The `edit_help` query parameter is removed from the URL without page reload (via `history.replaceState`)

### Changes
- Add `edit_help` tooltip effect in `NavbarLeft` component (`navbar-left.tsx`)
- Only activates for logged-in users (checks `isLoggedIn`)
- Does not show when edit is disabled (map not zoomed in enough)
- Move `edit_help` i18n key from `changesets.show.edit_help` to `site.edit_help` (correct path matching `javascripts.site.edit_help`)
- Cleanup on component unmount

### Behavior matches original
This replicates the behavior from the [original OSM website](https://github.com/openstreetmap/openstreetmap-website/blob/master/app/assets/javascripts/index.js#L258):
- Shows tooltip on the edit anchor element
- Placement: bottom
- Dismisses on body click
- Removes query param after dismiss

Closes #28