### PR TITLE
Reject null island node edits

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,8 +36,4 @@ jobs:
 
       - name: Run tests
         run: |
-          run_tests_args="--extended --term"
-          if [[ "${{ matrix.implementation }}" == "cython" ]]; then
-            run_tests_args="$run_tests_args --no-coverage --hard-exit"
-          fi
-          nix-shell --pure --run "run-tests $run_tests_args"
+          nix-shell --pure --run "run-tests --extended --term"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,4 +36,8 @@ jobs:
 
       - name: Run tests
         run: |
-          nix-shell --pure --run "run-tests --extended --term"
+          run_tests_args="--extended --term"
+          if [[ "${{ matrix.implementation }}" == "cython" ]]; then
+            run_tests_args="$run_tests_args --no-coverage --hard-exit"
+          fi
+          nix-shell --pure --run "run-tests $run_tests_args"

--- a/app/format/api06_element.py
+++ b/app/format/api06_element.py
@@ -371,6 +371,15 @@ def _decode_element_unsafe(
         and (lat := data.get('@lat')) is not None
         else None
     )
+    if (
+        type == 'node'
+        and data.get('@visible', True)
+        and point is not None
+        and point.x == 0
+        and point.y == 0
+    ):
+        raise ValueError('Nodes cannot be placed at null island')
+
     members = None
     members_roles = None
 

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -5,8 +5,6 @@ if [[ ! -S $PC_SOCKET_PATH ]]; then
 fi
 
 term_output=0
-coverage=1
-hard_exit=0
 args=(
   --verbose
   --no-header
@@ -15,13 +13,6 @@ args=(
 
 for arg in "$@"; do
   case "$arg" in
-  --hard-exit)
-    hard_exit=1
-    coverage=0
-    ;;
-  --no-coverage)
-    coverage=0
-    ;;
   --term)
     term_output=1
     ;;
@@ -32,41 +23,17 @@ for arg in "$@"; do
 done
 
 set +e
-if [[ $hard_exit == 1 ]]; then
-  (
-    set -x
-    python - "${args[@]}" <<'PY'
-import os
-import sys
-
-import pytest
-
-result = pytest.main(sys.argv[1:])
-sys.stdout.flush()
-sys.stderr.flush()
-os._exit(result)
-PY
-  )
-elif [[ $coverage == 1 ]]; then
-  (
-    set -x
-    python -m coverage run -m pytest "${args[@]}"
-  )
-else
-  (
-    set -x
-    python -m pytest "${args[@]}"
-  )
-fi
+(
+  set -x
+  python -m coverage run -m pytest "${args[@]}"
+)
 result=$?
 set -e
 
-if [[ $coverage == 1 ]]; then
-  if [[ $term_output == 1 ]]; then
-    python -m coverage report --skip-covered
-  else
-    python -m coverage xml --quiet
-  fi
-  python -m coverage erase
+if [[ $term_output == 1 ]]; then
+  python -m coverage report --skip-covered
+else
+  python -m coverage xml --quiet
 fi
+python -m coverage erase
 exit "$result"

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -5,6 +5,8 @@ if [[ ! -S $PC_SOCKET_PATH ]]; then
 fi
 
 term_output=0
+coverage=1
+hard_exit=0
 args=(
   --verbose
   --no-header
@@ -13,6 +15,13 @@ args=(
 
 for arg in "$@"; do
   case "$arg" in
+  --hard-exit)
+    hard_exit=1
+    coverage=0
+    ;;
+  --no-coverage)
+    coverage=0
+    ;;
   --term)
     term_output=1
     ;;
@@ -23,17 +32,41 @@ for arg in "$@"; do
 done
 
 set +e
-(
-  set -x
-  python -m coverage run -m pytest "${args[@]}"
-)
+if [[ $hard_exit == 1 ]]; then
+  (
+    set -x
+    python - "${args[@]}" <<'PY'
+import os
+import sys
+
+import pytest
+
+result = pytest.main(sys.argv[1:])
+sys.stdout.flush()
+sys.stderr.flush()
+os._exit(result)
+PY
+  )
+elif [[ $coverage == 1 ]]; then
+  (
+    set -x
+    python -m coverage run -m pytest "${args[@]}"
+  )
+else
+  (
+    set -x
+    python -m pytest "${args[@]}"
+  )
+fi
 result=$?
 set -e
 
-if [[ $term_output == 1 ]]; then
-  python -m coverage report --skip-covered
-else
-  python -m coverage xml --quiet
+if [[ $coverage == 1 ]]; then
+  if [[ $term_output == 1 ]]; then
+    python -m coverage report --skip-covered
+  else
+    python -m coverage xml --quiet
+  fi
+  python -m coverage erase
 fi
-python -m coverage erase
 exit "$result"

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -5,6 +5,8 @@ if [[ ! -S $PC_SOCKET_PATH ]]; then
 fi
 
 term_output=0
+coverage=1
+hard_exit=0
 args=(
   --verbose
   --no-header
@@ -13,6 +15,12 @@ args=(
 
 for arg in "$@"; do
   case "$arg" in
+  --hard-exit)
+    hard_exit=1
+    ;;
+  --no-coverage)
+    coverage=0
+    ;;
   --term)
     term_output=1
     ;;
@@ -23,17 +31,41 @@ for arg in "$@"; do
 done
 
 set +e
-(
-  set -x
-  python -m coverage run -m pytest "${args[@]}"
-)
+if [[ $hard_exit == 1 ]]; then
+  (
+    set -x
+    python - "${args[@]}" <<'PY'
+import os
+import sys
+
+import pytest
+
+result = pytest.main(sys.argv[1:])
+sys.stdout.flush()
+sys.stderr.flush()
+os._exit(result)
+PY
+  )
+elif [[ $coverage == 1 ]]; then
+  (
+    set -x
+    python -m coverage run -m pytest "${args[@]}"
+  )
+else
+  (
+    set -x
+    python -m pytest "${args[@]}"
+  )
+fi
 result=$?
 set -e
 
-if [[ $term_output == 1 ]]; then
-  python -m coverage report --skip-covered
-else
-  python -m coverage xml --quiet
+if [[ $coverage == 1 ]]; then
+  if [[ $term_output == 1 ]]; then
+    python -m coverage report --skip-covered
+  else
+    python -m coverage xml --quiet
+  fi
+  python -m coverage erase
 fi
-python -m coverage erase
 exit "$result"

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -17,6 +17,7 @@ for arg in "$@"; do
   case "$arg" in
   --hard-exit)
     hard_exit=1
+    coverage=0
     ;;
   --no-coverage)
     coverage=0

--- a/tests/controllers/test_api06_changeset.py
+++ b/tests/controllers/test_api06_changeset.py
@@ -132,7 +132,7 @@ async def test_changeset_upload(client: AsyncClient):
         content=XMLToDict.unparse({
             'osmChange': {
                 'create': [
-                    ('node', {'@id': -1, '@lat': 0, '@lon': 0}),
+                    ('node', {'@id': -1, '@lat': 1.0, '@lon': 1.0}),
                     ('way', {'@id': -1, 'nd': [{'@ref': -1}]}),
                 ]
             }
@@ -157,10 +157,10 @@ async def test_changeset_upload(client: AsyncClient):
             '@updated_at': datetime,
             '@closed_at': datetime,
             '@changes_count': 2,
-            '@min_lat': 0.0,
-            '@max_lat': 0.0,
-            '@min_lon': 0.0,
-            '@max_lon': 0.0,
+            '@min_lat': 1.0,
+            '@max_lat': 1.0,
+            '@min_lon': 1.0,
+            '@max_lon': 1.0,
         },
     )
 
@@ -285,7 +285,9 @@ async def test_changeset_upload_closed(client: AsyncClient):
     r = await client.post(
         f'/api/0.6/changeset/{changeset_id}/upload',
         content=XMLToDict.unparse({
-            'osmChange': {'create': [('node', {'@id': -1, '@lat': 0, '@lon': 0})]}
+            'osmChange': {
+                'create': [('node', {'@id': -1, '@lat': 1.0, '@lon': 1.0})]
+            }
         }),
     )
     assert r.status_code == status.HTTP_409_CONFLICT, r.text

--- a/tests/format/test_api06_element.py
+++ b/tests/format/test_api06_element.py
@@ -1,0 +1,37 @@
+import pytest
+
+from app.format import Format06
+
+
+def test_decode_node_rejects_null_island():
+    with pytest.raises(ValueError, match='null island'):
+        Format06.decode_elements([
+            (
+                'node',
+                {
+                    '@id': -1,
+                    '@changeset': 1,
+                    '@version': 0,
+                    '@lon': 0,
+                    '@lat': 0,
+                },
+            )
+        ])
+
+
+def test_decode_hidden_node_allows_null_island():
+    elements = Format06.decode_elements([
+        (
+            'node',
+            {
+                '@id': 1,
+                '@changeset': 1,
+                '@version': 1,
+                '@visible': False,
+                '@lon': 0,
+                '@lat': 0,
+            },
+        )
+    ])
+
+    assert elements[0]['point'] is None


### PR DESCRIPTION
## Summary
- reject visible node edits whose submitted coordinates round to 0,0
- keep hidden/deleted nodes from being blocked so bad existing data can still be removed
- add focused API 0.6 decode coverage for the null-island rejection

Fixes #128
/claim #128

## Testing
- `git diff --check`
- `python3 -m py_compile app/format/api06_element.py tests/format/test_api06_element.py`

## Notes
- Focused local pytest could not run because this machine's system Python has no repo test dependencies installed (`pytest` is missing), and `nix-shell` is unavailable here.

## CI note
This branch includes the Cython runner workaround from #345 because upstream main's Cython job currently exits 134 after pytest under Python 3.14. Python jobs stay on the normal coverage path.