### PR TITLE
Add configurable element history limit

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,4 +36,8 @@ jobs:
 
       - name: Run tests
         run: |
-          nix-shell --pure --run "run-tests --extended --term"
+          if [[ "${{ matrix.implementation }}" == "cython" ]]; then
+            nix-shell --pure --run "run-tests --extended --term --no-coverage --hard-exit"
+          else
+            nix-shell --pure --run "run-tests --extended --term"
+          fi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,4 +36,8 @@ jobs:
 
       - name: Run tests
         run: |
-          nix-shell --pure --run "run-tests --extended --term"
+          run_tests_args="--extended --term"
+          if [[ "${{ matrix.implementation }}" == "cython" ]]; then
+            run_tests_args="$run_tests_args --no-coverage --hard-exit"
+          fi
+          nix-shell --pure --run "run-tests $run_tests_args"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,8 +36,4 @@ jobs:
 
       - name: Run tests
         run: |
-          if [[ "${{ matrix.implementation }}" == "cython" ]]; then
-            nix-shell --pure --run "run-tests --extended --term --no-coverage --hard-exit"
-          else
-            nix-shell --pure --run "run-tests --extended --term"
-          fi
+          nix-shell --pure --run "run-tests --extended --term"

--- a/app/models/proto/element.proto
+++ b/app/models/proto/element.proto
@@ -45,6 +45,7 @@ message GetHistoryRequest {
   StandardPaginationRequest state = 1;
   ElementRef element = 2 [(buf.validate.field).required = true];
   bool tags_diff = 3;
+  uint32 limit = 4;
 }
 
 message GetHistoryResponse {

--- a/app/rpc/element.py
+++ b/app/rpc/element.py
@@ -49,6 +49,8 @@ from app.queries.element_query import ElementQuery
 from app.queries.user_query import UserQuery
 from speedup import split_typed_element_id, typed_element_id
 
+_ELEMENT_HISTORY_PAGE_SIZE_MAX = 100
+
 
 class _Service(Service):
     @override
@@ -116,6 +118,10 @@ class _Service(Service):
         element_type = ElementType.Name(request.element.type)
         id = ElementId(request.element.id)
         tid = typed_element_id(element_type, id)
+        page_size = min(
+            max(request.limit or ELEMENT_HISTORY_PAGE_SIZE, 1),
+            _ELEMENT_HISTORY_PAGE_SIZE_MAX,
+        )
 
         elements, state = await sp_paginate_query(
             Element,
@@ -125,7 +131,7 @@ class _Service(Service):
             where=t'typed_id = {tid}',
             cursor_key='sequence_id',
             id_key='version',
-            page_size=ELEMENT_HISTORY_PAGE_SIZE,
+            page_size=page_size,
             cursor_kind='id',
             order_dir='desc',
         )
@@ -138,7 +144,7 @@ class _Service(Service):
         num_items = state.snapshot_max_id
         state.known_total.num_items = num_items
         state.known_total.num_pages = sp_num_pages(
-            num_items=num_items, page_size=ELEMENT_HISTORY_PAGE_SIZE
+            num_items=num_items, page_size=page_size
         )
 
         if not elements:

--- a/app/views/index/element-history.tsx
+++ b/app/views/index/element-history.tsx
@@ -14,14 +14,45 @@ import {
 import { defineRoute } from "@index/router"
 import { focusObjects } from "@map/layers/focus-layer"
 import { convertRenderElementsData } from "@map/render-objects"
-import type { ReadonlySignal } from "@preact/signals"
+import { type ReadonlySignal, useSignal, useSignalEffect } from "@preact/signals"
 import { type DataValid, Service } from "@proto/element_pb"
 import { ElementType } from "@proto/shared_pb"
 import { setPageTitle } from "@runtime/title"
 import { tagsDiffStorage } from "@utils/local-storage"
+import { queryParam } from "@utils/path-codecs"
+import {
+  currentUrlSignal,
+  readUrlQueryParam,
+  updateUrlQueryParam,
+} from "@utils/url-state"
 import { t } from "i18next"
 import type { Map as MaplibreMap } from "maplibre-gl"
 import { useEffect, useRef } from "preact/hooks"
+
+const DEFAULT_HISTORY_LIMIT = 10
+const HISTORY_LIMIT_MIN = 1
+const HISTORY_LIMIT_MAX = 100
+const HISTORY_LIMIT_QUERY = queryParam.positiveInt()
+
+const normalizeHistoryLimit = (value: number | undefined) => {
+  if (value === undefined) return
+  const limit = Math.min(
+    Math.max(Math.trunc(value), HISTORY_LIMIT_MIN),
+    HISTORY_LIMIT_MAX,
+  )
+  return limit === DEFAULT_HISTORY_LIMIT ? undefined : limit
+}
+
+const readHistoryLimit = (url?: URL) =>
+  normalizeHistoryLimit(readUrlQueryParam("limit", HISTORY_LIMIT_QUERY, url))
+
+const updateHistoryLimit = (value: number | undefined) =>
+  updateUrlQueryParam(
+    "limit",
+    HISTORY_LIMIT_QUERY,
+    normalizeHistoryLimit(value),
+    "replace",
+  )
 
 const getPageTitle = (type: ElementTypeSlug, id: string) => {
   switch (type) {
@@ -84,11 +115,16 @@ const ElementHistorySidebar = ({
   id: ReadonlySignal<bigint>
 }) => {
   const title = getPageTitle(type.value, id.toString())
+  const limit = useSignal(readHistoryLimit())
 
   setPageTitle(title)
 
   // Effect: unfocus on unmount
   useEffect(() => () => focusObjects(map), [])
+  useSignalEffect(() => {
+    const value = readHistoryLimit(currentUrlSignal.value)
+    if (limit.peek() !== value) limit.value = value
+  })
 
   return (
     <div class="sidebar-content">
@@ -113,6 +149,23 @@ const ElementHistorySidebar = ({
               </BTooltip>
             </label>
           </div>
+          <label class="form-label small text-body-secondary mb-0 ms-1">
+            {t("element.versions_per_page", { defaultValue: "Versions per page" })}
+            <input
+              class="form-control form-control-sm mt-1"
+              type="number"
+              min={HISTORY_LIMIT_MIN}
+              max={HISTORY_LIMIT_MAX}
+              step={1}
+              value={limit.value ?? DEFAULT_HISTORY_LIMIT}
+              onChange={(e) => {
+                const value = e.currentTarget.valueAsNumber
+                const next = Number.isFinite(value) ? value : undefined
+                limit.value = normalizeHistoryLimit(next)
+                updateHistoryLimit(next)
+              }}
+            />
+          </label>
         </SidebarHeader>
       </div>
 
@@ -121,6 +174,7 @@ const ElementHistorySidebar = ({
         request={{
           element: { type: ElementType[type.value], id: id.value },
           tagsDiff: tagsDiffStorage.value,
+          ...(limit.value === undefined ? {} : { limit: limit.value }),
         }}
         urlKey="page"
         ariaLabel={t("alt.elements_page_navigation")}

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -5,8 +5,6 @@ if [[ ! -S $PC_SOCKET_PATH ]]; then
 fi
 
 term_output=0
-coverage=1
-hard_exit=0
 args=(
   --verbose
   --no-header
@@ -18,12 +16,6 @@ for arg in "$@"; do
   --term)
     term_output=1
     ;;
-  --no-coverage)
-    coverage=0
-    ;;
-  --hard-exit)
-    hard_exit=1
-    ;;
   *)
     args+=("$arg")
     ;;
@@ -33,23 +25,15 @@ done
 set +e
 (
   set -x
-  if [[ $hard_exit == 1 ]]; then
-    python -c 'import os, sys, pytest; os._exit(pytest.main(sys.argv[1:]))' "${args[@]}"
-  elif [[ $coverage == 1 ]]; then
-    python -m coverage run -m pytest "${args[@]}"
-  else
-    python -m pytest "${args[@]}"
-  fi
+  python -m coverage run -m pytest "${args[@]}"
 )
 result=$?
 set -e
 
-if [[ $coverage == 1 ]]; then
-  if [[ $term_output == 1 ]]; then
-    python -m coverage report --skip-covered
-  else
-    python -m coverage xml --quiet
-  fi
-  python -m coverage erase
+if [[ $term_output == 1 ]]; then
+  python -m coverage report --skip-covered
+else
+  python -m coverage xml --quiet
 fi
+python -m coverage erase
 exit "$result"

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -5,6 +5,8 @@ if [[ ! -S $PC_SOCKET_PATH ]]; then
 fi
 
 term_output=0
+coverage=1
+hard_exit=0
 args=(
   --verbose
   --no-header
@@ -16,6 +18,12 @@ for arg in "$@"; do
   --term)
     term_output=1
     ;;
+  --no-coverage)
+    coverage=0
+    ;;
+  --hard-exit)
+    hard_exit=1
+    ;;
   *)
     args+=("$arg")
     ;;
@@ -25,15 +33,23 @@ done
 set +e
 (
   set -x
-  python -m coverage run -m pytest "${args[@]}"
+  if [[ $hard_exit == 1 ]]; then
+    python -c 'import os, sys, pytest; os._exit(pytest.main(sys.argv[1:]))' "${args[@]}"
+  elif [[ $coverage == 1 ]]; then
+    python -m coverage run -m pytest "${args[@]}"
+  else
+    python -m pytest "${args[@]}"
+  fi
 )
 result=$?
 set -e
 
-if [[ $term_output == 1 ]]; then
-  python -m coverage report --skip-covered
-else
-  python -m coverage xml --quiet
+if [[ $coverage == 1 ]]; then
+  if [[ $term_output == 1 ]]; then
+    python -m coverage report --skip-covered
+  else
+    python -m coverage xml --quiet
+  fi
+  python -m coverage erase
 fi
-python -m coverage erase
 exit "$result"

--- a/shellscripts/run-tests.sh
+++ b/shellscripts/run-tests.sh
@@ -5,6 +5,8 @@ if [[ ! -S $PC_SOCKET_PATH ]]; then
 fi
 
 term_output=0
+coverage=1
+hard_exit=0
 args=(
   --verbose
   --no-header
@@ -13,6 +15,13 @@ args=(
 
 for arg in "$@"; do
   case "$arg" in
+  --hard-exit)
+    hard_exit=1
+    coverage=0
+    ;;
+  --no-coverage)
+    coverage=0
+    ;;
   --term)
     term_output=1
     ;;
@@ -23,17 +32,41 @@ for arg in "$@"; do
 done
 
 set +e
-(
-  set -x
-  python -m coverage run -m pytest "${args[@]}"
-)
+if [[ $hard_exit == 1 ]]; then
+  (
+    set -x
+    python - "${args[@]}" <<'PY'
+import os
+import sys
+
+import pytest
+
+result = pytest.main(sys.argv[1:])
+sys.stdout.flush()
+sys.stderr.flush()
+os._exit(result)
+PY
+  )
+elif [[ $coverage == 1 ]]; then
+  (
+    set -x
+    python -m coverage run -m pytest "${args[@]}"
+  )
+else
+  (
+    set -x
+    python -m pytest "${args[@]}"
+  )
+fi
 result=$?
 set -e
 
-if [[ $term_output == 1 ]]; then
-  python -m coverage report --skip-covered
-else
-  python -m coverage xml --quiet
+if [[ $coverage == 1 ]]; then
+  if [[ $term_output == 1 ]]; then
+    python -m coverage report --skip-covered
+  else
+    python -m coverage xml --quiet
+  fi
+  python -m coverage erase
 fi
-python -m coverage erase
 exit "$result"


### PR DESCRIPTION
## Summary
- Add an optional `limit` field to element history requests and clamp page sizes to `1..100` server-side while preserving the default page size.
- Add a history sidebar "Versions per page" input backed by `?limit=` so the pagination request reloads with the selected page size.

Fixes #15

/claim #15

## Verification
- `git diff --check`
- `bash -n shellscripts/proto-pipeline.sh`
- `buf format --diff --path app/models/proto/element.proto`
- `buf lint --path app/models/proto/element.proto`
- TSX parse check for `app/views/index/element-history.tsx`
- `tsc --noEmit` attempted with generated TS bindings; blocked by pre-existing unrelated type errors in `query-features.tsx`, `search.tsx`, `utils/i18n.ts`, and third-party zod sources.

## CI note
This branch includes the Cython runner workaround from #345 because upstream main's Cython job currently exits 134 after pytest under Python 3.14. Python jobs stay on the normal coverage path.