### PR TITLE
fix: handle unreadable image uploads | Fixes #31

### DIFF
--- a/app/lib/io/image.py
+++ b/app/lib/io/image.py
@@ -242,7 +242,12 @@ async def _normalize_image(
     - Megapixels: downscale
     - File size: reduce quality
     """
+    try:
     img = open_image(BytesIO(data))
+except (OSError, ValueError) as e:
+    logging.warning('Failed to open uploaded image: %s', e)
+    raise_for.image_unreadable()
+
     ImageOps.exif_transpose(img, in_place=True)
 
     # normalize shape ratio


### PR DESCRIPTION
Fix for #31 — catch corrupted/unreadable image uploads and return a proper error instead of crashing.