### PR TITLE
Add OSM-NG Founders badge asset

### DIFF
--- a/app/static/img/banner/osmng-founders.svg
+++ b/app/static/img/banner/osmng-founders.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" viewBox="0 0 500 500" role="img" aria-labelledby="title desc">
+  <title id="title">OpenStreetMap-NG Founders logo</title>
+  <desc id="desc">A folded map and NG monogram with a gold founder compass badge.</desc>
+  <defs>
+    <linearGradient id="map-a" x1="70" y1="60" x2="430" y2="440" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#dff4bd" />
+      <stop offset="0.52" stop-color="#bfe29a" />
+      <stop offset="1" stop-color="#8fca79" />
+    </linearGradient>
+    <linearGradient id="map-b" x1="105" y1="100" x2="405" y2="405" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#f6ffd9" stop-opacity="0.72" />
+      <stop offset="1" stop-color="#6fbf7b" stop-opacity="0.2" />
+    </linearGradient>
+    <linearGradient id="gold" x1="274" y1="65" x2="417" y2="220" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#fff0a6" />
+      <stop offset="0.54" stop-color="#f0b94e" />
+      <stop offset="1" stop-color="#c77c1c" />
+    </linearGradient>
+    <filter id="soft-shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="12" stdDeviation="12" flood-color="#17351d" flood-opacity="0.22" />
+    </filter>
+  </defs>
+
+  <rect width="500" height="500" rx="96" fill="#f5f9ef" />
+  <g filter="url(#soft-shadow)">
+    <path
+      d="M58 78c61 10 116-6 169-16 69-13 139 0 215-9 16 67-4 125 8 195 12 71 42 124 28 195-70-12-125 5-191 11-72 7-140-4-215 10 13-71-7-126-12-194-5-74 15-125-2-192Z"
+      fill="url(#map-a)"
+    />
+    <path
+      d="M80 103c69 6 121-13 177-8 54 5 94 25 164 10-14 67 3 106 7 156 5 61-14 99 3 159-57-12-104-1-158 7-58 8-117-11-179 1 11-61-4-108-8-164-4-55 9-102-6-161Z"
+      fill="url(#map-b)"
+      opacity="0.72"
+    />
+
+    <path d="M74 198c44 7 70 31 115 28 53-3 84-37 138-39 45-2 78 19 121 21" fill="none" stroke="#84a86f" stroke-width="5" stroke-linecap="round" opacity="0.5" />
+    <path d="M112 330c53-27 84-30 134-13 54 19 107 2 159-38" fill="none" stroke="#84a86f" stroke-width="5" stroke-linecap="round" opacity="0.48" />
+    <path d="M211 86c-3 48 18 85 14 131-5 58-36 102-31 168" fill="none" stroke="#80a36d" stroke-width="5" stroke-linecap="round" opacity="0.45" />
+    <path d="M340 83c-21 52-15 106 7 154 22 50 25 92 4 151" fill="none" stroke="#80a36d" stroke-width="5" stroke-linecap="round" opacity="0.45" />
+
+    <path d="M103 130l42 25-12 64 72 24 17 75 84 19 36 55" fill="none" stroke="#c6605f" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" opacity="0.82" />
+    <path d="M87 282l82-18 63 30 92-58 86 15" fill="none" stroke="#8eb3ee" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" opacity="0.88" />
+  </g>
+
+  <g transform="translate(0 10)">
+    <text
+      x="91"
+      y="307"
+      fill="#ffffff"
+      stroke="#070707"
+      stroke-width="14"
+      paint-order="stroke"
+      font-family="Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="176"
+      font-weight="900"
+      letter-spacing="0"
+    >NG</text>
+    <text
+      x="91"
+      y="307"
+      fill="#ffffff"
+      font-family="Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="176"
+      font-weight="900"
+      letter-spacing="0"
+    >NG</text>
+  </g>
+
+  <g transform="translate(324 106)">
+    <circle cx="0" cy="0" r="74" fill="#17324d" opacity="0.2" />
+    <circle cx="0" cy="0" r="64" fill="url(#gold)" stroke="#6b4511" stroke-width="7" />
+    <path d="M0-42l11 29 31-7-18 27 24 22-33 1-15 30-15-30-33-1 24-22-18-27 31 7Z" fill="#fff8cf" stroke="#6b4511" stroke-width="5" stroke-linejoin="round" />
+    <path d="M-44 0h88M0-44v88" stroke="#6b4511" stroke-width="4" stroke-linecap="round" opacity="0.68" />
+  </g>
+
+  <path d="M122 370h256c18 0 32 14 32 32s-14 32-32 32H122c-18 0-32-14-32-32s14-32 32-32Z" fill="#17324d" opacity="0.95" />
+  <text
+    x="250"
+    y="415"
+    text-anchor="middle"
+    fill="#fff1b8"
+    font-family="Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+    font-size="34"
+    font-weight="800"
+    letter-spacing="0"
+  >FOUNDERS</text>
+</svg>

--- a/app/views/user/profile/profile.tsx
+++ b/app/views/user/profile/profile.tsx
@@ -43,7 +43,7 @@ const GROUP_EXAMPLES: readonly GroupExample[] = [
     title: "OpenStreetMap-NG Founders",
     description:
       "The OpenStreetMap-NG Founders is a group of early-stage contributors who helped shape the future of OpenStreetMap. We build the next generation of the OpenStreetMap project.",
-    banner: "/static/img/banner/example1.webp",
+    banner: "/static/img/banner/osmng-founders.svg",
     exclusive: true,
   },
   {


### PR DESCRIPTION
## Summary
- Add a square SVG Founders badge based on the existing folded-map + NG visual language
- Use the new badge for the existing `osmng-founders` profile group example instead of the generic sample image
- Keep the design as a lightweight static asset with a gold founder/compass marker and readable `FOUNDERS` label

Refs #114

## Validation
- `xmllint --noout app/static/img/banner/osmng-founders.svg`
- `git diff --cached --check`
- Rendered the SVG locally with Quick Look to confirm it is nonblank and legible at square badge scale

## AI Disclosure
This PR was drafted with AI assistance in Codex and manually reviewed before submission.