### PR TITLE
Add hybrid aerial base layer

### DIFF
--- a/app/views/index/sidebar/layers.tsx
+++ b/app/views/index/sidebar/layers.tsx
@@ -14,6 +14,7 @@ import {
   GPS_LAYER_ID,
   hasMapLayer,
   HOT_LAYER_ID,
+  HYBRID_AERIAL_LAYER_ID,
   type LayerId,
   LIBERTY_LAYER_ID,
   NOTES_LAYER_ID,
@@ -49,6 +50,7 @@ const BASE_LAYERS = new Set([
   TRANSPORTMAP_LAYER_ID,
   TRACESTRACKTOPO_LAYER_ID,
   LIBERTY_LAYER_ID,
+  HYBRID_AERIAL_LAYER_ID,
   HOT_LAYER_ID,
 ])
 
@@ -63,6 +65,7 @@ const OVERLAY_LAYERS = new Set([
 // Avoids "Too many active WebGL context even after destroyed".
 const LAYER_THUMBNAILS = new Map<LayerId, string>([
   [AERIAL_LAYER_ID, "/static/img/layer/aerial.webp"],
+  [HYBRID_AERIAL_LAYER_ID, "/static/img/layer/aerial.webp"],
 ])
 
 type Minimap =
@@ -385,6 +388,12 @@ export const LayersSidebar = ({ close }: { close: () => void }) => {
                 {layerId === LIBERTY_LAYER_ID && (
                   <>
                     {t("map.layers.liberty")}
+                    <span class="vector">{t("map.layers.vector")}</span>
+                  </>
+                )}
+                {layerId === HYBRID_AERIAL_LAYER_ID && (
+                  <>
+                    {t("map.layers.hybrid_aerial")}
                     <span class="vector">{t("map.layers.vector")}</span>
                   </>
                 )}

--- a/app/views/map/layers/layers.ts
+++ b/app/views/map/layers/layers.ts
@@ -103,11 +103,13 @@ const aerialSource = {
   tileSize: 256,
 } satisfies SourceSpecification
 
-const hybridAerialStyle = {
-  ...libertyStyle,
+const typedLibertyStyle = libertyStyle as unknown as StyleSpecification
+
+const hybridAerialStyle: StyleSpecification = {
+  ...typedLibertyStyle,
   sources: {
     imagery: aerialSource,
-    openmaptiles: libertyStyle.sources.openmaptiles,
+    openmaptiles: typedLibertyStyle.sources.openmaptiles!,
   },
   layers: [
     {
@@ -115,8 +117,11 @@ const hybridAerialStyle = {
       type: "raster",
       source: "imagery",
     },
-    ...libertyStyle.layers.filter(
-      (layer) => layer.type === "line" || layer.type === "symbol",
+    ...typedLibertyStyle.layers.filter(
+      (layer) =>
+        layer.type === "line" ||
+        layer.type === "symbol" ||
+        layer.type === "circle",
     ),
   ],
 }
@@ -161,8 +166,7 @@ layersConfig.set(STANDARD_LAYER_ID, {
 
 layersConfig.set(LIBERTY_LAYER_ID, {
   specification: { type: "vector" },
-  // @ts-expect-error
-  vectorStyle: libertyStyle,
+  vectorStyle: typedLibertyStyle,
   isBaseLayer: true,
   layerCode: LIBERTY_LAYER_CODE,
 })
@@ -248,7 +252,6 @@ layersConfig.set(HYBRID_AERIAL_LAYER_ID, {
     type: "vector",
     attribution: `${copyright}. ${aerialEsriCredit}. ${terms}`,
   },
-  // @ts-expect-error derived from the imported Liberty style
   vectorStyle: hybridAerialStyle,
   isBaseLayer: true,
   layerCode: HYBRID_AERIAL_LAYER_CODE,

--- a/app/views/map/layers/layers.ts
+++ b/app/views/map/layers/layers.ts
@@ -31,6 +31,7 @@ export const CYCLEMAP_LAYER_ID = "cyclemap" as LayerId
 export const TRANSPORTMAP_LAYER_ID = "transportmap" as LayerId
 export const TRACESTRACKTOPO_LAYER_ID = "tracestracktopo" as LayerId
 export const HOT_LAYER_ID = "hot" as LayerId
+export const HYBRID_AERIAL_LAYER_ID = "hybrid-aerial" as LayerId
 
 const LIBERTY_LAYER_CODE = "L" as LayerCode
 const CYCLOSM_LAYER_CODE = "Y" as LayerCode
@@ -38,6 +39,7 @@ const CYCLEMAP_LAYER_CODE = "C" as LayerCode
 const TRANSPORTMAP_LAYER_CODE = "T" as LayerCode
 const TRACESTRACKTOPO_LAYER_CODE = "P" as LayerCode
 const HOT_LAYER_CODE = "H" as LayerCode
+const HYBRID_AERIAL_LAYER_CODE = "I" as LayerCode
 
 export const AERIAL_LAYER_ID = "aerial" as LayerId
 export const NOTES_LAYER_ID = "notes" as LayerId
@@ -92,6 +94,32 @@ const hotosmCredit = t("javascripts.map.hotosm_credit", {
 // https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/0
 const aerialEsriCredit =
   "Esri, Maxar, Earthstar Geographics, and the GIS User Community"
+const aerialSource = {
+  type: "raster",
+  maxzoom: 23,
+  tiles: [
+    "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+  ],
+  tileSize: 256,
+} satisfies SourceSpecification
+
+const hybridAerialStyle = {
+  ...libertyStyle,
+  sources: {
+    imagery: aerialSource,
+    openmaptiles: libertyStyle.sources.openmaptiles,
+  },
+  layers: [
+    {
+      id: "imagery",
+      type: "raster",
+      source: "imagery",
+    },
+    ...libertyStyle.layers.filter(
+      (layer) => layer.type === "line" || layer.type === "symbol",
+    ),
+  ],
+}
 
 export const emptyFeatureCollection: FeatureCollection = {
   type: "FeatureCollection",
@@ -215,15 +243,21 @@ layersConfig.set(HOT_LAYER_ID, {
   layerCode: HOT_LAYER_CODE,
 })
 
+layersConfig.set(HYBRID_AERIAL_LAYER_ID, {
+  specification: {
+    type: "vector",
+    attribution: `${copyright}. ${aerialEsriCredit}. ${terms}`,
+  },
+  // @ts-expect-error derived from the imported Liberty style
+  vectorStyle: hybridAerialStyle,
+  isBaseLayer: true,
+  layerCode: HYBRID_AERIAL_LAYER_CODE,
+})
+
 // Overlay layers
 layersConfig.set(AERIAL_LAYER_ID, {
   specification: {
-    type: "raster",
-    maxzoom: 23,
-    tiles: [
-      "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
-    ],
-    tileSize: 256,
+    ...aerialSource,
     attribution: aerialEsriCredit,
   },
   layerOptions: {
@@ -309,10 +343,11 @@ export const addMapLayerSources = (
           !(source.tiles || source.url)
         )
           continue
-        if (source.attribution || config.specification.attribution)
+        const sourceSpec = { ...source }
+        if (sourceSpec.attribution || config.specification.attribution)
           // @ts-expect-error override source attribution
-          source.attribution = config.specification.attribution
-        map.addSource(getExtendedLayerId(layerId, sourceId as LayerType), source)
+          sourceSpec.attribution = config.specification.attribution
+        map.addSource(getExtendedLayerId(layerId, sourceId as LayerType), sourceSpec)
       }
     }
   }

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -9,6 +9,7 @@ map:
   zoom_out_to_see_the_world_in_3d: Zoom out to see the world in 3D
   layers:
     esri_world_imagery: Esri World Imagery
+    hybrid_aerial: Hybrid aerial
     liberty: Liberty
     vector: Vector
   overlays:


### PR DESCRIPTION
Fixes #182
/claim #182

## Summary
- Adds a Hybrid aerial base layer using Esri World Imagery as the 100% opacity underlay.
- Reuses Liberty line and symbol layers for roads, boundaries, POIs, and labels without landuse/landcover fills covering imagery.
- Adds the layer to the map layer sidebar, mobile thumbnail handling, and URL layer-code state.

## Verification
- git diff --check
- bunx tsc --noEmit --pretty false (blocked by missing generated app/views/proto files in this local checkout; no errors reported for app/views/map/layers/layers.ts after fixing the raster source type)
