### PR TITLE
Add hybrid aerial base layer

### DIFF
--- a/app/views/index/sidebar/layers.tsx
+++ b/app/views/index/sidebar/layers.tsx
@@ -14,6 +14,7 @@ import {
   GPS_LAYER_ID,
   hasMapLayer,
   HOT_LAYER_ID,
+  HYBRID_LAYER_ID,
   type LayerId,
   LIBERTY_LAYER_ID,
   NOTES_LAYER_ID,
@@ -49,6 +50,7 @@ const BASE_LAYERS = new Set([
   TRANSPORTMAP_LAYER_ID,
   TRACESTRACKTOPO_LAYER_ID,
   LIBERTY_LAYER_ID,
+  HYBRID_LAYER_ID,
   HOT_LAYER_ID,
 ])
 
@@ -385,6 +387,12 @@ export const LayersSidebar = ({ close }: { close: () => void }) => {
                 {layerId === LIBERTY_LAYER_ID && (
                   <>
                     {t("map.layers.liberty")}
+                    <span class="vector">{t("map.layers.vector")}</span>
+                  </>
+                )}
+                {layerId === HYBRID_LAYER_ID && (
+                  <>
+                    {t("map.layers.hybrid_aerial")}
                     <span class="vector">{t("map.layers.vector")}</span>
                   </>
                 )}

--- a/app/views/map/layers/layers.ts
+++ b/app/views/map/layers/layers.ts
@@ -31,6 +31,7 @@ export const CYCLEMAP_LAYER_ID = "cyclemap" as LayerId
 export const TRANSPORTMAP_LAYER_ID = "transportmap" as LayerId
 export const TRACESTRACKTOPO_LAYER_ID = "tracestracktopo" as LayerId
 export const HOT_LAYER_ID = "hot" as LayerId
+export const HYBRID_LAYER_ID = "hybrid" as LayerId
 
 const LIBERTY_LAYER_CODE = "L" as LayerCode
 const CYCLOSM_LAYER_CODE = "Y" as LayerCode
@@ -38,6 +39,7 @@ const CYCLEMAP_LAYER_CODE = "C" as LayerCode
 const TRANSPORTMAP_LAYER_CODE = "T" as LayerCode
 const TRACESTRACKTOPO_LAYER_CODE = "P" as LayerCode
 const HOT_LAYER_CODE = "H" as LayerCode
+const HYBRID_LAYER_CODE = "I" as LayerCode
 
 export const AERIAL_LAYER_ID = "aerial" as LayerId
 export const NOTES_LAYER_ID = "notes" as LayerId
@@ -92,6 +94,34 @@ const hotosmCredit = t("javascripts.map.hotosm_credit", {
 // https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/0
 const aerialEsriCredit =
   "Esri, Maxar, Earthstar Geographics, and the GIS User Community"
+
+const hybridVisibleLayerTypes = new Set(["line", "symbol", "circle"])
+
+const hybridLibertyStyle = {
+  ...libertyStyle,
+  sources: {
+    aerial: {
+      type: "raster",
+      maxzoom: 23,
+      tiles: [
+        "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+      ],
+      tileSize: 256,
+      attribution: aerialEsriCredit,
+    },
+    ...libertyStyle.sources,
+  },
+  layers: [
+    {
+      id: "aerial",
+      type: "raster",
+      source: "aerial",
+    },
+    ...libertyStyle.layers.filter((layer) =>
+      hybridVisibleLayerTypes.has(layer.type),
+    ),
+  ],
+} as StyleSpecification
 
 export const emptyFeatureCollection: FeatureCollection = {
   type: "FeatureCollection",
@@ -213,6 +243,13 @@ layersConfig.set(HOT_LAYER_ID, {
   },
   isBaseLayer: true,
   layerCode: HOT_LAYER_CODE,
+})
+
+layersConfig.set(HYBRID_LAYER_ID, {
+  specification: { type: "vector" },
+  vectorStyle: hybridLibertyStyle,
+  isBaseLayer: true,
+  layerCode: HYBRID_LAYER_CODE,
 })
 
 // Overlay layers

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -9,6 +9,7 @@ map:
   zoom_out_to_see_the_world_in_3d: Zoom out to see the world in 3D
   layers:
     esri_world_imagery: Esri World Imagery
+    hybrid_aerial: Hybrid Aerial
     liberty: Liberty
     vector: Vector
   overlays:


### PR DESCRIPTION
Closes #182.

Adds a Hybrid Aerial base layer that uses Esri World Imagery as the raster background and overlays selected Liberty vector layers for roads, labels, POIs, and other map-readable features.

Implementation notes:

- Adds HYBRID_LAYER_ID and HYBRID_LAYER_CODE.
- Reuses the existing Liberty vector style, filtered to line, symbol, and circle layers so polygon fills/backgrounds do not obscure the imagery.
- Adds the new base layer to the Layers sidebar.
- Adds English UI text for the layer label.

Verification:

- Not run locally; the repository could not be cloned reliably in this environment, so the changes were prepared via GitHub API against current main.