### PR TITLE
Implement edit help tooltip

### DIFF
--- a/app/views/navbar/navbar-left.tsx
+++ b/app/views/navbar/navbar-left.tsx
@@ -1,8 +1,9 @@
 import { RemoteEditButton } from "@index/remote-edit"
-import { routerRemoteEditTarget } from "@index/router"
+import { routerCtx, routerRemoteEditTarget } from "@index/router"
 import { useSignalEffect } from "@preact/signals"
 import { assertNever } from "@std/assert/unstable-never"
-import { useDisposeEffect } from "@utils/dispose-scope"
+import { isLoggedIn } from "@utils/config"
+import { useDisposeEffect, useDisposeSignalEffect } from "@utils/dispose-scope"
 import { type Editor, preferredEditorStorage } from "@utils/local-storage"
 import { qsEncode } from "@utils/query-string"
 import { Dropdown, Tooltip } from "bootstrap"
@@ -16,6 +17,25 @@ const buildEditHref = (editor: Editor) => {
   const target = routerRemoteEditTarget.value
   if (target) params[target.type] = target.id.toString()
   return `/edit${qsEncode(params)}${currentHash.value}`
+}
+
+const isEditHelpActive = () =>
+  isLoggedIn && Boolean(routerCtx.value.queryParams.edit_help?.length)
+
+const removeEditHelpQuery = () => {
+  const params = new URLSearchParams(window.location.search)
+  if (!params.has("edit_help")) return
+
+  params.delete("edit_help")
+  const search = params.toString()
+  const href = `${window.location.pathname}${search ? `?${search}` : ""}${window.location.hash}`
+  window.history.replaceState(null, "", href)
+
+  try {
+    window.dispatchEvent(new PopStateEvent("popstate"))
+  } catch {
+    window.dispatchEvent(new Event("popstate"))
+  }
 }
 
 const getEditorImage = (editor: Editor) => {
@@ -52,6 +72,7 @@ const EditorImg = ({
 
 const NavbarLeft = () => {
   const dropdownRootRef = useRef<HTMLDivElement>(null)
+  const defaultEditLinkRef = useRef<HTMLAnchorElement>(null)
   const dropdownToggleRef = useRef<HTMLButtonElement>(null)
   const dropdownRef = useRef<Dropdown>(null)
   const tooltipRef = useRef<Tooltip>(null)
@@ -76,6 +97,34 @@ const NavbarLeft = () => {
     return () => tooltip.dispose()
   }, [])
 
+  // Effect: show the one-shot edit help tooltip requested by ?edit_help=1
+  useDisposeSignalEffect((scope) => {
+    if (!isEditHelpActive()) return
+
+    const tooltip = new Tooltip(defaultEditLinkRef.current!, {
+      title: t("javascripts.edit_help"),
+      placement: "bottom",
+      trigger: "manual",
+    })
+    let disposed = false
+
+    const disposeTooltip = () => {
+      if (disposed) return
+      disposed = true
+      tooltip.hide()
+      tooltip.dispose()
+    }
+
+    const finish = () => {
+      disposeTooltip()
+      removeEditHelpQuery()
+    }
+
+    tooltip.show()
+    scope.dom(document.body, "click", finish, { once: true })
+    scope.defer(disposeTooltip)
+  })
+
   // Effect: hide dropdown when edit is disabled
   useSignalEffect(() => {
     if (!editDisabled.value) return
@@ -98,7 +147,7 @@ const NavbarLeft = () => {
   // Effect: toggle tooltip based when edit is disabled/enabled
   useSignalEffect(() => {
     const tooltip = tooltipRef.current!
-    if (editDisabled.value) {
+    if (editDisabled.value && !isEditHelpActive()) {
       tooltip.enable()
     } else {
       tooltip.disable()
@@ -126,6 +175,7 @@ const NavbarLeft = () => {
           href={!disabled ? buildEditHref(preferredEditorStorage.value) : undefined}
           aria-disabled={disabled}
           tabIndex={disabled ? -1 : undefined}
+          ref={defaultEditLinkRef}
         >
           {t("layouts.edit")}
           <EditorImg


### PR DESCRIPTION
Fixes #28.

## Summary

- show the translated edit-help tooltip on the navbar Edit button for logged-in users when `?edit_help=1` is present
- dismiss the tooltip on the next body click and remove `edit_help` from the URL without a reload
- keep the index router state in sync after removing the query parameter
- suppress the regular disabled-edit tooltip while the edit-help tutorial tooltip is active

## Notes

This follows the current OpenStreetMap website behavior in `openstreetmap-website/app/assets/javascripts/index.js`: the existing site shows a Bootstrap tooltip on `#editanchor`, places it at the bottom, and hides it on the next body click.

This intentionally uses the existing `javascripts.edit_help` translation key that is already present in the downloaded locale files.

## Verification

- `git diff --check`
- `bunx oxfmt --check app/views/navbar/navbar-left.tsx`
- `bunx oxlint app/views/navbar/navbar-left.tsx`

`bunx oxlint app/views/navbar/navbar-left.tsx` exits successfully, with one existing warning on the remember-choice checkbox label association outside this change.

I also generated the frontend protobuf stubs with a temporary `bunx @bufbuild/buf` toolchain and tried:

- `bunx tsc --noEmit --pretty false`
- `bunx tsc --noEmit --pretty false --skipLibCheck`

After generating `app/views/proto`, the app-source `@proto/*` errors are gone. The remaining local TypeScript failures are confined to vendored `@jsr/zod__zod` TypeScript sources under `node_modules/.bun/...`. The repo's normal `proto-pipeline` and postinstall helper are Nix-shell commands, and this local Windows shell does not provide Nix or `_scripts-postinstall`.
