### PR TITLE
Fix globe aerial label ordering

### DIFF
--- a/app/views/map/layers/layers.ts
+++ b/app/views/map/layers/layers.ts
@@ -3,7 +3,7 @@ import { batch, effect, signal } from "@preact/signals"
 import { effectiveTheme } from "@runtime/theme"
 import { memoize } from "@std/cache/memoize"
 import { filterKeys } from "@std/collections/filter-keys"
-import { overlayOpacityStorage } from "@utils/local-storage"
+import { globeProjectionStorage, overlayOpacityStorage } from "@utils/local-storage"
 import type { FeatureCollection } from "geojson"
 import { t } from "i18next"
 import {
@@ -389,6 +389,47 @@ const LAYER_TYPE_FILTERS: Partial<Record<LayerType, FilterSpecification>> = {
   symbol: ["==", ["geometry-type"], "Point"],
 }
 
+const getPriorityBeforeId = (
+  map: MaplibreMap,
+  layerId: LayerId,
+): string | undefined => {
+  const priority = layersConfig.get(layerId)?.priority ?? 0
+  return map
+    .getLayersOrder()
+    .find(
+      (id) => priority < (layersConfig.get(resolveExtendedLayerId(id))?.priority ?? 0),
+    )
+}
+
+const getFirstSymbolLayerId = (
+  map: MaplibreMap,
+  layerId: LayerId,
+): string | undefined =>
+  map.getLayersOrder().find((id) => {
+    if (resolveExtendedLayerId(id) !== layerId) return false
+    return map.getLayer(id)?.type === "symbol"
+  })
+
+export const syncAerialLayerOrder = (map: MaplibreMap) => {
+  if (!map.getLayer(AERIAL_LAYER_ID)) return
+
+  const activeBaseLayer = activeBaseLayerId.peek()
+  const symbolBeforeId =
+    globeProjectionStorage.peek() && activeBaseLayer
+      ? getFirstSymbolLayerId(map, activeBaseLayer)
+      : undefined
+  const beforeId = symbolBeforeId ?? getPriorityBeforeId(map, AERIAL_LAYER_ID)
+
+  const order = map.getLayersOrder()
+  const aerialIndex = order.indexOf(AERIAL_LAYER_ID)
+  const beforeIndex = beforeId ? order.indexOf(beforeId) : order.length
+  if (aerialIndex === -1 || beforeIndex === -1) return
+  if (aerialIndex === beforeIndex - 1) return
+
+  console.debug("Layers: Moving", AERIAL_LAYER_ID, "before", beforeId)
+  map.moveLayer(AERIAL_LAYER_ID, beforeId)
+}
+
 export const addMapLayer = (
   map: MaplibreMap,
   layerId: LayerId,
@@ -507,6 +548,10 @@ export const addMapLayer = (
         handler(true, layerId, config)
       }
     })
+  }
+
+  if (triggerEvent && (layerId === AERIAL_LAYER_ID || config.isBaseLayer)) {
+    syncAerialLayerOrder(map)
   }
 }
 

--- a/app/views/map/main-map.ts
+++ b/app/views/map/main-map.ts
@@ -28,7 +28,11 @@ import { QueryFeaturesControl } from "./controls/query-features"
 import { CustomZoomControl } from "./controls/zoom"
 import { configureDefaultMapBehavior } from "./defaults"
 import { configureDataLayer } from "./layers/data-layer"
-import { addLayerEventHandler, addMapLayerSources } from "./layers/layers"
+import {
+  addLayerEventHandler,
+  addMapLayerSources,
+  syncAerialLayerOrder,
+} from "./layers/layers"
 import { configureNotesLayer } from "./layers/notes-layer"
 import type { MapState } from "./state"
 import { applyMapState, getInitialMapState, getMapState, parseMapState } from "./state"
@@ -73,6 +77,7 @@ const createMainMap = (
     globeWasEnabled = enabled
 
     map.setProjection({ type: enabled ? "globe" : "mercator" })
+    syncAerialLayerOrder(map)
 
     // Workaround a bug where after switching back to mercator,
     // the map is not fit to the screen (there is grey padding).


### PR DESCRIPTION
Fixes #184
/claim #184

## Summary
- Keeps the aerial overlay below active vector label layers while globe projection is enabled.
- Re-syncs the aerial layer order when aerial/base layers are added and when globe/mercator projection changes.
- Preserves the existing priority-based overlay order outside globe mode.

## Verification
- git diff --check
- bunx prettier --no-semi --check app/views/map/layers/layers.ts app/views/map/main-map.ts
- bunx oxlint app/views/map/layers/layers.ts app/views/map/main-map.ts
- bunx tsc --noEmit --pretty false (global checkout still lacks generated app/views/proto files; no errors matched the changed files)
