### PR TITLE
fix: handle oversized avatar uploads more gracefully

### DIFF
--- a/app/lib/io/image.py
+++ b/app/lib/io/image.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Literal, NamedTuple, TypeAlias, overload
 import cython
 from blurhash_rs import blurhash_encode
 from PIL import ImageOps, ImageSequence
+from PIL.Image import DecompressionBombError
 from PIL.Image import Image as PILImage
 from PIL.Image import Resampling
 from PIL.Image import open as open_image
@@ -242,74 +243,77 @@ async def _normalize_image(
     - Megapixels: downscale
     - File size: reduce quality
     """
-    img = open_image(BytesIO(data))
-    ImageOps.exif_transpose(img, in_place=True)
+    try:
+        img = open_image(BytesIO(data))
+        ImageOps.exif_transpose(img, in_place=True)
 
-    # normalize shape ratio
-    img_width: cython.size_t
-    img_height: cython.size_t
-    img_width, img_height = img.size
+        # normalize shape ratio
+        img_width: cython.size_t
+        img_height: cython.size_t
+        img_width, img_height = img.size
 
-    crop_box: tuple[int, int, int, int] | None = None
-    resize_to: tuple[int, int] | None = None
+        crop_box: tuple[int, int, int, int] | None = None
+        resize_to: tuple[int, int] | None = None
 
-    # the image is too wide
-    if max_ratio is not None and (img_width / img_height) > max_ratio:
-        logging.debug('Image is too wide (%dx%d)', img_width, img_height)
-        new_width: cython.size_t = int(img_height * max_ratio)
-        x1 = (img_width - new_width) // 2
-        x2 = (img_width + new_width) // 2
-        crop_box = (x1, 0, x2, img_height)
-        img_width = new_width
+        # the image is too wide
+        if max_ratio is not None and (img_width / img_height) > max_ratio:
+            logging.debug('Image is too wide (%dx%d)', img_width, img_height)
+            new_width: cython.size_t = int(img_height * max_ratio)
+            x1 = (img_width - new_width) // 2
+            x2 = (img_width + new_width) // 2
+            crop_box = (x1, 0, x2, img_height)
+            img_width = new_width
 
-    # the image is too tall
-    elif min_ratio is not None and (img_width / img_height) < min_ratio:
-        logging.debug('Image is too tall (%dx%d)', img_width, img_height)
-        new_height: cython.size_t = int(img_width / min_ratio)
-        y1 = (img_height - new_height) // 2
-        y2 = (img_height + new_height) // 2
-        crop_box = (0, y1, img_width, y2)
-        img_height = new_height
+        # the image is too tall
+        elif min_ratio is not None and (img_width / img_height) < min_ratio:
+            logging.debug('Image is too tall (%dx%d)', img_width, img_height)
+            new_height: cython.size_t = int(img_width / min_ratio)
+            y1 = (img_height - new_height) // 2
+            y2 = (img_height + new_height) // 2
+            crop_box = (0, y1, img_width, y2)
+            img_height = new_height
 
-    # limit dimensions
-    if max_side is not None:
-        side_ratio: cython.double = max(img_width, img_height) / max_side
-        if side_ratio > 1:
-            logging.debug('Image is too big (%dx%d)', img_width, img_height)
-            img_width = max(1, int(img_width / side_ratio))
-            img_height = max(1, int(img_height / side_ratio))
-            resize_to = (img_width, img_height)
+        # limit dimensions
+        if max_side is not None:
+            side_ratio: cython.double = max(img_width, img_height) / max_side
+            if side_ratio > 1:
+                logging.debug('Image is too big (%dx%d)', img_width, img_height)
+                img_width = max(1, int(img_width / side_ratio))
+                img_height = max(1, int(img_height / side_ratio))
+                resize_to = (img_width, img_height)
 
-    # limit megapixels
-    if max_megapixels is not None:
-        mp_ratio: cython.double = (img_width * img_height) / max_megapixels
-        if mp_ratio > 1:
-            logging.debug('Image is too big (%dx%d)', img_width, img_height)
-            mp_ratio = sqrt(mp_ratio)
-            img_width = max(1, int(img_width / mp_ratio))
-            img_height = max(1, int(img_height / mp_ratio))
-            resize_to = (img_width, img_height)
+        # limit megapixels
+        if max_megapixels is not None:
+            mp_ratio: cython.double = (img_width * img_height) / max_megapixels
+            if mp_ratio > 1:
+                logging.debug('Image is too big (%dx%d)', img_width, img_height)
+                mp_ratio = sqrt(mp_ratio)
+                img_width = max(1, int(img_width / mp_ratio))
+                img_height = max(1, int(img_height / mp_ratio))
+                resize_to = (img_width, img_height)
 
-    animation = _extract_animation(img)
+        animation = _extract_animation(img)
 
-    if resize_to is None and crop_box is None:
-        pass
-    elif animation is not None:
-        frames: list[PILImage] = []
+        if resize_to is None and crop_box is None:
+            pass
+        elif animation is not None:
+            frames: list[PILImage] = []
 
-        for frame in animation.frames:
-            if resize_to is not None:
-                frame = frame.resize(resize_to, Resampling.BOX, crop_box)
-            elif crop_box is not None:
-                frame = frame.crop(crop_box)
-            frames.append(frame)
+            for frame in animation.frames:
+                if resize_to is not None:
+                    frame = frame.resize(resize_to, Resampling.BOX, crop_box)
+                elif crop_box is not None:
+                    frame = frame.crop(crop_box)
+                frames.append(frame)
 
-        img = frames[0]
-        animation = animation._replace(frames=frames)
-    elif resize_to is not None:
-        img = img.resize(resize_to, Resampling.BOX, crop_box)
-    elif crop_box is not None:
-        img = img.crop(crop_box)
+            img = frames[0]
+            animation = animation._replace(frames=frames)
+        elif resize_to is not None:
+            img = img.resize(resize_to, Resampling.BOX, crop_box)
+        elif crop_box is not None:
+            img = img.crop(crop_box)
+    except DecompressionBombError:
+        raise_for.image_too_big()
 
     async with _get_pipeline() as pipe:
         if pipe is not None:

--- a/app/views/settings/applications/edit.tsx
+++ b/app/views/settings/applications/edit.tsx
@@ -34,6 +34,9 @@ mountProtoPage(
     const avatarFormRef = useRef<HTMLFormElement>(null)
     const avatarFileInputRef = useRef<HTMLInputElement>(null)
     const resetSecretFormRef = useRef<HTMLFormElement>(null)
+    const clearAvatarFileInput = () => {
+      avatarFileInputRef.current!.value = ""
+    }
 
     return (
       <>
@@ -251,7 +254,11 @@ mountProtoPage(
                           id,
                           avatarFile: await formDataBytes(formData, "avatar_file"),
                         })}
-                        onSuccess={(resp) => (avatarUrl.value = resp.avatarUrl)}
+                        onSuccess={(resp) => {
+                          clearAvatarFileInput()
+                          avatarUrl.value = resp.avatarUrl
+                        }}
+                        onError={clearAvatarFileInput}
                       >
                         <input
                           class="visually-hidden"
@@ -285,7 +292,10 @@ mountProtoPage(
                               <button
                                 class="dropdown-item"
                                 type="button"
-                                onClick={() => avatarFileInputRef.current!.click()}
+                                onClick={() => {
+                                  clearAvatarFileInput()
+                                  avatarFileInputRef.current!.click()
+                                }}
                               >
                                 {t("action.upload_image")}...
                               </button>
@@ -295,7 +305,7 @@ mountProtoPage(
                                 class="dropdown-item"
                                 type="button"
                                 onClick={() => {
-                                  avatarFileInputRef.current!.value = ""
+                                  clearAvatarFileInput()
                                   avatarFormRef.current!.requestSubmit()
                                 }}
                               >

--- a/app/views/user/profile/profile.tsx
+++ b/app/views/user/profile/profile.tsx
@@ -243,6 +243,9 @@ const AvatarForm = ({
 }) => {
   const avatarPresetRef = useRef(UpdateAvatarRequest_Preset.default)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const clearAvatarInput = () => {
+    fileInputRef.current!.value = ""
+  }
 
   return (
     <StandardForm
@@ -266,7 +269,11 @@ const AvatarForm = ({
           },
         }
       }}
-      onSuccess={(resp) => (avatarUrl.value = resp.avatarUrl)}
+      onSuccess={(resp) => {
+        clearAvatarInput()
+        avatarUrl.value = resp.avatarUrl
+      }}
+      onError={clearAvatarInput}
     >
       <input
         class="visually-hidden"
@@ -304,6 +311,7 @@ const AvatarForm = ({
                 class="dropdown-item"
                 type="button"
                 onClick={() => {
+                  clearAvatarInput()
                   fileInputRef.current!.click()
                 }}
               >
@@ -316,7 +324,7 @@ const AvatarForm = ({
                 type="button"
                 onClick={() => {
                   avatarPresetRef.current = UpdateAvatarRequest_Preset.gravatar
-                  fileInputRef.current!.value = ""
+                  clearAvatarInput()
                   fileInputRef.current!.form!.requestSubmit()
                 }}
               >
@@ -329,7 +337,7 @@ const AvatarForm = ({
                 type="button"
                 onClick={() => {
                   avatarPresetRef.current = UpdateAvatarRequest_Preset.default
-                  fileInputRef.current!.value = ""
+                  clearAvatarInput()
                   fileInputRef.current!.form!.requestSubmit()
                 }}
               >

--- a/tests/lib/test_image.py
+++ b/tests/lib/test_image.py
@@ -3,7 +3,13 @@ from pathlib import Path
 
 import pytest
 from PIL import Image as PILImage
+from PIL.Image import DecompressionBombError
+from starlette import status
 
+from app.exceptions import Exceptions
+from app.exceptions.api_error import APIError
+from app.exceptions.context import exceptions_context
+from app.lib.io import image as image_module
 from app.config import IMAGE_MAX_FRAMES
 from app.lib.io.image import Image
 
@@ -42,3 +48,16 @@ async def test_normalize_avatar_preserves_animation(animation: bytes):
     assert len(normalized[0]) < len(animation)
     assert result.is_animated  # type: ignore
     assert 1 < result.n_frames <= IMAGE_MAX_FRAMES  # type: ignore
+
+
+async def test_normalize_avatar_rejects_decompression_bomb(monkeypatch: pytest.MonkeyPatch):
+    def bomb(*_args, **_kwargs):
+        raise DecompressionBombError("too many pixels")
+
+    monkeypatch.setattr(image_module, "open_image", bomb)
+
+    with exceptions_context(Exceptions()), pytest.raises(APIError) as exc_info:
+        await Image.normalize_avatar(b"not-an-image")
+
+    assert exc_info.value.status_code == status.HTTP_413_CONTENT_TOO_LARGE
+    assert exc_info.value.detail == "Image is too large"


### PR DESCRIPTION
Closes #31

## Summary
- treat Pillow DecompressionBombError as the existing "Image is too large" response
- reset avatar file inputs after profile and application upload attempts so the same file can be retried cleanly
- add regression coverage for decompression-bomb avatar normalization

## Verification
- /Users/lyy/Documents/Codex/2026-05-21/10/openstreetmap-ng/.venv/bin/python -m py_compile app/lib/io/image.py tests/lib/test_image.py
- uv run pytest tests/lib/test_image.py -q (blocked here by first-run speedup toolchain bootstrap, so no completed pytest run yet)
