### PR TITLE
Append #osm-ng hashtag to created notes

### DIFF
--- a/app/services/note_service.py
+++ b/app/services/note_service.py
@@ -27,12 +27,23 @@ from app.services.email_service import EmailService
 from app.services.user_subscription_service import UserSubscriptionService
 from app.validators.geometry import validate_geometry
 
+NOTE_APP_HASHTAG = '#osm-ng'
+
+
+def with_note_app_hashtag(text: str) -> str:
+    """Append the app hashtag to newly created notes, unless already present."""
+    text = text.rstrip()
+    if NOTE_APP_HASHTAG.lower() in text.lower().split():
+        return text
+    return f'{text}\n\n{NOTE_APP_HASHTAG}'
+
 
 class NoteService:
     @staticmethod
     async def create(lon: float, lat: float, text: str) -> NoteId:
         """Create a note and return its id."""
         point = validate_geometry(Point(lon, lat))
+        text = with_note_app_hashtag(text)
 
         user = auth_user()
         if user is not None:

--- a/tests/controllers/test_api06_note.py
+++ b/tests/controllers/test_api06_note.py
@@ -8,6 +8,7 @@ from pydantic import PositiveInt
 from starlette import status
 
 from app.lib.io.xml_codec import XMLToDict
+from app.services.note_service import with_note_app_hashtag
 from speedup import buffered_randbytes
 from tests.utils.assert_model import assert_model
 
@@ -41,7 +42,7 @@ async def test_note_create_xml(client: AsyncClient):
         {
             'user': 'user1',
             'action': 'opened',
-            'text': test_note_create_xml.__qualname__,
+            'text': with_note_app_hashtag(test_note_create_xml.__qualname__),
         },
     )
 
@@ -62,7 +63,7 @@ async def test_note_create_json(client: AsyncClient):
         {
             'user': 'user1',
             'action': 'opened',
-            'text': test_note_create_json.__qualname__,
+            'text': with_note_app_hashtag(test_note_create_json.__qualname__),
         },
     )
 
@@ -104,7 +105,7 @@ async def test_note_create_anonymous(client: AsyncClient):
         props['comments'][0],
         {
             'action': 'opened',
-            'text': test_note_create_anonymous.__qualname__,
+            'text': with_note_app_hashtag(test_note_create_anonymous.__qualname__),
         },
     )
     assert 'user' not in props['comments'][0]
@@ -128,7 +129,7 @@ async def test_note_crud(client: AsyncClient):
         {
             'user': 'user1',
             'action': 'opened',
-            'text': test_note_crud.__qualname__,
+            'text': with_note_app_hashtag(test_note_crud.__qualname__),
         },
     )
 
@@ -255,7 +256,10 @@ async def test_note_query_by_bbox(client: AsyncClient):
 
     # Verify that note is found
     assert_model(props, {'status': 'open', 'comments': Len(1, 1)})
-    assert_model(props['comments'][0], {'text': test_note_query_by_bbox.__qualname__})
+    assert_model(
+        props['comments'][0],
+        {'text': with_note_app_hashtag(test_note_query_by_bbox.__qualname__)},
+    )
 
 
 async def test_note_search(client: AsyncClient):
@@ -281,7 +285,7 @@ async def test_note_search(client: AsyncClient):
 
     # Verify that note is found
     assert_model(props, {'status': 'open', 'comments': Len(1, 1)})
-    assert_model(props['comments'][0], {'text': text})
+    assert_model(props['comments'][0], {'text': with_note_app_hashtag(text)})
 
 
 async def test_invalid_note_id(client: AsyncClient):

--- a/tests/middlewares/test_request_body_middleware.py
+++ b/tests/middlewares/test_request_body_middleware.py
@@ -15,6 +15,7 @@ from starlette import status
 from app.config import REQUEST_BODY_MAX_SIZE
 from app.lib.io.xml_codec import XMLToDict
 from app.models.types import ChangesetId
+from app.services.note_service import with_note_app_hashtag
 from tests.utils.assert_model import assert_model
 
 # Lightweight compression levels for faster tests.
@@ -100,7 +101,7 @@ async def test_compressed_json(
         {
             'user': 'user1',
             'action': 'opened',
-            'text': text,
+            'text': with_note_app_hashtag(text),
         },
     )
 
@@ -188,7 +189,7 @@ async def test_passthrough_unsupported_compression(client: AsyncClient):
         {
             'user': 'user1',
             'action': 'opened',
-            'text': text,
+            'text': with_note_app_hashtag(text),
         },
     )
 

--- a/tests/test_note_hashtag.py
+++ b/tests/test_note_hashtag.py
@@ -1,0 +1,13 @@
+from app.services.note_service import with_note_app_hashtag
+
+
+def test_with_note_app_hashtag_appends_hashtag():
+    assert with_note_app_hashtag('Missing path here') == 'Missing path here\n\n#osm-ng'
+
+
+def test_with_note_app_hashtag_preserves_existing_hashtag_case_insensitive():
+    assert with_note_app_hashtag('Missing path here #OSM-NG') == 'Missing path here #OSM-NG'
+
+
+def test_with_note_app_hashtag_trims_trailing_whitespace_before_append():
+    assert with_note_app_hashtag('Missing path here  \n') == 'Missing path here\n\n#osm-ng'


### PR DESCRIPTION
Fixes #76

This centralizes the `#osm-ng` note source marker in `NoteService.create`, so notes created through the API 0.6 endpoints get the application hashtag appended consistently.

Changes:
- add `with_note_app_hashtag()` helper
- append `#osm-ng` to newly created note text unless already present, case-insensitively
- trim trailing whitespace before appending
- add focused regression tests for append, duplicate preservation, and trailing whitespace

Validation:
- `uv run --no-sync python` helper checks: passed (`helper_ok`)
- `git diff --check origin/main..ari/issue-76-note-hashtag`: passed
- `python -m pytest tests/test_note_hashtag.py`: blocked by missing `email_validator` in plain Python environment
- `uv run python -m pytest tests/test_note_hashtag.py`: blocked by local build environment (`speedup` Rust extension cannot compile because linker `cc`/Nix shell is unavailable)
