### PR TITLE
Add founders waypoint badge assets

### DIFF
--- a/resources/founders-waypoint-badge.svg
+++ b/resources/founders-waypoint-badge.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">OSM-NG Founder waypoint badge</title>
+  <desc id="desc">A square OpenStreetMap-NG Founder badge using a folded map, waypoint pin, and founder ribbon.</desc>
+  <defs>
+    <linearGradient id="bg" x1="76" y1="74" x2="436" y2="438" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#f8fbf3"/>
+      <stop offset="1" stop-color="#d9ecd2"/>
+    </linearGradient>
+    <linearGradient id="mapGreen" x1="154" y1="136" x2="348" y2="358" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#d9f4b7"/>
+      <stop offset="1" stop-color="#7fc15d"/>
+    </linearGradient>
+    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="145%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#122016" flood-opacity=".22"/>
+    </filter>
+  </defs>
+  <rect x="24" y="24" width="464" height="464" rx="72" fill="url(#bg)"/>
+  <rect x="44" y="44" width="424" height="424" rx="56" fill="none" stroke="#253136" stroke-width="16"/>
+
+  <g filter="url(#softShadow)">
+    <path d="M142 130l79 18 69-27 80 20 6 207-74 29-82-22-73 27-6-252z" fill="url(#mapGreen)" stroke="#263237" stroke-width="14" stroke-linejoin="round"/>
+    <path d="M221 148l-1 207M290 121l12 256" fill="none" stroke="#263237" stroke-width="9" stroke-linecap="round" opacity=".55"/>
+    <path d="M159 199c37-16 69-17 101-2 38 18 73 14 103-10M161 271c34-14 67-13 98 2 36 18 71 18 105 0" fill="none" stroke="#ffffff" stroke-width="12" stroke-linecap="round" opacity=".62"/>
+    <path d="M188 236l35-18 48 12 50-25 18 9" fill="none" stroke="#263237" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" opacity=".35"/>
+  </g>
+
+  <g transform="translate(0 2)">
+    <path d="M256 101c-51 0-92 40-92 91 0 68 92 156 92 156s92-88 92-156c0-51-41-91-92-91z" fill="#253136"/>
+    <circle cx="256" cy="192" r="48" fill="#f4ce51"/>
+    <path d="M225 206v-52h17l28 31v-31h20v52h-17l-28-31v31h-20z" fill="#253136"/>
+  </g>
+
+  <g>
+    <path d="M111 349h290l34 39-34 39H111l-34-39 34-39z" fill="#253136"/>
+    <path d="M122 364h268l20 24-20 24H122l-20-24 20-24z" fill="#f4ce51"/>
+    <text x="256" y="400" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="35" font-weight="800" letter-spacing="4" fill="#253136">FOUNDER</text>
+  </g>
+
+  <g fill="#253136">
+    <circle cx="144" cy="102" r="8"/>
+    <circle cx="368" cy="102" r="8"/>
+    <circle cx="256" cy="438" r="8"/>
+  </g>
+</svg>

--- a/resources/founders-waypoint-wordmark-dark.svg
+++ b/resources/founders-waypoint-wordmark-dark.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="320" viewBox="0 0 960 320" role="img" aria-labelledby="title desc">
+  <title id="title">OSM-NG Founder waypoint wordmark dark</title>
+  <desc id="desc">Dark-background OpenStreetMap-NG Founder wordmark with a folded-map waypoint badge.</desc>
+  <defs>
+    <linearGradient id="mapGreen" x1="70" y1="68" x2="210" y2="232" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#d9f4b7"/>
+      <stop offset="1" stop-color="#7fc15d"/>
+    </linearGradient>
+  </defs>
+  <rect width="960" height="320" rx="40" fill="#253136"/>
+  <g transform="translate(42 40)">
+    <rect x="0" y="0" width="240" height="240" rx="38" fill="#f8fbf3" stroke="#f4ce51" stroke-width="12"/>
+    <path d="M62 61l42 10 37-15 44 11 3 105-41 16-45-12-39 15-3-130z" fill="url(#mapGreen)" stroke="#253136" stroke-width="8" stroke-linejoin="round"/>
+    <path d="M104 71v105M141 56l7 132" fill="none" stroke="#253136" stroke-width="5" stroke-linecap="round" opacity=".58"/>
+    <path d="M120 42c-37 0-66 29-66 66 0 49 66 112 66 112s66-63 66-112c0-37-29-66-66-66z" fill="#253136"/>
+    <circle cx="120" cy="108" r="34" fill="#f4ce51"/>
+    <path d="M98 118V82h12l19 21V82h14v36h-12l-19-21v21H98z" fill="#253136"/>
+  </g>
+  <g transform="translate(318 84)">
+    <text x="0" y="58" font-family="Inter, Arial, sans-serif" font-size="46" font-weight="850" letter-spacing="0" fill="#ffffff">OpenStreetMap-NG</text>
+    <text x="2" y="125" font-family="Inter, Arial, sans-serif" font-size="56" font-weight="850" letter-spacing="8" fill="#9de070">FOUNDER</text>
+    <path d="M2 152h402" stroke="#f4ce51" stroke-width="14" stroke-linecap="round"/>
+    <path d="M2 183h301" stroke="#ffffff" stroke-width="8" stroke-linecap="round" opacity=".2"/>
+  </g>
+</svg>

--- a/resources/founders-waypoint-wordmark.svg
+++ b/resources/founders-waypoint-wordmark.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="320" viewBox="0 0 960 320" role="img" aria-labelledby="title desc">
+  <title id="title">OSM-NG Founder waypoint wordmark</title>
+  <desc id="desc">Light-background OpenStreetMap-NG Founder wordmark with a folded-map waypoint badge.</desc>
+  <defs>
+    <linearGradient id="mapGreen" x1="70" y1="68" x2="210" y2="232" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#d9f4b7"/>
+      <stop offset="1" stop-color="#7fc15d"/>
+    </linearGradient>
+  </defs>
+  <rect width="960" height="320" rx="40" fill="#ffffff"/>
+  <g transform="translate(42 40)">
+    <rect x="0" y="0" width="240" height="240" rx="38" fill="#f8fbf3" stroke="#253136" stroke-width="12"/>
+    <path d="M62 61l42 10 37-15 44 11 3 105-41 16-45-12-39 15-3-130z" fill="url(#mapGreen)" stroke="#253136" stroke-width="8" stroke-linejoin="round"/>
+    <path d="M104 71v105M141 56l7 132" fill="none" stroke="#253136" stroke-width="5" stroke-linecap="round" opacity=".58"/>
+    <path d="M120 42c-37 0-66 29-66 66 0 49 66 112 66 112s66-63 66-112c0-37-29-66-66-66z" fill="#253136"/>
+    <circle cx="120" cy="108" r="34" fill="#f4ce51"/>
+    <path d="M98 118V82h12l19 21V82h14v36h-12l-19-21v21H98z" fill="#253136"/>
+  </g>
+  <g transform="translate(318 84)">
+    <text x="0" y="58" font-family="Inter, Arial, sans-serif" font-size="46" font-weight="850" letter-spacing="0" fill="#253136">OpenStreetMap-NG</text>
+    <text x="2" y="125" font-family="Inter, Arial, sans-serif" font-size="56" font-weight="850" letter-spacing="8" fill="#7fc15d">FOUNDER</text>
+    <path d="M2 152h402" stroke="#f4ce51" stroke-width="14" stroke-linecap="round"/>
+    <path d="M2 183h301" stroke="#253136" stroke-width="8" stroke-linecap="round" opacity=".2"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add a distinct Founder waypoint badge direction for the OpenStreetMap-NG contributor incentives badge
- keep the design grounded in the existing folded-map + NG visual language
- include badge, light wordmark, and dark wordmark SVG variants for review

Addresses #114.

## Previews

| Badge | Light wordmark | Dark wordmark |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/innergclaw/openstreetmap-ng/codex/founder-waypoint-badge/resources/founders-waypoint-badge.svg" width="180" alt="Founder waypoint badge"> | <img src="https://raw.githubusercontent.com/innergclaw/openstreetmap-ng/codex/founder-waypoint-badge/resources/founders-waypoint-wordmark.svg" width="320" alt="Founder waypoint wordmark"> | <img src="https://raw.githubusercontent.com/innergclaw/openstreetmap-ng/codex/founder-waypoint-badge/resources/founders-waypoint-wordmark-dark.svg" width="320" alt="Founder waypoint wordmark dark"> |

## Validation
- XML parsed all three SVG files with xmllint
- Quick Look generated thumbnails for all three SVG files
- git diff --check

/claim #114