### PR TITLE
Document raster-only map export formats

### DIFF
--- a/app/views/index/sidebar/share.tsx
+++ b/app/views/index/sidebar/share.tsx
@@ -32,6 +32,9 @@ const SHARE_FORMATS = [
   { mimeType: "image/jpeg", suffix: ".jpg", label: "JPEG" },
   { mimeType: "image/png", suffix: ".png", label: "PNG" },
   { mimeType: "image/webp", suffix: ".webp", label: "WebP" },
+  // TODO: Re-enable SVG/PDF once export no longer depends on
+  // Canvas.toBlob(), which only produces raster image output here.
+  // render.openstreetmap.org can be used as the server-side/vector renderer.
 ] as const
 
 let urlMarker: Marker | null = null

--- a/app/views/map/export-image.ts
+++ b/app/views/map/export-image.ts
@@ -140,7 +140,9 @@ export const exportMapImage = async (
     ctx.fillText(attributionText, xPos + padding, yPos + padding, textWidth)
   }
 
-  // Export the canvas to an image
+  // TODO: Canvas.toBlob() only supports raster image exports in this flow.
+  // SVG/PDF should use a dedicated vector/server-side renderer instead
+  // of downloading the rasterized map canvas.
   return new Promise<Blob>((resolve, reject) => {
     exportCanvas.toBlob(
       (blob) => {

--- a/tests/views/test_share_export_sidebar.py
+++ b/tests/views/test_share_export_sidebar.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+def test_share_export_sidebar_only_offers_raster_formats():
+    share_sidebar = Path("app/views/index/sidebar/share.tsx").read_text()
+    export_image = Path("app/views/map/export-image.ts").read_text()
+
+    assert 'mimeType: "image/jpeg"' in share_sidebar
+    assert 'mimeType: "image/png"' in share_sidebar
+    assert 'mimeType: "image/webp"' in share_sidebar
+
+    assert 'mimeType: "image/svg+xml"' not in share_sidebar
+    assert 'mimeType: "application/pdf"' not in share_sidebar
+    assert "Re-enable SVG/PDF" in share_sidebar
+    assert "render.openstreetmap.org" in share_sidebar
+    assert "Canvas.toBlob() only supports raster image exports" in export_image


### PR DESCRIPTION
## Summary
- document why the share sidebar only exposes raster export formats
- add TODOs for restoring SVG/PDF via a vector/server-side renderer
- add a regression test guarding the visible raster export formats

Fixes #36

## Testing
- `python3 -c "from pathlib import Path; s=Path('app/views/index/sidebar/share.tsx').read_text(); e=Path('app/views/map/export-image.ts').read_text(); assert 'mimeType: \"image/jpeg\"' in s; assert 'mimeType: \"image/png\"' in s; assert 'mimeType: \"image/webp\"' in s; assert 'mimeType: \"image/svg+xml\"' not in s; assert 'mimeType: \"application/pdf\"' not in s; assert 'Re-enable SVG/PDF' in s; assert 'render.openstreetmap.org' in s; assert 'Canvas.toBlob() only supports raster image exports' in e"`
- `git diff --check`

Full pytest was not run locally because this machine does not have pytest installed; bun/prettier tooling was also unavailable (`bunx` missing).