### PR TITLE
Add OSM software showcase page

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,8 +36,4 @@ jobs:
 
       - name: Run tests
         run: |
-          run_tests_args="--extended --term"
-          if [[ "${{ matrix.implementation }}" == "cython" ]]; then
-            run_tests_args="$run_tests_args --no-coverage --hard-exit"
-          fi
-          nix-shell --pure --run "run-tests $run_tests_args"
+          nix-shell --pure --run "run-tests --extended --term"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,4 +36,8 @@ jobs:
 
       - name: Run tests
         run: |
-          nix-shell --pure --run "run-tests --extended --term"
+          run_tests_args="--extended --term"
+          if [[ "${{ matrix.implementation }}" == "cython" ]]; then
+            run_tests_args="$run_tests_args --no-coverage --hard-exit"
+          fi
+          nix-shell --pure --run "run-tests $run_tests_args"

--- a/app/controllers/index.py
+++ b/app/controllers/index.py
@@ -27,6 +27,204 @@ from app.services.user_token_unsubscribe_service import UserTokenUnsubscribeServ
 
 router = APIRouter()
 
+_SOFTWARE_FILTERS = {
+    'category': (
+        {'value': 'editor', 'label': 'Editors'},
+        {'value': 'mobile_editor', 'label': 'Mobile editors'},
+        {'value': 'navigation', 'label': 'Navigation'},
+        {'value': 'analysis', 'label': 'Analysis'},
+        {'value': 'qa', 'label': 'Quality assurance'},
+        {'value': 'visualization', 'label': 'Visualization'},
+        {'value': 'imagery', 'label': 'Imagery'},
+    ),
+    'platform': (
+        {'value': 'web', 'label': 'Web'},
+        {'value': 'desktop', 'label': 'Desktop'},
+        {'value': 'android', 'label': 'Android'},
+        {'value': 'ios', 'label': 'iOS'},
+    ),
+    'license': (
+        {'value': 'open_source', 'label': 'Open source'},
+        {'value': 'proprietary', 'label': 'Proprietary'},
+    ),
+    'status': (
+        {'value': 'active', 'label': 'Active development'},
+        {'value': 'mature', 'label': 'Mature'},
+    ),
+}
+
+_SOFTWARE_FILTER_LABELS = {
+    key: {option['value']: option['label'] for option in options}
+    for key, options in _SOFTWARE_FILTERS.items()
+}
+
+_SOFTWARE_ITEMS = (
+    {
+        'name': 'iD',
+        'url': 'https://ideditor.com/',
+        'image': '/static/img/brand/id.webp',
+        'description': 'The default in-browser editor for quick OpenStreetMap edits.',
+        'category': 'editor',
+        'platforms': ('web',),
+        'license': 'open_source',
+        'status': 'active',
+    },
+    {
+        'name': 'Rapid',
+        'url': 'https://rapideditor.org/',
+        'image': '/static/img/brand/rapid.webp',
+        'description': 'A web editor with assisted mapping tools and modern workflows.',
+        'category': 'editor',
+        'platforms': ('web',),
+        'license': 'open_source',
+        'status': 'active',
+    },
+    {
+        'name': 'JOSM',
+        'url': 'https://josm.openstreetmap.de/',
+        'image': '/static/img/brand/josm.webp',
+        'description': 'A powerful desktop editor for advanced mapping and validation.',
+        'category': 'editor',
+        'platforms': ('desktop',),
+        'license': 'open_source',
+        'status': 'mature',
+    },
+    {
+        'name': 'Vespucci',
+        'url': 'https://vespucci.io/',
+        'image': '/static/img/favicon/256.webp',
+        'description': 'A full-featured OpenStreetMap editor for Android devices.',
+        'category': 'mobile_editor',
+        'platforms': ('android',),
+        'license': 'open_source',
+        'status': 'active',
+    },
+    {
+        'name': 'Go Map!!',
+        'url': 'https://gomaposm.com/',
+        'image': '/static/img/favicon/256.webp',
+        'description': 'An iOS editor for surveying and editing OpenStreetMap outdoors.',
+        'category': 'mobile_editor',
+        'platforms': ('ios',),
+        'license': 'open_source',
+        'status': 'active',
+    },
+    {
+        'name': 'StreetComplete',
+        'url': 'https://streetcomplete.app/',
+        'image': '/static/img/favicon/256.webp',
+        'description': 'A quest-based mobile editor for adding missing street details.',
+        'category': 'mobile_editor',
+        'platforms': ('android',),
+        'license': 'open_source',
+        'status': 'active',
+    },
+    {
+        'name': 'Every Door',
+        'url': 'https://every-door.app/',
+        'image': '/static/img/favicon/256.webp',
+        'description': 'A mobile editor focused on shops, amenities, entrances, and POIs.',
+        'category': 'mobile_editor',
+        'platforms': ('android', 'ios'),
+        'license': 'open_source',
+        'status': 'active',
+    },
+    {
+        'name': 'OsmAnd',
+        'url': 'https://osmand.net/',
+        'image': '/static/img/favicon/256.webp',
+        'description': 'Offline maps and navigation powered by OpenStreetMap data.',
+        'category': 'navigation',
+        'platforms': ('android', 'ios'),
+        'license': 'open_source',
+        'status': 'active',
+    },
+    {
+        'name': 'Organic Maps',
+        'url': 'https://organicmaps.app/',
+        'image': '/static/img/favicon/256.webp',
+        'description': 'Offline maps and routing for travelers, hikers, and cyclists.',
+        'category': 'navigation',
+        'platforms': ('android', 'ios'),
+        'license': 'open_source',
+        'status': 'active',
+    },
+    {
+        'name': 'QGIS',
+        'url': 'https://qgis.org/',
+        'image': '/static/img/favicon/256.webp',
+        'description': 'Desktop GIS software for analyzing and styling OpenStreetMap data.',
+        'category': 'analysis',
+        'platforms': ('desktop',),
+        'license': 'open_source',
+        'status': 'mature',
+    },
+    {
+        'name': 'Overpass Turbo',
+        'url': 'https://overpass-turbo.eu/',
+        'image': '/static/img/brand/overpass.webp',
+        'description': 'A web tool for querying and exploring OpenStreetMap data.',
+        'category': 'analysis',
+        'platforms': ('web',),
+        'license': 'open_source',
+        'status': 'mature',
+    },
+    {
+        'name': 'MapRoulette',
+        'url': 'https://maproulette.org/',
+        'image': '/static/img/favicon/256.webp',
+        'description': 'Task-based quality assurance and micro-mapping challenges.',
+        'category': 'qa',
+        'platforms': ('web',),
+        'license': 'open_source',
+        'status': 'active',
+    },
+    {
+        'name': 'uMap',
+        'url': 'https://umap.openstreetmap.fr/',
+        'image': '/static/img/favicon/256.webp',
+        'description': 'Create and share custom maps using OpenStreetMap backgrounds.',
+        'category': 'visualization',
+        'platforms': ('web',),
+        'license': 'open_source',
+        'status': 'active',
+    },
+    {
+        'name': 'Mapillary',
+        'url': 'https://www.mapillary.com/',
+        'image': '/static/img/favicon/256.webp',
+        'description': 'Street-level imagery collection and browsing for map improvement.',
+        'category': 'imagery',
+        'platforms': ('web', 'android', 'ios'),
+        'license': 'proprietary',
+        'status': 'active',
+    },
+)
+
+
+def _valid_software_filter(filter_name: str, value: str | None):
+    if value is None:
+        return ''
+    allowed = _SOFTWARE_FILTER_LABELS[filter_name]
+    return value if value in allowed else ''
+
+
+def _software_matches_filters(item: dict, selected: dict[str, str]):
+    category = selected['category']
+    if category and item['category'] != category:
+        return False
+
+    platform = selected['platform']
+    if platform and platform not in item['platforms']:
+        return False
+
+    license_ = selected['license']
+    if license_ and item['license'] != license_:
+        return False
+
+    status_ = selected['status']
+    return not status_ or item['status'] == status_
+
 
 @router.get('/')
 @router.get('/export')
@@ -162,6 +360,34 @@ async def about():
 @router.get('/help')
 async def help_():
     return await render_proto_page(HelpPage(), title_prefix=t('layouts.help'))
+
+
+@router.get('/software')
+async def software(
+    category: Annotated[str | None, Query()] = None,
+    platform: Annotated[str | None, Query()] = None,
+    license_: Annotated[str | None, Query(alias='license')] = None,
+    status_: Annotated[str | None, Query(alias='status')] = None,
+):
+    selected = {
+        'category': _valid_software_filter('category', category),
+        'platform': _valid_software_filter('platform', platform),
+        'license': _valid_software_filter('license', license_),
+        'status': _valid_software_filter('status', status_),
+    }
+    software_items = [
+        item for item in _SOFTWARE_ITEMS if _software_matches_filters(item, selected)
+    ]
+
+    return await render_response(
+        'software',
+        {
+            'SOFTWARE_FILTERS': _SOFTWARE_FILTERS,
+            'SOFTWARE_FILTER_LABELS': _SOFTWARE_FILTER_LABELS,
+            'SOFTWARE_ITEMS': software_items,
+            'SELECTED_FILTERS': selected,
+        },
+    )
 
 
 @router.get('/fixthemap')

--- a/app/views/help.tsx
+++ b/app/views/help.tsx
@@ -58,6 +58,12 @@ mountProtoPage(PageSchema, () => (
             {t("site.help.beginners_guide.description")}
           </HelpCard>
           <HelpCard
+            href="/software"
+            title={t("site.help.software.title")}
+          >
+            {t("site.help.software.description")}
+          </HelpCard>
+          <HelpCard
             href="https://wiki.openstreetmap.org"
             title={t("site.help.wiki.title")}
           >

--- a/app/views/software.html.jinja
+++ b/app/views/software.html.jinja
@@ -1,0 +1,116 @@
+{% extends '_base' %}
+{% block title_prefix %}{{ t('site.software.title') }} |{% endblock %}
+{% block body_class %}software-page{% endblock %}
+{% block body %}
+  <div class="content-header">
+    <div class="container">
+      <h1>{{ t('site.software.title') }}</h1>
+      <p class="lead mb-0">{{ t('site.software.description') }}</p>
+    </div>
+  </div>
+
+  <div class="content-body">
+    <div class="container">
+      <form
+        class="row g-3 align-items-end mb-4"
+        method="GET"
+        action="/software"
+      >
+        {% for filter_name, options in SOFTWARE_FILTERS.items() %}
+          <div class="col-sm-6 col-lg-3">
+            <label
+              class="form-label"
+              for="software-filter-{{ filter_name }}"
+            >
+              {{ t('site.software.filters.' ~ filter_name) }}
+            </label>
+            <select
+              class="form-select"
+              id="software-filter-{{ filter_name }}"
+              name="{{ filter_name }}"
+            >
+              <option value="">{{ t('site.software.filters.any') }}</option>
+              {% for option in options %}
+                <option
+                  value="{{ option.value }}"
+                  {% if SELECTED_FILTERS[filter_name] == option.value %}selected{% endif %}
+                >
+                  {{ option.label }}
+                </option>
+              {% endfor %}
+            </select>
+          </div>
+        {% endfor %}
+
+        <div class="col-sm-6 col-lg-3">
+          <button
+            class="btn btn-primary me-2"
+            type="submit"
+          >
+            {{ t('action.apply') }}
+          </button>
+          <a
+            class="btn btn-link"
+            href="/software"
+          >
+            {{ t('action.reset_filters') }}
+          </a>
+        </div>
+      </form>
+
+      {% if SOFTWARE_ITEMS %}
+        <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-3">
+          {% for item in SOFTWARE_ITEMS %}
+            <div class="col">
+              <article class="card h-100">
+                <div class="bg-body-secondary text-center p-4 border-bottom">
+                  <img
+                    class="img-fluid"
+                    src="{{ item.image }}"
+                    alt=""
+                    loading="lazy"
+                    draggable="false"
+                    style="max-height: 4rem"
+                  />
+                </div>
+                <div class="card-body d-flex flex-column">
+                  <h2 class="h5 card-title">
+                    <a
+                      class="stretched-link"
+                      href="{{ item.url }}"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      {{ item.name }}
+                    </a>
+                  </h2>
+                  <p class="card-text">{{ item.description }}</p>
+                  <div class="d-flex flex-wrap gap-1 mt-auto">
+                    <span class="badge text-bg-light">
+                      {{ SOFTWARE_FILTER_LABELS['category'][item.category] }}
+                    </span>
+                    {% for platform in item.platforms %}
+                      <span class="badge text-bg-light">
+                        {{ SOFTWARE_FILTER_LABELS['platform'][platform] }}
+                      </span>
+                    {% endfor %}
+                    <span class="badge text-bg-light">
+                      {{ SOFTWARE_FILTER_LABELS['license'][item.license] }}
+                    </span>
+                    <span class="badge text-bg-light">
+                      {{ SOFTWARE_FILTER_LABELS['status'][item.status] }}
+                    </span>
+                  </div>
+                </div>
+              </article>
+            </div>
+          {% endfor %}
+        </div>
+      {% else %}
+        <div class="alert alert-info mb-0">
+          {{ t('site.software.no_results') }}
+        </div>
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -232,7 +232,7 @@ settings:
   new_password: New password
   new_password_repeat: Repeat new password
   logout_from_browsers: Automatically logout from all other browsers
-  password_has_been_changed: Your password has been changed
+  password_has_beeen_changed: Your password has been changed
   enter_your_password_to_confirm: Enter your password to confirm
   active_sessions: Active sessions
   review_and_manage_your_active_login_sessions: Review and manage your active login sessions.
@@ -555,7 +555,7 @@ two_fa:
   recovery_codes_description: |-
     Recovery codes can be used to access your account if you lose access to your two-factor device.
   each_code_can_be_used_once: Each code can be used once.
-  generated_on_date: "Added on {{date}}"
+  generated_on_date: "Generated on {{date}}"
   save_recovery_codes_warning: |-
     Make sure to save these codes in a safe place. We will not show them again.
     If you lose access to your two-factor device and your recovery codes, you will lose access to your account.
@@ -646,7 +646,7 @@ action:
   updated: updated
   clear_markers: Clear markers
   show_more: Show more
-  show_less: Show_less
+  show_less: Show less
   remove_filter: Remove filter
   remove: Remove
   continue_reading: Continue reading

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -497,7 +497,7 @@ alt:
   background_image: Background image
   service_image: Service image
   passkey_icon: Passkey icon
-  image_of_planet_earth: Image of Planet Earth
+  image_of_planet_earth: Image of planet Earth
   new_note_icon: New note icon
 internalization:
   get_started: |-
@@ -555,7 +555,7 @@ two_fa:
   recovery_codes_description: |-
     Recovery codes can be used to access your account if you lose access to your two-factor device.
   each_code_can_be_used_once: Each code can be used once.
-  generated_on_date: "Generated on {{date}}"
+  generated_on_date: "Added on {{date}}"
   save_recovery_codes_warning: |-
     Make sure to save these codes in a safe place. We will not show them again.
     If you lose access to your two-factor device and your recovery codes, you will lose access to your account.
@@ -590,10 +590,10 @@ validation:
   passwords_missmatch: The passwords do not match
   you_must_be_logged_in_to_perform_this_action: You must be logged in to perform this action
   reached_app_limit: You have reached the maximum number of applications
-  too_many_redirect_uris: Too many Redirect URIs
+  too_many_redirect_uris: Too many redirect URIs
   redirect_uri_too_long: Redirect URI is too long
-  invalid_redirect_uri: Invalid Redirect URI
-  insecure_redirect_uri: Insecure Redirect URI, use https:// for public endpoints
+  invalid_redirect_uri: Invalid redirect URI
+  insecure_redirect_uri: Insecure redirect URI, use https:// for public endpoints
   cant_send_message_to_self: You can't send a message to yourself
   user_not_found: User {{user}} not found
   you_can_send_message_to_at_most_count_recipients: "You can send a message to at most {{count}} recipients"
@@ -646,7 +646,7 @@ action:
   updated: updated
   clear_markers: Clear markers
   show_more: Show more
-  show_less: Show less
+  show_less: Show_less
   remove_filter: Remove filter
   remove: Remove
   continue_reading: Continue reading

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -134,6 +134,25 @@ user:
     view_all: View full statistics
     less: Less
     more: More
+site:
+  software:
+    title: OpenStreetMap software
+    description: |-
+      Discover editors, mobile apps, navigation tools, analysis tools, and
+      quality assurance workflows built around OpenStreetMap.
+    no_results: No software matches these filters.
+    filters:
+      any: Any
+      category: Category
+      platform: Platform
+      license: License
+      status: Development status
+  help:
+    software:
+      title: OpenStreetMap software
+      description: |-
+        Find editors, mobile apps, navigation tools, and quality assurance
+        workflows.
 privacy:
   enable_activity_tracking:
     title: Enable activity tracking
@@ -478,7 +497,7 @@ alt:
   background_image: Background image
   service_image: Service image
   passkey_icon: Passkey icon
-  image_of_planet_earth: Image of planet Earth
+  image_of_planet_earth: Image of Planet Earth
   new_note_icon: New note icon
 internalization:
   get_started: |-
@@ -571,16 +590,17 @@ validation:
   passwords_missmatch: The passwords do not match
   you_must_be_logged_in_to_perform_this_action: You must be logged in to perform this action
   reached_app_limit: You have reached the maximum number of applications
-  too_many_redirect_uris: Too many redirect URIs
+  too_many_redirect_uris: Too many Redirect URIs
   redirect_uri_too_long: Redirect URI is too long
-  invalid_redirect_uri: Invalid redirect URI
-  insecure_redirect_uri: Insecure redirect URI, use https:// for public endpoints
+  invalid_redirect_uri: Invalid Redirect URI
+  insecure_redirect_uri: Insecure Redirect URI, use https:// for public endpoints
   cant_send_message_to_self: You can't send a message to yourself
   user_not_found: User {{user}} not found
   you_can_send_message_to_at_most_count_recipients: "You can send a message to at most {{count}} recipients"
   you_can_add_at_most_count_tags: "You can add at most {{count}} tags"
   incomplete_location_information: Incomplete location information
 action:
+  apply: Apply
   go_back: Go back
   authorize: Authorize
   block_user: Block user

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -232,7 +232,7 @@ settings:
   new_password: New password
   new_password_repeat: Repeat new password
   logout_from_browsers: Automatically logout from all other browsers
-  password_has_beeen_changed: Your password has been changed
+  password_has_been_changed: Your password has been changed
   enter_your_password_to_confirm: Enter your password to confirm
   active_sessions: Active sessions
   review_and_manage_your_active_login_sessions: Review and manage your active login sessions.

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -5,8 +5,6 @@ if [[ ! -S $PC_SOCKET_PATH ]]; then
 fi
 
 term_output=0
-coverage=1
-hard_exit=0
 args=(
   --verbose
   --no-header
@@ -15,13 +13,6 @@ args=(
 
 for arg in "$@"; do
   case "$arg" in
-  --hard-exit)
-    hard_exit=1
-    coverage=0
-    ;;
-  --no-coverage)
-    coverage=0
-    ;;
   --term)
     term_output=1
     ;;
@@ -32,41 +23,17 @@ for arg in "$@"; do
 done
 
 set +e
-if [[ $hard_exit == 1 ]]; then
-  (
-    set -x
-    python - "${args[@]}" <<'PY'
-import os
-import sys
-
-import pytest
-
-result = pytest.main(sys.argv[1:])
-sys.stdout.flush()
-sys.stderr.flush()
-os._exit(result)
-PY
-  )
-elif [[ $coverage == 1 ]]; then
-  (
-    set -x
-    python -m coverage run -m pytest "${args[@]}"
-  )
-else
-  (
-    set -x
-    python -m pytest "${args[@]}"
-  )
-fi
+(
+  set -x
+  python -m coverage run -m pytest "${args[@]}"
+)
 result=$?
 set -e
 
-if [[ $coverage == 1 ]]; then
-  if [[ $term_output == 1 ]]; then
-    python -m coverage report --skip-covered
-  else
-    python -m coverage xml --quiet
-  fi
-  python -m coverage erase
+if [[ $term_output == 1 ]]; then
+  python -m coverage report --skip-covered
+else
+  python -m coverage xml --quiet
 fi
+python -m coverage erase
 exit "$result"

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -5,6 +5,8 @@ if [[ ! -S $PC_SOCKET_PATH ]]; then
 fi
 
 term_output=0
+coverage=1
+hard_exit=0
 args=(
   --verbose
   --no-header
@@ -13,6 +15,13 @@ args=(
 
 for arg in "$@"; do
   case "$arg" in
+  --hard-exit)
+    hard_exit=1
+    coverage=0
+    ;;
+  --no-coverage)
+    coverage=0
+    ;;
   --term)
     term_output=1
     ;;
@@ -23,17 +32,41 @@ for arg in "$@"; do
 done
 
 set +e
-(
-  set -x
-  python -m coverage run -m pytest "${args[@]}"
-)
+if [[ $hard_exit == 1 ]]; then
+  (
+    set -x
+    python - "${args[@]}" <<'PY'
+import os
+import sys
+
+import pytest
+
+result = pytest.main(sys.argv[1:])
+sys.stdout.flush()
+sys.stderr.flush()
+os._exit(result)
+PY
+  )
+elif [[ $coverage == 1 ]]; then
+  (
+    set -x
+    python -m coverage run -m pytest "${args[@]}"
+  )
+else
+  (
+    set -x
+    python -m pytest "${args[@]}"
+  )
+fi
 result=$?
 set -e
 
-if [[ $term_output == 1 ]]; then
-  python -m coverage report --skip-covered
-else
-  python -m coverage xml --quiet
+if [[ $coverage == 1 ]]; then
+  if [[ $term_output == 1 ]]; then
+    python -m coverage report --skip-covered
+  else
+    python -m coverage xml --quiet
+  fi
+  python -m coverage erase
 fi
-python -m coverage erase
 exit "$result"

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -5,6 +5,8 @@ if [[ ! -S $PC_SOCKET_PATH ]]; then
 fi
 
 term_output=0
+coverage=1
+hard_exit=0
 args=(
   --verbose
   --no-header
@@ -13,6 +15,12 @@ args=(
 
 for arg in "$@"; do
   case "$arg" in
+  --hard-exit)
+    hard_exit=1
+    ;;
+  --no-coverage)
+    coverage=0
+    ;;
   --term)
     term_output=1
     ;;
@@ -23,17 +31,41 @@ for arg in "$@"; do
 done
 
 set +e
-(
-  set -x
-  python -m coverage run -m pytest "${args[@]}"
-)
+if [[ $hard_exit == 1 ]]; then
+  (
+    set -x
+    python - "${args[@]}" <<'PY'
+import os
+import sys
+
+import pytest
+
+result = pytest.main(sys.argv[1:])
+sys.stdout.flush()
+sys.stderr.flush()
+os._exit(result)
+PY
+  )
+elif [[ $coverage == 1 ]]; then
+  (
+    set -x
+    python -m coverage run -m pytest "${args[@]}"
+  )
+else
+  (
+    set -x
+    python -m pytest "${args[@]}"
+  )
+fi
 result=$?
 set -e
 
-if [[ $term_output == 1 ]]; then
-  python -m coverage report --skip-covered
-else
-  python -m coverage xml --quiet
+if [[ $coverage == 1 ]]; then
+  if [[ $term_output == 1 ]]; then
+    python -m coverage report --skip-covered
+  else
+    python -m coverage xml --quiet
+  fi
+  python -m coverage erase
 fi
-python -m coverage erase
 exit "$result"

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -17,6 +17,7 @@ for arg in "$@"; do
   case "$arg" in
   --hard-exit)
     hard_exit=1
+    coverage=0
     ;;
   --no-coverage)
     coverage=0


### PR DESCRIPTION
## Summary
- add a `/software` showcase page for OpenStreetMap-related editors, apps, navigation, analysis, QA, visualization, and imagery tools
- include filter controls for category, platform, license, and development status
- link the page from Help and add English copy

Fixes #24
/claim #24

## Testing
- `python3 -m py_compile app/controllers/index.py`
- `ruby -e 'require "yaml"; YAML.load_file("config/locale/extra_en.yaml"); puts "extra_en.yaml ok"'`
- `git diff --check`

## CI note
This branch includes the Cython runner workaround from #345 because upstream main's Cython job currently exits 134 after pytest under Python 3.14. Python jobs stay on the normal coverage path.