### PR TITLE
Add embedded changeset diff mode

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,8 +36,4 @@ jobs:
 
       - name: Run tests
         run: |
-          run_tests_args="--extended --term"
-          if [[ "${{ matrix.implementation }}" == "cython" ]]; then
-            run_tests_args="$run_tests_args --no-coverage --hard-exit"
-          fi
-          nix-shell --pure --run "run-tests $run_tests_args"
+          nix-shell --pure --run "run-tests --extended --term"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,4 +36,8 @@ jobs:
 
       - name: Run tests
         run: |
-          nix-shell --pure --run "run-tests --extended --term"
+          run_tests_args="--extended --term"
+          if [[ "${{ matrix.implementation }}" == "cython" ]]; then
+            run_tests_args="$run_tests_args --no-coverage --hard-exit"
+          fi
+          nix-shell --pure --run "run-tests $run_tests_args"

--- a/app/middlewares/headers_middleware.py
+++ b/app/middlewares/headers_middleware.py
@@ -30,6 +30,8 @@ from app.middlewares.request_context_middleware import get_request
 from app.models.types import StorageKey
 from app.services.rate_limit_service import RateLimitService
 
+_ACHAVI_URL = 'https://overpass-api.de'
+
 # Please keep it CSP version 2-compatible for the time being.
 CSP_HEADER = '; '.join(
     filter(
@@ -54,7 +56,7 @@ CSP_HEADER = '; '.join(
             'child-src blob:',  # TODO: worker-src in CSP 3
             'img-src * data:',
             'connect-src * data:',
-            f'frame-src {" ".join({ID_URL, RAPID_URL})}',
+            f'frame-src {" ".join(sorted({ID_URL, RAPID_URL, _ACHAVI_URL}))}',
             f'frame-ancestors {APP_URL}',
             (f'report-uri {SENTRY_DSN}' if SENTRY_DSN else None),
         ),

--- a/app/views/index/changeset.scss
+++ b/app/views/index/changeset.scss
@@ -16,4 +16,19 @@
     background: rgba($success, 0.3);
     border: 1px solid rgba($success, 0.5);
   }
+
+  .changeset-diff-panel {
+    overflow: hidden;
+    background: var(--bs-body-bg);
+    border: 1px solid var(--bs-border-color);
+    border-radius: $border-radius;
+
+    iframe {
+      display: block;
+      width: 100%;
+      height: min(70vh, 34rem);
+      background: var(--bs-body-bg);
+      border: 0;
+    }
+  }
 }

--- a/app/views/index/changeset.tsx
+++ b/app/views/index/changeset.tsx
@@ -74,6 +74,9 @@ const getChangesetElementsTitle = (type: ElementType) => {
   return (count: string) => t("browse.changeset.relation", { count })
 }
 
+const getChangesetDiffUrl = (changesetId: bigint) =>
+  `https://overpass-api.de/achavi/?changeset=${changesetId}`
+
 const ChangesetHeader = ({ data }: { data: DataValid }) => {
   const isOpen = !data.closedAt
   return (
@@ -208,6 +211,87 @@ const ChangesetComment = ({
   </li>
 )
 
+const ChangesetDiffPanel = ({
+  changesetId,
+  onClose,
+}: {
+  changesetId: bigint
+  onClose: () => void
+}) => {
+  const diffUrl = getChangesetDiffUrl(changesetId)
+  return (
+    <section class="changeset-diff-panel mt-3 mb-3">
+      <div class="d-flex align-items-center justify-content-between gap-2 p-2">
+        <div>
+          <h4 class="h6 mb-0">Changeset diff</h4>
+          <p class="small text-muted mb-0">
+            View the changed objects without leaving this page.
+          </p>
+        </div>
+        <button
+          class="btn-close"
+          type="button"
+          aria-label={t("javascripts.close")}
+          onClick={onClose}
+        />
+      </div>
+      <iframe
+        src={diffUrl}
+        title="Changeset diff map"
+        loading="lazy"
+        referrerPolicy="no-referrer"
+        sandbox="allow-forms allow-popups allow-same-origin allow-scripts"
+      />
+      <div class="p-2 text-end">
+        <a
+          class="btn btn-sm btn-outline-primary"
+          href={diffUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <i class="bi bi-box-arrow-up-right me-1" />
+          Open full Achavi view
+        </a>
+      </div>
+    </section>
+  )
+}
+
+const ChangesetDiffToggle = ({
+  changesetId,
+  selectedChangesetId,
+}: {
+  changesetId: bigint
+  selectedChangesetId: Signal<bigint | null>
+}) => {
+  const isOpen = selectedChangesetId.value === changesetId
+
+  return (
+    <>
+      <div class="d-grid mt-3">
+        <button
+          class={`btn btn-sm ${isOpen ? "btn-primary" : "btn-outline-primary"}`}
+          type="button"
+          aria-expanded={isOpen}
+          onClick={() =>
+            (selectedChangesetId.value = isOpen ? null : changesetId)
+          }
+        >
+          <i class="bi bi-bezier2 me-1" />
+          {isOpen ? "Hide changeset diff" : "Open changeset diff"}
+        </button>
+      </div>
+
+      {isOpen && (
+        <ChangesetDiffPanel
+          changesetId={changesetId}
+          onClose={() => (selectedChangesetId.value = null)}
+        />
+      )}
+    </>
+  )
+}
+
 const ChangesetFooter = ({ data }: { data: DataValid }) => {
   const changesetIdStr = data.id.toString()
   return (
@@ -315,6 +399,7 @@ const ChangesetSidebar = ({
 }) => {
   const isSubscribed = useSignal(false)
   const preloadedComments = useSignal<GetCommentsResponseValid | null>(null)
+  const diffChangesetId = useSignal<bigint | null>(null)
 
   const { resource, data } = useSidebar(
     useComputed(() => ({ id: id.value })),
@@ -377,6 +462,11 @@ const ChangesetSidebar = ({
 
             <ChangesetHeader data={d} />
             <Tags tags={d.tags} />
+
+            <ChangesetDiffToggle
+              changesetId={d.id}
+              selectedChangesetId={diffChangesetId}
+            />
 
             {/* Report button */}
             {isLoggedIn && d.user && config.userConfig!.user.id !== d.user.id && (

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -5,8 +5,6 @@ if [[ ! -S $PC_SOCKET_PATH ]]; then
 fi
 
 term_output=0
-coverage=1
-hard_exit=0
 args=(
   --verbose
   --no-header
@@ -15,13 +13,6 @@ args=(
 
 for arg in "$@"; do
   case "$arg" in
-  --hard-exit)
-    hard_exit=1
-    coverage=0
-    ;;
-  --no-coverage)
-    coverage=0
-    ;;
   --term)
     term_output=1
     ;;
@@ -32,41 +23,17 @@ for arg in "$@"; do
 done
 
 set +e
-if [[ $hard_exit == 1 ]]; then
-  (
-    set -x
-    python - "${args[@]}" <<'PY'
-import os
-import sys
-
-import pytest
-
-result = pytest.main(sys.argv[1:])
-sys.stdout.flush()
-sys.stderr.flush()
-os._exit(result)
-PY
-  )
-elif [[ $coverage == 1 ]]; then
-  (
-    set -x
-    python -m coverage run -m pytest "${args[@]}"
-  )
-else
-  (
-    set -x
-    python -m pytest "${args[@]}"
-  )
-fi
+(
+  set -x
+  python -m coverage run -m pytest "${args[@]}"
+)
 result=$?
 set -e
 
-if [[ $coverage == 1 ]]; then
-  if [[ $term_output == 1 ]]; then
-    python -m coverage report --skip-covered
-  else
-    python -m coverage xml --quiet
-  fi
-  python -m coverage erase
+if [[ $term_output == 1 ]]; then
+  python -m coverage report --skip-covered
+else
+  python -m coverage xml --quiet
 fi
+python -m coverage erase
 exit "$result"

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -5,6 +5,8 @@ if [[ ! -S $PC_SOCKET_PATH ]]; then
 fi
 
 term_output=0
+coverage=1
+hard_exit=0
 args=(
   --verbose
   --no-header
@@ -13,6 +15,13 @@ args=(
 
 for arg in "$@"; do
   case "$arg" in
+  --hard-exit)
+    hard_exit=1
+    coverage=0
+    ;;
+  --no-coverage)
+    coverage=0
+    ;;
   --term)
     term_output=1
     ;;
@@ -23,17 +32,41 @@ for arg in "$@"; do
 done
 
 set +e
-(
-  set -x
-  python -m coverage run -m pytest "${args[@]}"
-)
+if [[ $hard_exit == 1 ]]; then
+  (
+    set -x
+    python - "${args[@]}" <<'PY'
+import os
+import sys
+
+import pytest
+
+result = pytest.main(sys.argv[1:])
+sys.stdout.flush()
+sys.stderr.flush()
+os._exit(result)
+PY
+  )
+elif [[ $coverage == 1 ]]; then
+  (
+    set -x
+    python -m coverage run -m pytest "${args[@]}"
+  )
+else
+  (
+    set -x
+    python -m pytest "${args[@]}"
+  )
+fi
 result=$?
 set -e
 
-if [[ $term_output == 1 ]]; then
-  python -m coverage report --skip-covered
-else
-  python -m coverage xml --quiet
+if [[ $coverage == 1 ]]; then
+  if [[ $term_output == 1 ]]; then
+    python -m coverage report --skip-covered
+  else
+    python -m coverage xml --quiet
+  fi
+  python -m coverage erase
 fi
-python -m coverage erase
 exit "$result"

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -5,6 +5,8 @@ if [[ ! -S $PC_SOCKET_PATH ]]; then
 fi
 
 term_output=0
+coverage=1
+hard_exit=0
 args=(
   --verbose
   --no-header
@@ -13,6 +15,12 @@ args=(
 
 for arg in "$@"; do
   case "$arg" in
+  --hard-exit)
+    hard_exit=1
+    ;;
+  --no-coverage)
+    coverage=0
+    ;;
   --term)
     term_output=1
     ;;
@@ -23,17 +31,41 @@ for arg in "$@"; do
 done
 
 set +e
-(
-  set -x
-  python -m coverage run -m pytest "${args[@]}"
-)
+if [[ $hard_exit == 1 ]]; then
+  (
+    set -x
+    python - "${args[@]}" <<'PY'
+import os
+import sys
+
+import pytest
+
+result = pytest.main(sys.argv[1:])
+sys.stdout.flush()
+sys.stderr.flush()
+os._exit(result)
+PY
+  )
+elif [[ $coverage == 1 ]]; then
+  (
+    set -x
+    python -m coverage run -m pytest "${args[@]}"
+  )
+else
+  (
+    set -x
+    python -m pytest "${args[@]}"
+  )
+fi
 result=$?
 set -e
 
-if [[ $term_output == 1 ]]; then
-  python -m coverage report --skip-covered
-else
-  python -m coverage xml --quiet
+if [[ $coverage == 1 ]]; then
+  if [[ $term_output == 1 ]]; then
+    python -m coverage report --skip-covered
+  else
+    python -m coverage xml --quiet
+  fi
+  python -m coverage erase
 fi
-python -m coverage erase
 exit "$result"

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -17,6 +17,7 @@ for arg in "$@"; do
   case "$arg" in
   --hard-exit)
     hard_exit=1
+    coverage=0
     ;;
   --no-coverage)
     coverage=0

--- a/tests/middlewares/test_headers_middleware.py
+++ b/tests/middlewares/test_headers_middleware.py
@@ -1,0 +1,13 @@
+from app.middlewares.headers_middleware import CSP_HEADER
+
+
+def _csp_directive_values(name: str) -> set[str]:
+    for directive in CSP_HEADER.split('; '):
+        directive_name, *values = directive.split()
+        if directive_name == name:
+            return set(values)
+    raise AssertionError(f'Missing CSP directive: {name}')
+
+
+def test_csp_frame_src_allows_achavi_embed():
+    assert 'https://overpass-api.de' in _csp_directive_values('frame-src')


### PR DESCRIPTION
## Summary
- add an `Open changeset diff` toggle to the changeset sidebar
- embed Achavi for the selected changeset without navigating away from the page
- include a close control and a full Achavi fallback link

Fixes #7
/claim #7

## Testing
- `git diff --check HEAD~1..HEAD`
- `npx --yes esbuild app/views/index/changeset.tsx --loader:.tsx=tsx --format=esm --outfile=/tmp/osm-ng-changeset-check.js --log-level=warning`
- `curl -I -L -A 'Mozilla/5.0' 'https://overpass-api.de/achavi/?changeset=1'`

## CI note
This branch includes the Cython runner workaround from #345 because upstream main's Cython job currently exits 134 after pytest under Python 3.14. Python jobs stay on the normal coverage path.