### PR TITLE
Fix globe antimeridian geometry rendering

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,4 +36,8 @@ jobs:
 
       - name: Run tests
         run: |
-          nix-shell --pure --run "run-tests --extended --term"
+          run_tests_args="--extended --term"
+          if [[ "${{ matrix.implementation }}" == "cython" ]]; then
+            run_tests_args="$run_tests_args --no-coverage --hard-exit"
+          fi
+          nix-shell --pure --run "run-tests $run_tests_args"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,4 +36,8 @@ jobs:
 
       - name: Run tests
         run: |
-          nix-shell --pure --run "run-tests --extended --term"
+          if [[ "${{ matrix.implementation }}" == "cython" ]]; then
+            nix-shell --pure --run "run-tests --extended --term --no-coverage"
+          else
+            nix-shell --pure --run "run-tests --extended --term"
+          fi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,8 +36,4 @@ jobs:
 
       - name: Run tests
         run: |
-          if [[ "${{ matrix.implementation }}" == "cython" ]]; then
-            nix-shell --pure --run "run-tests --extended --term --no-coverage --hard-exit"
-          else
-            nix-shell --pure --run "run-tests --extended --term"
-          fi
+          nix-shell --pure --run "run-tests --extended --term"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Run tests
         run: |
           if [[ "${{ matrix.implementation }}" == "cython" ]]; then
-            nix-shell --pure --run "run-tests --extended --term --no-coverage"
+            nix-shell --pure --run "run-tests --extended --term --no-coverage --hard-exit"
           else
             nix-shell --pure --run "run-tests --extended --term"
           fi

--- a/app/views/index/distance.tsx
+++ b/app/views/index/distance.tsx
@@ -1,7 +1,7 @@
 import { SidebarHeader } from "@index/_action-sidebar"
 import { defineRoute } from "@index/router"
 import { fitBoundsIfNeeded } from "@map/bounds"
-import { closestPointOnSegment } from "@map/geometry"
+import { closestPointOnSegment, unwrapLongitude } from "@map/geometry"
 import { emptyFeatureCollection, type LayerId, layersConfig } from "@map/layers/layers"
 import { getMarkerIconElement, MARKER_ICON_ANCHOR, type MarkerColor } from "@map/marker"
 import { batch, type Signal, useSignal, useSignalEffect } from "@preact/signals"
@@ -145,15 +145,22 @@ const DistanceSidebar = ({
     markers.current[endIndex]!.label = null
   }
 
-  const updateLabel = (endIndex: number) => {
+  const getVisualSegment = (endIndex: number) => {
     assertGreater(endIndex, 0)
-    const startEntry = markers.current[endIndex - 1]!
-    const endEntry = markers.current[endIndex]!
-    const startLngLat = startEntry.marker.getLngLat()
-    const endLngLat = endEntry.marker.getLngLat()
+    const start = markers.current[endIndex - 1]!.marker.getLngLat()
+    const end = markers.current[endIndex]!.marker.getLngLat()
+    const visualEnd = {
+      lng: unwrapLongitude(end.lng, start.lng),
+      lat: end.lat,
+    }
+    return { start, end, visualEnd }
+  }
+
+  const updateLabel = (endIndex: number) => {
+    const { start: startLngLat, end: endLngLat, visualEnd } = getVisualSegment(endIndex)
 
     const startScreenPoint = map.project(startLngLat)
-    const endScreenPoint = map.project(endLngLat)
+    const endScreenPoint = map.project(visualEnd)
 
     // Calculate middle point
     // TODO: make sure this works correctly with 3d globe (#155)
@@ -173,7 +180,7 @@ const DistanceSidebar = ({
 
     const newDistance = startLngLat.distanceTo(endLngLat)
 
-    const label = endEntry.label!
+    const label = markers.current[endIndex]!.label!
     totalDistance.value = totalDistance.peek() + (newDistance - label.distance)
     label.distance = newDistance
     label.setLngLat(middlePoint)
@@ -182,12 +189,10 @@ const DistanceSidebar = ({
   }
 
   const segmentCoords = (endIndex: number) => {
-    assertGreater(endIndex, 0)
-    const startLngLat = markers.current[endIndex - 1]!.marker.getLngLat()
-    const endLngLat = markers.current[endIndex]!.marker.getLngLat()
+    const { start, visualEnd } = getVisualSegment(endIndex)
     return [
-      [startLngLat.lng, startLngLat.lat],
-      [endLngLat.lng, endLngLat.lat],
+      [start.lng, start.lat],
+      [visualEnd.lng, visualEnd.lat],
     ]
   }
 
@@ -463,13 +468,12 @@ const DistanceSidebar = ({
 
     const firstSegmentId = Number(features[0]!.id)
     const firstEndIndex = markerIdToIndex.get(firstSegmentId)!
-    const firstStartLngLat = markers.current[firstEndIndex - 1]!.marker.getLngLat()
-    const firstEndLngLat = markers.current[firstEndIndex]!.marker.getLngLat()
+    const firstSegment = getVisualSegment(firstEndIndex)
     let bestEndId = firstSegmentId
     let bestClosestPoint = closestPointOnSegment(
       hitPoint,
-      map.project(firstStartLngLat),
-      map.project(firstEndLngLat),
+      map.project(firstSegment.start),
+      map.project(firstSegment.visualEnd),
     )
     let bestDistanceSq =
       (bestClosestPoint.x - hitPoint.x) ** 2 + (bestClosestPoint.y - hitPoint.y) ** 2
@@ -477,12 +481,11 @@ const DistanceSidebar = ({
     for (let i = 1; i < features.length; i++) {
       const segmentId = Number(features[i]!.id)
       const endIndex = markerIdToIndex.get(segmentId)!
-      const startLngLat = markers.current[endIndex - 1]!.marker.getLngLat()
-      const endLngLat = markers.current[endIndex]!.marker.getLngLat()
+      const segment = getVisualSegment(endIndex)
       const closestPoint = closestPointOnSegment(
         hitPoint,
-        map.project(startLngLat),
-        map.project(endLngLat),
+        map.project(segment.start),
+        map.project(segment.visualEnd),
       )
       const distanceSq =
         (closestPoint.x - hitPoint.x) ** 2 + (closestPoint.y - hitPoint.y) ** 2

--- a/app/views/map/controls/location-filter.ts
+++ b/app/views/map/controls/location-filter.ts
@@ -98,10 +98,7 @@ export class LocationFilterControl implements IControl {
   }
 
   public getBounds() {
-    let [minLon, minLat, maxLon, maxLat] = this._bounds
-    if (minLon > maxLon) [minLon, maxLon] = [maxLon, minLon]
-    if (minLat > maxLat) [minLat, maxLat] = [maxLat, minLat]
-    return new LngLatBounds([minLon, minLat, maxLon, maxLat])
+    return new LngLatBounds(normalizeFilterBounds(this._bounds))
   }
 
   private _processMarkerUpdate(i: number) {
@@ -199,7 +196,7 @@ const createCornerElement = () => {
   return container
 }
 
-const getMaskData = ([minLon, minLat, maxLon, maxLat]: Bounds): Feature<Polygon> => {
+const normalizeFilterBounds = ([minLon, minLat, maxLon, maxLat]: Bounds): Bounds => {
   // Normalize latitude only. Longitude order carries antimeridian intent:
   // small inverted spans are normal handle inversions, while wider jumps should
   // remain dateline crossings and render as two mask holes.
@@ -208,6 +205,12 @@ const getMaskData = ([minLon, minLat, maxLon, maxLat]: Bounds): Feature<Polygon>
   if (minLat > maxLat) [minLat, maxLat] = [maxLat, minLat]
 
   maxLon = unwrapLongitude(maxLon, minLon)
+  return [minLon, minLat, maxLon, maxLat]
+}
+
+const getMaskData = (bounds: Bounds): Feature<Polygon> => {
+  let [minLon, minLat, maxLon, maxLat] = normalizeFilterBounds(bounds)
+
   minLon = wrapLongitude(minLon)
   maxLon = wrapLongitude(maxLon)
 

--- a/app/views/map/controls/location-filter.ts
+++ b/app/views/map/controls/location-filter.ts
@@ -9,6 +9,7 @@ import {
   type Map as MaplibreMap,
   Marker,
 } from "maplibre-gl"
+import { unwrapLongitude } from "../geometry"
 import { emptyFeatureCollection, type LayerId, layersConfig } from "../layers/layers"
 
 const LAYER_ID: LayerId = "location-filter" as LayerId
@@ -199,9 +200,14 @@ const createCornerElement = () => {
 }
 
 const getMaskData = ([minLon, minLat, maxLon, maxLat]: Bounds): Feature<Polygon> => {
-  // Normalize bounds
-  if (minLon > maxLon) [minLon, maxLon] = [maxLon, minLon]
+  // Normalize latitude only. Longitude order carries antimeridian intent:
+  // small inverted spans are normal handle inversions, while wider jumps should
+  // remain dateline crossings and render as two mask holes.
+  if (Math.abs(maxLon - minLon) < 180 && minLon > maxLon)
+    [minLon, maxLon] = [maxLon, minLon]
   if (minLat > maxLat) [minLat, maxLat] = [maxLat, minLat]
+
+  maxLon = unwrapLongitude(maxLon, minLon)
   minLon = wrapLongitude(minLon)
   maxLon = wrapLongitude(maxLon)
 

--- a/app/views/map/geometry.ts
+++ b/app/views/map/geometry.ts
@@ -1,6 +1,18 @@
 import { clamp } from "@std/math/clamp"
 import { Point } from "maplibre-gl"
 
+const WORLD_WIDTH_DEGREES = 360
+
+/**
+ * Return the copy of a longitude closest to a reference longitude.
+ *
+ * MapLibre accepts unwrapped longitude values. Keeping neighboring vertices in
+ * the same world copy prevents globe mode from rendering short antimeridian
+ * segments as lines that wrap around the earth.
+ */
+export const unwrapLongitude = (lon: number, referenceLon: number) =>
+  lon + Math.round((referenceLon - lon) / WORLD_WIDTH_DEGREES) * WORLD_WIDTH_DEGREES
+
 /** Get the closest point on a segment */
 export const closestPointOnSegment = (test: Point, start: Point, end: Point) => {
   const dx = end.x - start.x

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -6,6 +6,7 @@ fi
 
 term_output=0
 coverage=1
+hard_exit=0
 args=(
   --verbose
   --no-header
@@ -17,11 +18,12 @@ for arg in "$@"; do
   --term)
     term_output=1
     ;;
-  --hard-exit | --no-coverage)
+  --hard-exit)
     coverage=0
-    if [[ $arg == "--hard-exit" ]]; then
-      args+=("$arg")
-    fi
+    hard_exit=1
+    ;;
+  --no-coverage)
+    coverage=0
     ;;
   *)
     args+=("$arg")
@@ -34,6 +36,8 @@ set +e
   set -x
   if [[ $coverage == 1 ]]; then
     python -m coverage run -m pytest "${args[@]}"
+  elif [[ $hard_exit == 1 ]]; then
+    python -c 'import os, sys, pytest; os._exit(pytest.main(sys.argv[1:]))' "${args[@]}"
   else
     python -m pytest "${args[@]}"
   fi

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -5,6 +5,8 @@ if [[ ! -S $PC_SOCKET_PATH ]]; then
 fi
 
 term_output=0
+coverage=1
+hard_exit=0
 args=(
   --verbose
   --no-header
@@ -13,6 +15,13 @@ args=(
 
 for arg in "$@"; do
   case "$arg" in
+  --hard-exit)
+    hard_exit=1
+    coverage=0
+    ;;
+  --no-coverage)
+    coverage=0
+    ;;
   --term)
     term_output=1
     ;;
@@ -23,17 +32,41 @@ for arg in "$@"; do
 done
 
 set +e
-(
-  set -x
-  python -m coverage run -m pytest "${args[@]}"
-)
+if [[ $hard_exit == 1 ]]; then
+  (
+    set -x
+    python - "${args[@]}" <<'PY'
+import os
+import sys
+
+import pytest
+
+result = pytest.main(sys.argv[1:])
+sys.stdout.flush()
+sys.stderr.flush()
+os._exit(result)
+PY
+  )
+elif [[ $coverage == 1 ]]; then
+  (
+    set -x
+    python -m coverage run -m pytest "${args[@]}"
+  )
+else
+  (
+    set -x
+    python -m pytest "${args[@]}"
+  )
+fi
 result=$?
 set -e
 
-if [[ $term_output == 1 ]]; then
-  python -m coverage report --skip-covered
-else
-  python -m coverage xml --quiet
+if [[ $coverage == 1 ]]; then
+  if [[ $term_output == 1 ]]; then
+    python -m coverage report --skip-covered
+  else
+    python -m coverage xml --quiet
+  fi
+  python -m coverage erase
 fi
-python -m coverage erase
 exit "$result"

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -5,6 +5,7 @@ if [[ ! -S $PC_SOCKET_PATH ]]; then
 fi
 
 term_output=0
+coverage=1
 args=(
   --verbose
   --no-header
@@ -16,6 +17,10 @@ for arg in "$@"; do
   --term)
     term_output=1
     ;;
+  --hard-exit)
+    coverage=0
+    args+=("$arg")
+    ;;
   *)
     args+=("$arg")
     ;;
@@ -25,15 +30,21 @@ done
 set +e
 (
   set -x
-  python -m coverage run -m pytest "${args[@]}"
+  if [[ $coverage == 1 ]]; then
+    python -m coverage run -m pytest "${args[@]}"
+  else
+    python -m pytest "${args[@]}"
+  fi
 )
 result=$?
 set -e
 
-if [[ $term_output == 1 ]]; then
-  python -m coverage report --skip-covered
-else
-  python -m coverage xml --quiet
+if [[ $coverage == 1 ]]; then
+  if [[ $term_output == 1 ]]; then
+    python -m coverage report --skip-covered
+  else
+    python -m coverage xml --quiet
+  fi
+  python -m coverage erase
 fi
-python -m coverage erase
 exit "$result"

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -17,9 +17,11 @@ for arg in "$@"; do
   --term)
     term_output=1
     ;;
-  --hard-exit)
+  --hard-exit | --no-coverage)
     coverage=0
-    args+=("$arg")
+    if [[ $arg == "--hard-exit" ]]; then
+      args+=("$arg")
+    fi
     ;;
   *)
     args+=("$arg")

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -5,8 +5,6 @@ if [[ ! -S $PC_SOCKET_PATH ]]; then
 fi
 
 term_output=0
-coverage=1
-hard_exit=0
 args=(
   --verbose
   --no-header
@@ -18,13 +16,6 @@ for arg in "$@"; do
   --term)
     term_output=1
     ;;
-  --hard-exit)
-    coverage=0
-    hard_exit=1
-    ;;
-  --no-coverage)
-    coverage=0
-    ;;
   *)
     args+=("$arg")
     ;;
@@ -34,23 +25,15 @@ done
 set +e
 (
   set -x
-  if [[ $coverage == 1 ]]; then
-    python -m coverage run -m pytest "${args[@]}"
-  elif [[ $hard_exit == 1 ]]; then
-    python -c 'import os, sys, pytest; os._exit(pytest.main(sys.argv[1:]))' "${args[@]}"
-  else
-    python -m pytest "${args[@]}"
-  fi
+  python -m coverage run -m pytest "${args[@]}"
 )
 result=$?
 set -e
 
-if [[ $coverage == 1 ]]; then
-  if [[ $term_output == 1 ]]; then
-    python -m coverage report --skip-covered
-  else
-    python -m coverage xml --quiet
-  fi
-  python -m coverage erase
+if [[ $term_output == 1 ]]; then
+  python -m coverage report --skip-covered
+else
+  python -m coverage xml --quiet
 fi
+python -m coverage erase
 exit "$result"


### PR DESCRIPTION
Fixes #161
/claim #161

## Summary
- Render distance-tool segments with the nearest unwrapped longitude copy so globe mode chooses the short antimeridian path.
- Use the same visual segment for distance labels and ghost-marker insertion hit testing.
- Preserve antimeridian intent in the location-filter mask instead of normalizing wide crossings into the long way around.

## Tests
- `git diff --check`
- Parsed touched TS/TSX files with `@babel/parser`
- `tsc --noEmit` attempted locally; blocked by missing generated `@proto/*` outputs and unrelated fresh-clone type errors before this change set.

## CI note
This branch includes the Cython runner workaround from #345 because upstream main's Cython job currently exits 134 after pytest under Python 3.14. Python jobs stay on the normal coverage path.