### PR TITLE
Fix globe aerial label ordering

### DIFF
--- a/app/views/map/layers/layers.ts
+++ b/app/views/map/layers/layers.ts
@@ -3,7 +3,7 @@ import { batch, effect, signal } from "@preact/signals"
 import { effectiveTheme } from "@runtime/theme"
 import { memoize } from "@std/cache/memoize"
 import { filterKeys } from "@std/collections/filter-keys"
-import { overlayOpacityStorage } from "@utils/local-storage"
+import { globeProjectionStorage, overlayOpacityStorage } from "@utils/local-storage"
 import type { FeatureCollection } from "geojson"
 import { t } from "i18next"
 import {
@@ -508,6 +508,52 @@ export const addMapLayer = (
       }
     })
   }
+
+  if (triggerEvent && (layerId === AERIAL_LAYER_ID || config.isBaseLayer))
+    syncAerialLayerOrder(map)
+}
+
+const getPriorityBeforeId = (
+  map: MaplibreMap,
+  layerId: LayerId,
+): string | undefined => {
+  const priority = layersConfig.get(layerId)?.priority ?? 0
+  return map
+    .getLayersOrder()
+    .find(
+      (id) => priority < (layersConfig.get(resolveExtendedLayerId(id))?.priority ?? 0),
+    )
+}
+
+const getFirstSymbolLayerId = (
+  map: MaplibreMap,
+  layerId: LayerId,
+): string | undefined =>
+  map.getLayersOrder().find((id) => {
+    if (resolveExtendedLayerId(id) !== layerId) return false
+    return map.getLayer(id)?.type === "symbol"
+  })
+
+export const syncAerialLayerOrder = (map: MaplibreMap) => {
+  if (!map.getLayer(AERIAL_LAYER_ID)) return
+
+  const activeBaseLayer = activeBaseLayerId.peek()
+  const symbolBeforeId =
+    globeProjectionStorage.peek() && activeBaseLayer
+      ? getFirstSymbolLayerId(map, activeBaseLayer)
+      : undefined
+  const beforeId = symbolBeforeId ?? getPriorityBeforeId(map, AERIAL_LAYER_ID)
+
+  if (beforeId === AERIAL_LAYER_ID) return
+
+  const order = map.getLayersOrder()
+  const aerialIndex = order.indexOf(AERIAL_LAYER_ID)
+  const beforeIndex = beforeId ? order.indexOf(beforeId) : order.length
+  if (aerialIndex === -1 || beforeIndex === -1) return
+  if (aerialIndex === beforeIndex - 1) return
+
+  console.debug("Layers: Moving", AERIAL_LAYER_ID, "before", beforeId)
+  map.moveLayer(AERIAL_LAYER_ID, beforeId)
 }
 
 export const removeMapLayer = (

--- a/app/views/map/main-map.ts
+++ b/app/views/map/main-map.ts
@@ -28,7 +28,11 @@ import { QueryFeaturesControl } from "./controls/query-features"
 import { CustomZoomControl } from "./controls/zoom"
 import { configureDefaultMapBehavior } from "./defaults"
 import { configureDataLayer } from "./layers/data-layer"
-import { addLayerEventHandler, addMapLayerSources } from "./layers/layers"
+import {
+  addLayerEventHandler,
+  addMapLayerSources,
+  syncAerialLayerOrder,
+} from "./layers/layers"
 import { configureNotesLayer } from "./layers/notes-layer"
 import type { MapState } from "./state"
 import { applyMapState, getInitialMapState, getMapState, parseMapState } from "./state"
@@ -73,6 +77,7 @@ const createMainMap = (
     globeWasEnabled = enabled
 
     map.setProjection({ type: enabled ? "globe" : "mercator" })
+    syncAerialLayerOrder(map)
 
     // Workaround a bug where after switching back to mercator,
     // the map is not fit to the screen (there is grey padding).


### PR DESCRIPTION
Fixes #184.

## Summary
- Reorder the aerial raster layer below the active vector base map's first symbol layer while globe projection is enabled.
- Re-sync the aerial layer order when the active base layer changes, when aerial is enabled, and when globe/mercator projection toggles.
- Fall back to the existing priority-based overlay ordering outside globe mode.

## Testing
- `npx prettier --no-semi --check app/views/map/layers/layers.ts app/views/map/main-map.ts`
- `npx --yes oxlint app/views/map/layers/layers.ts app/views/map/main-map.ts`

Note: full `tsc --noEmit` could not be used from this bare checkout because generated `@proto/*` bindings are absent without the project dev/proto pipeline.