### PR TITLE
feat: group untagged node members separately

### DIFF
--- a/app/format/element_list.py
+++ b/app/format/element_list.py
@@ -78,9 +78,9 @@ class FormatElementList:
         if not members:
             return []
 
-        type_id_map: dict[TypedElementId, tuple[str | None, FeatureIcon | None]]
+        type_id_map: dict[TypedElementId, tuple[str | None, FeatureIcon | None, bool]]
         type_id_map = {
-            element['typed_id']: (name, icon)
+            element['typed_id']: (name, icon, not (element['tags'] or {}))
             for element, name, icon in zip(
                 members_elements,
                 features_names(members_elements),
@@ -159,7 +159,7 @@ def _encode_parents(
 
 @cython.cfunc
 def _encode_members(
-    type_id_map: dict[TypedElementId, tuple[str | None, FeatureIcon | None]],
+    type_id_map: dict[TypedElementId, tuple[str | None, FeatureIcon | None, bool]],
     members: list[TypedElementId],
     members_roles: list[str] | list[None] | None,
 ):
@@ -170,7 +170,7 @@ def _encode_members(
     for member, role in zip(members, members_roles):
         type, id = split_typed_element_id(member)
         data = type_id_map.get(member)
-        name, feature_icon = data or (None, None)
+        name, feature_icon, untagged = data or (None, None, False)
         icon = (
             ElementIcon(icon=feature_icon.filename, title=feature_icon.title)
             if feature_icon is not None
@@ -182,6 +182,7 @@ def _encode_members(
                 roles=(role,) if role is not None else None,
                 name=name,
                 icon=icon,
+                untagged=untagged and type == 'node',
             )
         )
     return result

--- a/app/models/proto/element.proto
+++ b/app/models/proto/element.proto
@@ -59,6 +59,7 @@ message Data {
       repeated string roles = 2;
       optional string name = 3;
       optional ElementIcon icon = 4;
+      bool untagged = 5;
     }
 
     repeated Entry members = 1;

--- a/app/views/index/element.tsx
+++ b/app/views/index/element.tsx
@@ -333,6 +333,8 @@ const ElementSidebar = ({
     >
       {(d) => {
         const { parents, members } = d.context
+        const taggedMembers = members.filter((member) => !member.untagged)
+        const untaggedNodeMembers = members.filter((member) => member.untagged)
         const hasRelations = parents.length > 0 || members.length > 0
 
         return (
@@ -364,14 +366,25 @@ const ElementSidebar = ({
                     keyFn={(el) =>
                       `${el.ref.type}-${el.ref.id}-${el.roles.join("\x1F")}`
                     }
-                    items={members}
+                    items={taggedMembers}
                     title={(count) =>
                       d.ref.type === ElementType.way
-                        ? t("browse.changeset.node", { count })
+                        ? t("element.tagged_nodes", { count })
                         : `${t("browse.relation.members")} (${count})`
                     }
                     renderRow={(el) => <ElementRow element={el} />}
                   />
+                  {d.ref.type === ElementType.way && (
+                    <ElementsSection
+                      keyFn={(el) =>
+                        `${el.ref.type}-${el.ref.id}-${el.roles.join("\x1F")}`
+                      }
+                      items={untaggedNodeMembers}
+                      title={(count) => t("element.untagged_nodes", { count })}
+                      renderRow={(el) => <ElementRow element={el} />}
+                      class="text-muted"
+                    />
+                  )}
                 </div>
               )}
             </div>

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -49,6 +49,8 @@ changesets_history:
 element:
   tags_diff_mode: Tags diff mode
   highlight_changed_tags_between_versions: Highlight changed tags between versions
+  tagged_nodes: Tagged nodes ({{count}})
+  untagged_nodes: Untagged nodes ({{count}})
 note:
   title: Note
   count_one: "note"


### PR DESCRIPTION
## Summary

Separates untagged node members from tagged node members when browsing ways.

### Changes
- Adds an `untagged` marker to element context entries.
- Marks node members with no tags as untagged in the backend formatter.
- Splits way members into “Tagged nodes” and “Untagged nodes” sections in the sidebar.
- Renders the untagged section muted so structural nodes are easier to distinguish.

Closes #17
