### PR TITLE
Add login provider shortcuts

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,8 +36,4 @@ jobs:
 
       - name: Run tests
         run: |
-          run_tests_args="--extended --term"
-          if [[ "${{ matrix.implementation }}" == "cython" ]]; then
-            run_tests_args="$run_tests_args --no-coverage --hard-exit"
-          fi
-          nix-shell --pure --run "run-tests $run_tests_args"
+          nix-shell --pure --run "run-tests --extended --term"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,4 +36,8 @@ jobs:
 
       - name: Run tests
         run: |
-          nix-shell --pure --run "run-tests --extended --term"
+          run_tests_args="--extended --term"
+          if [[ "${{ matrix.implementation }}" == "cython" ]]; then
+            run_tests_args="$run_tests_args --no-coverage --hard-exit"
+          fi
+          nix-shell --pure --run "run-tests $run_tests_args"

--- a/app/views/user/_login-body.scss
+++ b/app/views/user/_login-body.scss
@@ -35,11 +35,49 @@
   }
 
   .passkey-login {
+    width: 100%;
+
     img {
       position: relative;
       top: -1px;
       width: 0.875em;
       height: 0.875em;
+    }
+  }
+
+  .quick-login-options {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.5rem;
+    align-items: stretch;
+
+    @include media-breakpoint-down(sm) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .provider-shortcuts {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .provider-shortcut-form {
+    display: contents;
+  }
+
+  .provider-shortcut {
+    width: 2.5rem;
+    min-width: 2.5rem;
+    height: 100%;
+    min-height: 2.5rem;
+    padding: 0;
+
+    .auth-provider-icon {
+      width: 1.25rem;
+      height: 1.25rem;
+      font-size: 1.25rem;
+      line-height: 1;
+      object-fit: contain;
     }
   }
 

--- a/app/views/user/login.tsx
+++ b/app/views/user/login.tsx
@@ -1,4 +1,9 @@
 import type { MessageInitShape } from "@bufbuild/protobuf"
+import {
+  AuthProviderIcon,
+  CONFIGURED_PROVIDERS,
+  getAuthProviderTitle,
+} from "@components/auth-provider"
 import { StandardForm } from "@components/standard-form"
 import { useSignal } from "@preact/signals"
 import {
@@ -8,7 +13,7 @@ import {
   type PasskeyAssertion,
   Service,
 } from "@proto/auth_pb"
-import { Action } from "@proto/auth_provider_pb"
+import { Action, Service as AuthProviderService } from "@proto/auth_provider_pb"
 import { PageSchema as LoginPageSchema } from "@proto/login_pb"
 import { memoize } from "@std/cache/memoize"
 import { ENV } from "@utils/config"
@@ -23,7 +28,6 @@ import { render } from "preact"
 import type { MutableRef } from "preact/hooks"
 import { useEffect, useId, useRef } from "preact/hooks"
 import { getAuthProviderReferer } from "./_auth-provider-referer"
-import { AuthSwitcher } from "./_auth-switcher"
 import { TestSiteReminder } from "./_test-site-reminder"
 
 const NON_DIGIT_RE = /\D/g
@@ -43,6 +47,58 @@ enum SubmitMode {
 }
 
 const TEST_LOGINS = ["user1", "user2", "moderator", "admin"] as const
+
+const ProviderShortcutButton = ({
+  provider,
+  referer,
+}: {
+  provider: (typeof CONFIGURED_PROVIDERS)[number]
+  referer: string | undefined
+}) => {
+  const title = getAuthProviderTitle(provider)
+  const label = t("login.sign_in_with_service", { service: title })
+
+  return (
+    <StandardForm
+      class="provider-shortcut-form"
+      method={AuthProviderService.method.startAuthorize}
+      buildRequest={() => ({
+        provider,
+        action: Action.login,
+        referer,
+      })}
+    >
+      <button
+        class="btn btn-soft provider-shortcut"
+        type="submit"
+        aria-label={label}
+        title={label}
+      >
+        <AuthProviderIcon
+          provider={provider}
+          decorative
+        />
+      </button>
+    </StandardForm>
+  )
+}
+
+const ProviderShortcutList = ({ referer }: { referer: string | undefined }) =>
+  CONFIGURED_PROVIDERS.length ? (
+    <div
+      class="provider-shortcuts"
+      role="group"
+      aria-label={t("login.or_continue_with")}
+    >
+      {CONFIGURED_PROVIDERS.map((provider) => (
+        <ProviderShortcutButton
+          key={provider}
+          provider={provider}
+          referer={referer}
+        />
+      ))}
+    </div>
+  ) : null
 
 const MethodButton = ({
   icon,
@@ -446,7 +502,6 @@ const LoginCard = ({
   const isModal = modalRef !== undefined
   const referrer = getAuthProviderReferer()
   const loginState = useSignal(LoginState.credentials)
-  const showAuthProviders = useSignal(false)
   const formRef = useRef<HTMLFormElement>(null)
   const displayNameInputRef = useRef<HTMLInputElement>(null)
   const passwordInputRef = useRef<HTMLInputElement>(null)
@@ -482,7 +537,6 @@ const LoginCard = ({
     conditionalMediationAbortRef.current = undefined
     loginResponseRef.current = undefined
     loginState.value = LoginState.credentials
-    showAuthProviders.value = false
     credentialsRef.current = undefined
     submitModeRef.current = SubmitMode.none
     bypass2faRef.current = false
@@ -754,38 +808,33 @@ const LoginCard = ({
           </p>
         </div>
 
-        <AuthSwitcher
-          class="mb-2"
-          action={Action.login}
-          showProviders={showAuthProviders}
-          referer={referrer}
-        >
-          <>
-            {form}
+        {form}
 
-            <div class="divider my-3">
-              <span class="divider-text">{t("login.or_continue_with")}</span>
-            </div>
+        <div class="divider my-3">
+          <span class="divider-text">{t("login.or_continue_with")}</span>
+        </div>
 
-            <button
-              class="passkey-login btn btn-soft w-100"
-              type="button"
-              onClick={() => {
-                resetLoginState()
-                requestSubmitPasswordless()
-              }}
-            >
-              <img
-                class="dark-filter-invert me-1-5"
-                src="/static/img/brand/passkeys-black.webp"
-                alt={t("alt.passkey_icon")}
-                draggable={false}
-                loading="lazy"
-              />
-              {t("login.sign_in_with_a_passkey")}
-            </button>
-          </>
-        </AuthSwitcher>
+        <div class="quick-login-options">
+          <button
+            class="passkey-login btn btn-soft"
+            type="button"
+            onClick={() => {
+              resetLoginState()
+              requestSubmitPasswordless()
+            }}
+          >
+            <img
+              class="dark-filter-invert me-1-5"
+              src="/static/img/brand/passkeys-black.webp"
+              alt={t("alt.passkey_icon")}
+              draggable={false}
+              loading="lazy"
+            />
+            {t("login.sign_in_with_a_passkey")}
+          </button>
+
+          <ProviderShortcutList referer={referrer} />
+        </div>
       </div>
 
       {ENV !== "prod" && (

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -5,8 +5,6 @@ if [[ ! -S $PC_SOCKET_PATH ]]; then
 fi
 
 term_output=0
-coverage=1
-hard_exit=0
 args=(
   --verbose
   --no-header
@@ -15,13 +13,6 @@ args=(
 
 for arg in "$@"; do
   case "$arg" in
-  --hard-exit)
-    hard_exit=1
-    coverage=0
-    ;;
-  --no-coverage)
-    coverage=0
-    ;;
   --term)
     term_output=1
     ;;
@@ -32,41 +23,17 @@ for arg in "$@"; do
 done
 
 set +e
-if [[ $hard_exit == 1 ]]; then
-  (
-    set -x
-    python - "${args[@]}" <<'PY'
-import os
-import sys
-
-import pytest
-
-result = pytest.main(sys.argv[1:])
-sys.stdout.flush()
-sys.stderr.flush()
-os._exit(result)
-PY
-  )
-elif [[ $coverage == 1 ]]; then
-  (
-    set -x
-    python -m coverage run -m pytest "${args[@]}"
-  )
-else
-  (
-    set -x
-    python -m pytest "${args[@]}"
-  )
-fi
+(
+  set -x
+  python -m coverage run -m pytest "${args[@]}"
+)
 result=$?
 set -e
 
-if [[ $coverage == 1 ]]; then
-  if [[ $term_output == 1 ]]; then
-    python -m coverage report --skip-covered
-  else
-    python -m coverage xml --quiet
-  fi
-  python -m coverage erase
+if [[ $term_output == 1 ]]; then
+  python -m coverage report --skip-covered
+else
+  python -m coverage xml --quiet
 fi
+python -m coverage erase
 exit "$result"

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -5,6 +5,8 @@ if [[ ! -S $PC_SOCKET_PATH ]]; then
 fi
 
 term_output=0
+coverage=1
+hard_exit=0
 args=(
   --verbose
   --no-header
@@ -13,6 +15,13 @@ args=(
 
 for arg in "$@"; do
   case "$arg" in
+  --hard-exit)
+    hard_exit=1
+    coverage=0
+    ;;
+  --no-coverage)
+    coverage=0
+    ;;
   --term)
     term_output=1
     ;;
@@ -23,17 +32,41 @@ for arg in "$@"; do
 done
 
 set +e
-(
-  set -x
-  python -m coverage run -m pytest "${args[@]}"
-)
+if [[ $hard_exit == 1 ]]; then
+  (
+    set -x
+    python - "${args[@]}" <<'PY'
+import os
+import sys
+
+import pytest
+
+result = pytest.main(sys.argv[1:])
+sys.stdout.flush()
+sys.stderr.flush()
+os._exit(result)
+PY
+  )
+elif [[ $coverage == 1 ]]; then
+  (
+    set -x
+    python -m coverage run -m pytest "${args[@]}"
+  )
+else
+  (
+    set -x
+    python -m pytest "${args[@]}"
+  )
+fi
 result=$?
 set -e
 
-if [[ $term_output == 1 ]]; then
-  python -m coverage report --skip-covered
-else
-  python -m coverage xml --quiet
+if [[ $coverage == 1 ]]; then
+  if [[ $term_output == 1 ]]; then
+    python -m coverage report --skip-covered
+  else
+    python -m coverage xml --quiet
+  fi
+  python -m coverage erase
 fi
-python -m coverage erase
 exit "$result"

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -5,6 +5,8 @@ if [[ ! -S $PC_SOCKET_PATH ]]; then
 fi
 
 term_output=0
+coverage=1
+hard_exit=0
 args=(
   --verbose
   --no-header
@@ -13,6 +15,12 @@ args=(
 
 for arg in "$@"; do
   case "$arg" in
+  --hard-exit)
+    hard_exit=1
+    ;;
+  --no-coverage)
+    coverage=0
+    ;;
   --term)
     term_output=1
     ;;
@@ -23,17 +31,41 @@ for arg in "$@"; do
 done
 
 set +e
-(
-  set -x
-  python -m coverage run -m pytest "${args[@]}"
-)
+if [[ $hard_exit == 1 ]]; then
+  (
+    set -x
+    python - "${args[@]}" <<'PY'
+import os
+import sys
+
+import pytest
+
+result = pytest.main(sys.argv[1:])
+sys.stdout.flush()
+sys.stderr.flush()
+os._exit(result)
+PY
+  )
+elif [[ $coverage == 1 ]]; then
+  (
+    set -x
+    python -m coverage run -m pytest "${args[@]}"
+  )
+else
+  (
+    set -x
+    python -m pytest "${args[@]}"
+  )
+fi
 result=$?
 set -e
 
-if [[ $term_output == 1 ]]; then
-  python -m coverage report --skip-covered
-else
-  python -m coverage xml --quiet
+if [[ $coverage == 1 ]]; then
+  if [[ $term_output == 1 ]]; then
+    python -m coverage report --skip-covered
+  else
+    python -m coverage xml --quiet
+  fi
+  python -m coverage erase
 fi
-python -m coverage erase
 exit "$result"

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -17,6 +17,7 @@ for arg in "$@"; do
   case "$arg" in
   --hard-exit)
     hard_exit=1
+    coverage=0
     ;;
   --no-coverage)
     coverage=0


### PR DESCRIPTION
## Summary
- show configured third-party login providers as compact icon shortcuts in the existing "or continue with" section
- keep passkey sign-in as the primary alternative login option while reducing the extra provider-switching step
- keep provider shortcuts accessible with localized labels/titles

Addresses #45
/claim #45

## Testing
- `npx --yes prettier --config /dev/null --check --no-semi --single-attribute-per-line app/views/user/login.tsx app/views/user/_login-body.scss`
- `printf '{}\n' > /tmp/empty-oxlint.json && npx --yes oxlint -c /tmp/empty-oxlint.json app/views/user/login.tsx`
- `npx --yes esbuild app/views/user/login.tsx --loader:.tsx=tsx --format=esm --outfile=/tmp/osm-login-check.js --log-level=warning`
- `git diff --check`

## Notes
- The plain worktree does not have the repo's prettier/oxlint plugin dependencies installed, so formatter/linter checks were run with config loading disabled/minimal config.

## CI note
This branch includes the Cython runner workaround from #345 because upstream main's Cython job currently exits 134 after pytest under Python 3.14. Python jobs stay on the normal coverage path.