### PR TITLE
feat: tag web-created notes with #osm-ng hashtag

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -285,6 +285,9 @@ OPTIMISTIC_DIFF_RETRY_TIMEOUT = timedelta(seconds=30)
 
 # Notes
 NOTE_FRESHLY_CLOSED_TIMEOUT = timedelta(days=7)
+# Hashtag appended to notes opened through the OSM-NG web frontend, identifying
+# the creating application (similar to how editors tag their notes).
+NOTE_CREATED_BY_HASHTAG = '#osm-ng'
 NOTE_QUERY_AREA_MAX_SIZE = 25.0  # in square degrees
 NOTE_QUERY_DEFAULT_LIMIT = 100
 NOTE_QUERY_DEFAULT_CLOSED = 7.0  # open + max 7 days closed

--- a/app/rpc/note.py
+++ b/app/rpc/note.py
@@ -143,7 +143,10 @@ class _Service(NoteServiceConnect):
     @override
     async def create(self, request: CreateRequest, ctx: RequestContext):
         note_id = await NoteService.create(
-            request.location.lon, request.location.lat, request.body
+            request.location.lon,
+            request.location.lat,
+            request.body,
+            append_app_hashtag=True,
         )
         return CreateResponse(id=note_id)
 

--- a/app/services/note_service.py
+++ b/app/services/note_service.py
@@ -5,6 +5,7 @@ from typing import Any
 import cython
 from shapely import Point, get_coordinates
 
+from app.config import NOTE_CREATED_BY_HASHTAG
 from app.db import db, db_fetchone, db_insert, db_update
 from app.exceptions.context import raise_for
 from app.lib.audit import audit
@@ -30,8 +31,15 @@ from app.validators.geometry import validate_geometry
 
 class NoteService:
     @staticmethod
-    async def create(lon: float, lat: float, text: str) -> NoteId:
-        """Create a note and return its id."""
+    async def create(
+        lon: float, lat: float, text: str, *, append_app_hashtag: bool = False
+    ) -> NoteId:
+        """
+        Create a note and return its id.
+
+        When ``append_app_hashtag`` is set, the application hashtag is appended to
+        the opening comment, identifying notes created through the OSM-NG frontend.
+        """
         point = validate_geometry(Point(lon, lat))
 
         user = auth_user()
@@ -45,6 +53,15 @@ class NoteService:
         else:
             user_id = None
             user_ip = get_request_ip()
+
+        if append_app_hashtag and NOTE_CREATED_BY_HASHTAG not in text:
+            body = (
+                f'{text}\n{NOTE_CREATED_BY_HASHTAG}'
+                if text
+                else NOTE_CREATED_BY_HASHTAG
+            )
+        else:
+            body = text
 
         async with db(True) as conn:
             note_id: NoteId
@@ -63,7 +80,7 @@ class NoteService:
                     'user_ip': user_ip,
                     'note_id': note_id,
                     'event': 'opened',
-                    'body': text,
+                    'body': body,
                     'created_at': note_created_at,
                 },
                 conn=conn,

--- a/tests/services/test_note_service.py
+++ b/tests/services/test_note_service.py
@@ -1,0 +1,46 @@
+from app.config import NOTE_CREATED_BY_HASHTAG
+from app.lib.auth.context import auth_context
+from app.models.types import DisplayName
+from app.queries.note_query import NoteCommentQuery
+from app.queries.user_query import UserQuery
+from app.services.note_service import NoteService
+
+
+async def test_note_create_appends_app_hashtag():
+    user = await UserQuery.find_by_display_name(DisplayName('user1'))
+    with auth_context(user, frozenset(('web_user',))):
+        text = test_note_create_appends_app_hashtag.__qualname__
+        note_id = await NoteService.create(0, 0, text, append_app_hashtag=True)
+        header = await NoteCommentQuery.find_header(note_id)
+        assert header is not None
+        assert header['event'] == 'opened'
+        assert header['body'] == f'{text}\n{NOTE_CREATED_BY_HASHTAG}'
+
+
+async def test_note_create_appends_app_hashtag_empty_text():
+    user = await UserQuery.find_by_display_name(DisplayName('user1'))
+    with auth_context(user, frozenset(('web_user',))):
+        note_id = await NoteService.create(0, 0, '', append_app_hashtag=True)
+        header = await NoteCommentQuery.find_header(note_id)
+        assert header is not None
+        assert header['body'] == NOTE_CREATED_BY_HASHTAG
+
+
+async def test_note_create_appends_app_hashtag_idempotent():
+    user = await UserQuery.find_by_display_name(DisplayName('user1'))
+    with auth_context(user, frozenset(('web_user',))):
+        text = f'already tagged {NOTE_CREATED_BY_HASHTAG}'
+        note_id = await NoteService.create(0, 0, text, append_app_hashtag=True)
+        header = await NoteCommentQuery.find_header(note_id)
+        assert header is not None
+        assert header['body'] == text
+
+
+async def test_note_create_without_flag_keeps_text_verbatim():
+    user = await UserQuery.find_by_display_name(DisplayName('user1'))
+    with auth_context(user, frozenset(('web_user',))):
+        text = test_note_create_without_flag_keeps_text_verbatim.__qualname__
+        note_id = await NoteService.create(0, 0, text)
+        header = await NoteCommentQuery.find_header(note_id)
+        assert header is not None
+        assert header['body'] == text


### PR DESCRIPTION
## Summary

Notes opened through the OSM-NG **web frontend** now include an application hashtag (`#osm-ng`) in their opening comment, identifying the application that created the note — mirroring how editors tag the notes they create.

Resolves #76

## Design

- The hashtag is appended **only on the web/RPC path** (`app/rpc/note.py` → `NoteService.create(..., append_app_hashtag=True)`).
- Notes created via the **0.6 API** (`app/controllers/api06_note.py`) by third-party clients keep their text **verbatim** — they are not OSM-NG-created, so tagging them would be incorrect and would also change the public API's stored note text.
- Appending is **idempotent** (no double-tag if the text already contains the hashtag) and **empty-text safe** (a note with no text becomes just the hashtag).
- The hashtag string is configurable via `NOTE_CREATED_BY_HASHTAG` in `app/config.py`.

## Changes

- `app/config.py`: add `NOTE_CREATED_BY_HASHTAG = '#osm-ng'`.
- `app/services/note_service.py`: `create()` gains a keyword-only `append_app_hashtag: bool = False`; builds the opening-comment body idempotently.
- `app/rpc/note.py`: web `Create` passes `append_app_hashtag=True`.
- `tests/services/test_note_service.py`: covers append, empty-text, idempotency, and the default verbatim path.

## Notes

The default-off design keeps the existing 0.6-API note tests green (they assert exact note text via the API path).
