### PR TITLE
Close tagged notes when closing changesets

### DIFF
--- a/app/services/changeset_service.py
+++ b/app/services/changeset_service.py
@@ -85,7 +85,7 @@ class ChangesetService:
         async with db(True) as conn:
             row = await db_fetchrow(
                 t"""
-                    SELECT user_id, closed_at, tags
+                    SELECT user_id, closed_at
                     FROM changeset
                     WHERE id = {changeset_id}
                 """,
@@ -97,8 +97,7 @@ class ChangesetService:
 
             changeset_user_id: UserId
             closed_at: datetime | None
-            tags: dict[str, str]
-            changeset_user_id, closed_at, tags = row
+            changeset_user_id, closed_at = row
 
             if changeset_user_id != user_id:
                 raise_for.changeset_access_denied()

--- a/app/services/changeset_service.py
+++ b/app/services/changeset_service.py
@@ -121,7 +121,7 @@ class ChangesetService:
         async with db(True) as conn:
             row = await db_fetchrow(
                 t"""
-                    SELECT user_id, closed_at
+                    SELECT user_id, closed_at, tags
                     FROM changeset
                     WHERE id = {changeset_id}
                 """,
@@ -133,7 +133,8 @@ class ChangesetService:
 
             changeset_user_id: UserId
             closed_at: datetime | None
-            changeset_user_id, closed_at = row
+            tags: dict[str, str]
+            changeset_user_id, closed_at, tags = row
 
             if changeset_user_id != user_id:
                 raise_for.changeset_access_denied()

--- a/app/services/changeset_service.py
+++ b/app/services/changeset_service.py
@@ -19,6 +19,7 @@ from app.db import (
     db_delete,
     db_fetchcol,
     db_fetchrow,
+    db_fetchrows,
     db_fetchval,
     db_insert,
     db_lock,
@@ -38,7 +39,14 @@ from app.models.db.changeset_comment import (
     ChangesetComment,
     changeset_comments_resolve_rich_text,
 )
-from app.models.types import ChangesetCommentId, ChangesetId, DisplayName, UserId
+from app.models.types import (
+    ChangesetCommentId,
+    ChangesetId,
+    DisplayName,
+    NoteCommentId,
+    NoteId,
+    UserId,
+)
 from app.queries.changeset_query import ChangesetQuery
 from app.queries.user_query import UserQuery
 from app.queries.user_subscription_query import UserSubscriptionQuery
@@ -77,7 +85,7 @@ class ChangesetService:
         async with db(True) as conn:
             row = await db_fetchrow(
                 t"""
-                    SELECT user_id, closed_at
+                    SELECT user_id, closed_at, tags
                     FROM changeset
                     WHERE id = {changeset_id}
                 """,
@@ -89,7 +97,8 @@ class ChangesetService:
 
             changeset_user_id: UserId
             closed_at: datetime | None
-            changeset_user_id, closed_at = row
+            tags: dict[str, str]
+            changeset_user_id, closed_at, tags = row
 
             if changeset_user_id != user_id:
                 raise_for.changeset_access_denied()
@@ -141,6 +150,7 @@ class ChangesetService:
                 conn=conn,
             )
             await audit('close_changeset', conn, extra={'id': changeset_id})
+            await _close_tagged_notes(changeset_id, changeset_user_id, tags, conn=conn)
 
     @staticmethod
     @asynccontextmanager
@@ -272,18 +282,118 @@ async def _process_task():
 
 async def _close_inactive():
     """Close all inactive changesets."""
-    rowcount = await db_update(
-        'changeset',
-        {'closed_at': t'statement_timestamp()', 'updated_at': t'DEFAULT'},
-        where=t"""closed_at IS NULL AND (
-                updated_at < statement_timestamp() - {CHANGESET_IDLE_TIMEOUT} OR
-                (updated_at >= statement_timestamp() - {CHANGESET_IDLE_TIMEOUT} AND
-                created_at < statement_timestamp() - {CHANGESET_OPEN_TIMEOUT})
-            )""",
-    )
+    async with db(True) as conn:
+        rows = await db_fetchrows(
+            t"""
+                UPDATE changeset
+                SET closed_at = statement_timestamp(), updated_at = DEFAULT
+                WHERE closed_at IS NULL AND (
+                    updated_at < statement_timestamp() - {CHANGESET_IDLE_TIMEOUT} OR
+                    (updated_at >= statement_timestamp() - {CHANGESET_IDLE_TIMEOUT} AND
+                    created_at < statement_timestamp() - {CHANGESET_OPEN_TIMEOUT})
+                )
+                RETURNING id, user_id, tags
+            """,
+            conn=conn,
+        )
+        for changeset_id, changeset_user_id, tags in rows:
+            await _close_tagged_notes(
+                changeset_id,
+                changeset_user_id,
+                tags,
+                conn=conn,
+            )
+
+    rowcount = len(rows)
 
     if rowcount:
         logging.debug('Closed %d inactive changesets', rowcount)
+
+
+async def _close_tagged_notes(
+    changeset_id: ChangesetId,
+    user_id: UserId | None,
+    tags: dict[str, str],
+    *,
+    conn,
+):
+    note_ids = _parse_closes_note_ids(tags.get('closes:note'))
+    if user_id is None or not note_ids:
+        return
+
+    open_note_ids = await db_fetchcol(
+        NoteId,
+        t"""
+            SELECT id FROM note
+            WHERE id = ANY({note_ids})
+              AND closed_at IS NULL
+              AND hidden_at IS NULL
+            FOR UPDATE
+        """,
+        conn=conn,
+    )
+    if not open_note_ids:
+        return
+
+    bulk_comment = tags.get('closes:note:comment')
+    default_comment = tags.get('comment', '')
+    for note_id in open_note_ids:
+        text = tags.get(f'closes:note:{note_id}:comment', bulk_comment)
+        if text is None:
+            text = default_comment
+
+        comment_id: NoteCommentId
+        created_at: datetime
+        comment_id, created_at = await db_insert(
+            'note_comment',
+            {
+                'user_id': user_id,
+                'user_ip': None,
+                'note_id': note_id,
+                'event': 'closed',
+                'body': text,
+            },
+            returning='id, created_at',
+            conn=conn,
+        )
+        await db_update(
+            'note',
+            {
+                'closed_at': t'statement_timestamp()',
+                'updated_at': created_at,
+            },
+            where={'id': note_id},
+            conn=conn,
+        )
+        if text:
+            await audit(
+                'create_note_comment',
+                conn,
+                extra={'id': comment_id, 'note': note_id, 'changeset': changeset_id},
+            )
+        await audit(
+            'update_note_status',
+            conn,
+            extra={'id': note_id, 'event': 'closed', 'changeset': changeset_id},
+        )
+
+
+def _parse_closes_note_ids(value: str | None) -> list[NoteId]:
+    if not value:
+        return []
+
+    result: list[NoteId] = []
+    seen: set[int] = set()
+    for part in value.split(';'):
+        part = part.strip()
+        if not part.isdecimal():
+            continue
+        note_id_int = int(part)
+        if note_id_int <= 0 or note_id_int in seen:
+            continue
+        seen.add(note_id_int)
+        result.append(NoteId(note_id_int))
+    return result
 
 
 async def _delete_empty():

--- a/tests/controllers/test_api06_changeset.py
+++ b/tests/controllers/test_api06_changeset.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 import pytest
-from annotated_types import Gt
+from annotated_types import Gt, Len
 from httpx import AsyncClient
 from starlette import status
 
@@ -162,6 +162,91 @@ async def test_changeset_upload(client: AsyncClient):
             '@min_lon': 0.0,
             '@max_lon': 0.0,
         },
+    )
+
+
+async def test_changeset_close_closes_tagged_notes(client: AsyncClient):
+    client.headers['Authorization'] = 'User user1'
+
+    async def create_note(text: str) -> int:
+        r = await client.post(
+            '/api/0.6/notes.json',
+            json={'lon': 0, 'lat': 0, 'text': text},
+        )
+        assert r.is_success, r.text
+        return r.json()['properties']['id']
+
+    default_note_id = await create_note('close from changeset default')
+    override_note_id = await create_note('close from changeset override')
+    already_closed_note_id = await create_note('already closed before changeset')
+
+    r = await client.post(
+        f'/api/0.6/notes/{already_closed_note_id}/close.json',
+        params={'text': 'already done'},
+    )
+    assert r.is_success, r.text
+
+    r = await client.put(
+        '/api/0.6/changeset/create',
+        content=XMLToDict.unparse({
+            'osm': {
+                'changeset': {
+                    'tag': [
+                        {'@k': 'comment', '@v': 'Closing mapped notes'},
+                        {
+                            '@k': 'closes:note',
+                            '@v': (
+                                f'{default_note_id};'
+                                f'{override_note_id};'
+                                f'{already_closed_note_id}'
+                            ),
+                        },
+                        {
+                            '@k': f'closes:note:{override_note_id}:comment',
+                            '@v': 'Specific close reason',
+                        },
+                    ]
+                }
+            }
+        }),
+    )
+    assert r.is_success, r.text
+    changeset_id = int(r.text)
+
+    r = await client.put(f'/api/0.6/changeset/{changeset_id}/close')
+    assert r.is_success, r.text
+
+    r = await client.get(f'/api/0.6/notes/{default_note_id}.json')
+    assert r.is_success, r.text
+    default_props = r.json()['properties']
+    assert_model(
+        default_props,
+        {'status': 'closed', 'comments': Len(2, 2), 'closed_at': str},
+    )
+    assert_model(
+        default_props['comments'][-1],
+        {'user': 'user1', 'action': 'closed', 'text': 'Closing mapped notes'},
+    )
+
+    r = await client.get(f'/api/0.6/notes/{override_note_id}.json')
+    assert r.is_success, r.text
+    override_props = r.json()['properties']
+    assert_model(
+        override_props,
+        {'status': 'closed', 'comments': Len(2, 2), 'closed_at': str},
+    )
+    assert_model(
+        override_props['comments'][-1],
+        {'user': 'user1', 'action': 'closed', 'text': 'Specific close reason'},
+    )
+
+    r = await client.get(f'/api/0.6/notes/{already_closed_note_id}.json')
+    assert r.is_success, r.text
+    already_closed_props = r.json()['properties']
+    assert_model(already_closed_props, {'status': 'closed', 'comments': Len(2, 2)})
+    assert_model(
+        already_closed_props['comments'][-1],
+        {'user': 'user1', 'action': 'closed', 'text': 'already done'},
     )
 
 


### PR DESCRIPTION
Closes #126

## Summary
- Close open, visible notes listed in the `closes:note` changeset tag when a changeset is closed.
- Use the changeset comment by default, with support for `closes:note:comment` and per-note `closes:note:{id}:comment` overrides.
- Skip already closed/hidden notes and add API coverage for default, overridden, and already-closed notes.

## Tests
- Not run locally: this machine only has Python 3.9.6, while the project uses Python 3.14 template string syntax (`t"""`). `python3 -m py_compile work/osmng-min/app/services/changeset_service.py work/osmng-min/tests/controllers/test_api06_changeset.py` stops at the existing `t"""` syntax before tests can run.