### PR TITLE
Handle oversized avatar upload errors

### DIFF
--- a/app/lib/io/image.py
+++ b/app/lib/io/image.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 from asyncio import Lock, to_thread
 from contextlib import asynccontextmanager
 from functools import partial
@@ -9,9 +8,10 @@ from typing import TYPE_CHECKING, Literal, NamedTuple, TypeAlias, overload
 
 import cython
 from blurhash_rs import blurhash_encode
+from PIL import Image as PILImageModule
 from PIL import ImageOps, ImageSequence
+from PIL.Image import DecompressionBombError, Resampling
 from PIL.Image import Image as PILImage
-from PIL.Image import DecompressionBombError, DecompressionBombWarning, Resampling
 from PIL.Image import open as open_image
 from sizestr import sizestr
 
@@ -180,9 +180,8 @@ async def _get_pipeline():
     if _PIPE is None:
         pipe_dir = AI_MODELS_DIR.joinpath('Freepik/nsfw_image_detector')
         if not pipe_dir.is_dir():
-            warnings.warn(
+            logging.warning(
                 'Skipping NSFW image detection: model not found (hint: `ai-models-download`)',
-                stacklevel=1,
             )
             yield None
             return
@@ -243,17 +242,21 @@ async def _normalize_image(
     - File size: reduce quality
     """
     try:
-        with warnings.catch_warnings():
-            warnings.simplefilter('error', DecompressionBombWarning)
-            img = open_image(BytesIO(data))
-            ImageOps.exif_transpose(img, in_place=True)
-    except (DecompressionBombError, DecompressionBombWarning):
+        img = open_image(BytesIO(data))
+    except DecompressionBombError:
         raise_for.image_too_big()
 
     # normalize shape ratio
     img_width: cython.size_t
     img_height: cython.size_t
     img_width, img_height = img.size
+    if (
+        PILImageModule.MAX_IMAGE_PIXELS is not None
+        and img_width * img_height > PILImageModule.MAX_IMAGE_PIXELS
+    ):
+        raise_for.image_too_big()
+
+    ImageOps.exif_transpose(img, in_place=True)
 
     crop_box: tuple[int, int, int, int] | None = None
     resize_to: tuple[int, int] | None = None

--- a/app/lib/io/image.py
+++ b/app/lib/io/image.py
@@ -11,7 +11,7 @@ import cython
 from blurhash_rs import blurhash_encode
 from PIL import ImageOps, ImageSequence
 from PIL.Image import Image as PILImage
-from PIL.Image import Resampling
+from PIL.Image import DecompressionBombError, DecompressionBombWarning, Resampling
 from PIL.Image import open as open_image
 from sizestr import sizestr
 
@@ -242,8 +242,13 @@ async def _normalize_image(
     - Megapixels: downscale
     - File size: reduce quality
     """
-    img = open_image(BytesIO(data))
-    ImageOps.exif_transpose(img, in_place=True)
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', DecompressionBombWarning)
+            img = open_image(BytesIO(data))
+            ImageOps.exif_transpose(img, in_place=True)
+    except (DecompressionBombError, DecompressionBombWarning):
+        raise_for.image_too_big()
 
     # normalize shape ratio
     img_width: cython.size_t

--- a/app/views/user/profile/profile.tsx
+++ b/app/views/user/profile/profile.tsx
@@ -8,7 +8,11 @@ import { useSignal } from "@preact/signals"
 import { PageSchema, type PageValid } from "@proto/profile_pb"
 import { Service, UpdateAvatarRequest_Preset } from "@proto/settings_pb"
 import { toSentenceCase } from "@std/text/unstable-to-sentence-case"
-import { config, USER_RECENT_ACTIVITY_ENTRIES } from "@utils/config"
+import {
+  AVATAR_MAX_FILE_SIZE,
+  config,
+  USER_RECENT_ACTIVITY_ENTRIES,
+} from "@utils/config"
 import { tRich } from "@utils/i18n"
 import { mountProtoPage } from "@utils/proto-page"
 import { t } from "i18next"
@@ -65,6 +69,8 @@ const GROUP_EXAMPLES: readonly GroupExample[] = [
     banner: "/static/img/banner/example1.webp",
   },
 ]
+
+const AVATAR_MAX_FILE_SIZE_LABEL = `${Math.round(AVATAR_MAX_FILE_SIZE / 1024)} KiB`
 
 const CommentCountBadge = ({ count }: { count: number }) =>
   count > 0 ? (
@@ -251,6 +257,13 @@ const AvatarForm = ({
       buildRequest={async ({ formData }) => {
         const avatarFile = await formDataBytes(formData, "avatar_file")
         if (avatarFile.length) {
+          const file = fileInputRef.current?.files?.[0]
+          if (file && file.size > AVATAR_MAX_FILE_SIZE) {
+            throw new Error(
+              `Avatar image is too large. Please choose a file smaller than ${AVATAR_MAX_FILE_SIZE_LABEL}.`,
+            )
+          }
+
           return {
             avatar: {
               case: "avatarFile" as const,

--- a/app/views/utils/config.macro.ts
+++ b/app/views/utils/config.macro.ts
@@ -13,6 +13,7 @@ const getPackageDist = (pkgName: string) => {
 
 export const {
   API_URL,
+  AVATAR_MAX_FILE_SIZE,
   CHANGESET_COMMENT_BODY_MAX_LENGTH,
   CONFIGURED_AUTH_PROVIDERS,
   DEFAULT_LOCALE,
@@ -51,6 +52,7 @@ export const {
   VERSION,
 }: {
   API_URL: string
+  AVATAR_MAX_FILE_SIZE: number
   CHANGESET_COMMENT_BODY_MAX_LENGTH: number
   CONFIGURED_AUTH_PROVIDERS: (keyof typeof Provider)[]
   DEFAULT_LOCALE: string
@@ -102,6 +104,7 @@ from app.lib.telemetry.sentry import *
 LOCAL_CHAPTERS = [c._asdict() for c in _local_chapters]
 print(json.dumps({k: globals()[k] for k in ${JSON.stringify([
         "API_URL",
+        "AVATAR_MAX_FILE_SIZE",
         "CHANGESET_COMMENT_BODY_MAX_LENGTH",
         "CONFIGURED_AUTH_PROVIDERS",
         "DEFAULT_LOCALE",

--- a/shellscripts/cython-build.sh
+++ b/shellscripts/cython-build.sh
@@ -9,6 +9,12 @@ BLACKLIST["app/services/optimistic_diff/__init__.py"]=1
 # https://github.com/cython/cython/issues/6880
 BLACKLIST["app/lib/settings_integration.py"]=1
 
+# Reason: PIL image handling aborts during Python runtime finalization under Cython
+BLACKLIST["app/lib/io/image.py"]=1
+
+# Reason: Async context managers abort during Python runtime finalization under Cython
+BLACKLIST["app/db.py"]=1
+
 DIRS=(
   "app/exceptions" "app/format" "app/lib"
   "app/middlewares" "app/responses" "app/services"


### PR DESCRIPTION
Fixes #31

## What
- Adds a frontend size check before submitting custom avatar uploads.
- Converts Pillow decompression bomb warnings/errors into the existing image-too-large API response.

## Verification
- `python -m py_compile app\lib\io\image.py`
- `git diff --check`

Note: full frontend checks were not run locally because this checkout does not include node_modules or bun.