### PR TITLE
Add closes:note handling when closing changesets

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,8 +36,4 @@ jobs:
 
       - name: Run tests
         run: |
-          run_tests_args="--extended --term"
-          if [[ "${{ matrix.implementation }}" == "cython" ]]; then
-            run_tests_args="$run_tests_args --no-coverage --hard-exit"
-          fi
-          nix-shell --pure --run "run-tests $run_tests_args"
+          nix-shell --pure --run "run-tests --extended --term"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,4 +36,8 @@ jobs:
 
       - name: Run tests
         run: |
-          nix-shell --pure --run "run-tests --extended --term"
+          run_tests_args="--extended --term"
+          if [[ "${{ matrix.implementation }}" == "cython" ]]; then
+            run_tests_args="$run_tests_args --no-coverage --hard-exit"
+          fi
+          nix-shell --pure --run "run-tests $run_tests_args"

--- a/app/services/changeset_service.py
+++ b/app/services/changeset_service.py
@@ -24,6 +24,7 @@ from app.db import (
     db_lock,
     db_update,
 )
+from app.exceptions.api_error import APIError
 from app.exceptions.context import raise_for
 from app.lib.audit import audit
 from app.lib.auth.context import auth_user
@@ -38,15 +39,66 @@ from app.models.db.changeset_comment import (
     ChangesetComment,
     changeset_comments_resolve_rich_text,
 )
-from app.models.types import ChangesetCommentId, ChangesetId, DisplayName, UserId
+from app.models.types import (
+    ChangesetCommentId,
+    ChangesetId,
+    DisplayName,
+    NoteId,
+    UserId,
+)
 from app.queries.changeset_query import ChangesetQuery
 from app.queries.user_query import UserQuery
 from app.queries.user_subscription_query import UserSubscriptionQuery
 from app.services.email_service import EmailService
+from app.services.note_service import NoteService
 from app.services.user_subscription_service import UserSubscriptionService
 
 _PROCESS_REQUEST_EVENT = Event()
 _PROCESS_DONE_EVENT = Event()
+
+
+async def _close_notes_tagged_by_changeset(
+    changeset_id: ChangesetId, tags: dict[str, str]
+):
+    note_comments = _changeset_note_close_comments(tags)
+    for note_id, comment in note_comments.items():
+        try:
+            await NoteService.comment(note_id, comment, 'closed')
+        except APIError as e:
+            # Closing a changeset must remain idempotent for notes that were
+            # already resolved or are no longer visible to this user.
+            if e.status_code not in {404, 409}:
+                raise
+            logging.debug(
+                'Skipping automatic note close from changeset %d for note %d',
+                changeset_id,
+                note_id,
+            )
+
+
+def _changeset_note_close_comments(tags: dict[str, str]) -> dict[NoteId, str]:
+    raw_note_ids = tags.get('closes:note')
+    if not raw_note_ids:
+        return {}
+
+    default_comment = tags.get('closes:note:comment')
+    if default_comment is None:
+        default_comment = tags.get('comment', '')
+
+    note_comments: dict[NoteId, str] = {}
+    for raw_note_id in raw_note_ids.split(';'):
+        raw_note_id = raw_note_id.strip()
+        if not raw_note_id.isdecimal():
+            continue
+
+        note_id = NoteId(int(raw_note_id))
+        if note_id in note_comments:
+            continue
+
+        comment = tags.get(f'closes:note:{note_id}:comment', default_comment)
+        note_comments[note_id] = comment
+
+    return note_comments
 
 
 class ChangesetService:
@@ -77,7 +129,7 @@ class ChangesetService:
         async with db(True) as conn:
             row = await db_fetchrow(
                 t"""
-                    SELECT user_id, closed_at
+                    SELECT user_id, closed_at, tags
                     FROM changeset
                     WHERE id = {changeset_id}
                 """,
@@ -89,7 +141,8 @@ class ChangesetService:
 
             changeset_user_id: UserId
             closed_at: datetime | None
-            changeset_user_id, closed_at = row
+            tags: dict[str, str]
+            changeset_user_id, closed_at, tags = row
 
             if changeset_user_id != user_id:
                 raise_for.changeset_access_denied()
@@ -141,6 +194,8 @@ class ChangesetService:
                 conn=conn,
             )
             await audit('close_changeset', conn, extra={'id': changeset_id})
+
+        await _close_notes_tagged_by_changeset(changeset_id, tags)
 
     @staticmethod
     @asynccontextmanager

--- a/app/services/changeset_service.py
+++ b/app/services/changeset_service.py
@@ -129,7 +129,7 @@ class ChangesetService:
         async with db(True) as conn:
             row = await db_fetchrow(
                 t"""
-                    SELECT user_id, closed_at, tags
+                    SELECT user_id, closed_at
                     FROM changeset
                     WHERE id = {changeset_id}
                 """,
@@ -141,8 +141,7 @@ class ChangesetService:
 
             changeset_user_id: UserId
             closed_at: datetime | None
-            tags: dict[str, str]
-            changeset_user_id, closed_at, tags = row
+            changeset_user_id, closed_at = row
 
             if changeset_user_id != user_id:
                 raise_for.changeset_access_denied()
@@ -165,7 +164,7 @@ class ChangesetService:
         async with db(True) as conn:
             row = await db_fetchrow(
                 t"""
-                    SELECT user_id, closed_at
+                    SELECT user_id, closed_at, tags
                     FROM changeset
                     WHERE id = {changeset_id}
                 """,
@@ -177,7 +176,8 @@ class ChangesetService:
 
             changeset_user_id: UserId
             closed_at: datetime | None
-            changeset_user_id, closed_at = row
+            tags: dict[str, str]
+            changeset_user_id, closed_at, tags = row
 
             if changeset_user_id != user_id:
                 raise_for.changeset_access_denied()

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -5,8 +5,6 @@ if [[ ! -S $PC_SOCKET_PATH ]]; then
 fi
 
 term_output=0
-coverage=1
-hard_exit=0
 args=(
   --verbose
   --no-header
@@ -15,13 +13,6 @@ args=(
 
 for arg in "$@"; do
   case "$arg" in
-  --hard-exit)
-    hard_exit=1
-    coverage=0
-    ;;
-  --no-coverage)
-    coverage=0
-    ;;
   --term)
     term_output=1
     ;;
@@ -32,41 +23,17 @@ for arg in "$@"; do
 done
 
 set +e
-if [[ $hard_exit == 1 ]]; then
-  (
-    set -x
-    python - "${args[@]}" <<'PY'
-import os
-import sys
-
-import pytest
-
-result = pytest.main(sys.argv[1:])
-sys.stdout.flush()
-sys.stderr.flush()
-os._exit(result)
-PY
-  )
-elif [[ $coverage == 1 ]]; then
-  (
-    set -x
-    python -m coverage run -m pytest "${args[@]}"
-  )
-else
-  (
-    set -x
-    python -m pytest "${args[@]}"
-  )
-fi
+(
+  set -x
+  python -m coverage run -m pytest "${args[@]}"
+)
 result=$?
 set -e
 
-if [[ $coverage == 1 ]]; then
-  if [[ $term_output == 1 ]]; then
-    python -m coverage report --skip-covered
-  else
-    python -m coverage xml --quiet
-  fi
-  python -m coverage erase
+if [[ $term_output == 1 ]]; then
+  python -m coverage report --skip-covered
+else
+  python -m coverage xml --quiet
 fi
+python -m coverage erase
 exit "$result"

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -5,6 +5,8 @@ if [[ ! -S $PC_SOCKET_PATH ]]; then
 fi
 
 term_output=0
+coverage=1
+hard_exit=0
 args=(
   --verbose
   --no-header
@@ -13,6 +15,13 @@ args=(
 
 for arg in "$@"; do
   case "$arg" in
+  --hard-exit)
+    hard_exit=1
+    coverage=0
+    ;;
+  --no-coverage)
+    coverage=0
+    ;;
   --term)
     term_output=1
     ;;
@@ -23,17 +32,41 @@ for arg in "$@"; do
 done
 
 set +e
-(
-  set -x
-  python -m coverage run -m pytest "${args[@]}"
-)
+if [[ $hard_exit == 1 ]]; then
+  (
+    set -x
+    python - "${args[@]}" <<'PY'
+import os
+import sys
+
+import pytest
+
+result = pytest.main(sys.argv[1:])
+sys.stdout.flush()
+sys.stderr.flush()
+os._exit(result)
+PY
+  )
+elif [[ $coverage == 1 ]]; then
+  (
+    set -x
+    python -m coverage run -m pytest "${args[@]}"
+  )
+else
+  (
+    set -x
+    python -m pytest "${args[@]}"
+  )
+fi
 result=$?
 set -e
 
-if [[ $term_output == 1 ]]; then
-  python -m coverage report --skip-covered
-else
-  python -m coverage xml --quiet
+if [[ $coverage == 1 ]]; then
+  if [[ $term_output == 1 ]]; then
+    python -m coverage report --skip-covered
+  else
+    python -m coverage xml --quiet
+  fi
+  python -m coverage erase
 fi
-python -m coverage erase
 exit "$result"

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -5,6 +5,8 @@ if [[ ! -S $PC_SOCKET_PATH ]]; then
 fi
 
 term_output=0
+coverage=1
+hard_exit=0
 args=(
   --verbose
   --no-header
@@ -13,6 +15,12 @@ args=(
 
 for arg in "$@"; do
   case "$arg" in
+  --hard-exit)
+    hard_exit=1
+    ;;
+  --no-coverage)
+    coverage=0
+    ;;
   --term)
     term_output=1
     ;;
@@ -23,17 +31,41 @@ for arg in "$@"; do
 done
 
 set +e
-(
-  set -x
-  python -m coverage run -m pytest "${args[@]}"
-)
+if [[ $hard_exit == 1 ]]; then
+  (
+    set -x
+    python - "${args[@]}" <<'PY'
+import os
+import sys
+
+import pytest
+
+result = pytest.main(sys.argv[1:])
+sys.stdout.flush()
+sys.stderr.flush()
+os._exit(result)
+PY
+  )
+elif [[ $coverage == 1 ]]; then
+  (
+    set -x
+    python -m coverage run -m pytest "${args[@]}"
+  )
+else
+  (
+    set -x
+    python -m pytest "${args[@]}"
+  )
+fi
 result=$?
 set -e
 
-if [[ $term_output == 1 ]]; then
-  python -m coverage report --skip-covered
-else
-  python -m coverage xml --quiet
+if [[ $coverage == 1 ]]; then
+  if [[ $term_output == 1 ]]; then
+    python -m coverage report --skip-covered
+  else
+    python -m coverage xml --quiet
+  fi
+  python -m coverage erase
 fi
-python -m coverage erase
 exit "$result"

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -17,6 +17,7 @@ for arg in "$@"; do
   case "$arg" in
   --hard-exit)
     hard_exit=1
+    coverage=0
     ;;
   --no-coverage)
     coverage=0


### PR DESCRIPTION
## Summary

Implements automatic note closure for changesets tagged with `closes:note`, per #126.

- parses numeric note IDs from semicolon-separated `closes:note` values
- uses `closes:note:<id>:comment`, then `closes:note:comment`, then the changeset `comment` as the note close message
- ignores invalid, duplicate, already-closed, or no-longer-visible notes so closing the changeset remains successful

## Testing

- `git diff --check`
- Not run locally: local checkout does not have the project Python 3.14/pytest environment available (`python3 -m pytest ...` failed with `No module named pytest`).

## CI note
This branch includes the Cython runner workaround from #345 because upstream main's Cython job currently exits 134 after pytest under Python 3.14. Python jobs stay on the normal coverage path.

Fixes #126
/claim #126