### PR TITLE
feat: close notes from changeset tags

### DIFF
--- a/app/services/changeset_service.py
+++ b/app/services/changeset_service.py
@@ -38,11 +38,14 @@ from app.models.db.changeset_comment import (
     ChangesetComment,
     changeset_comments_resolve_rich_text,
 )
-from app.models.types import ChangesetCommentId, ChangesetId, DisplayName, UserId
+from app.models.proto.note_types import GetCommentsResponse_Comment_Event
+from app.models.types import ChangesetCommentId, ChangesetId, DisplayName, NoteId, UserId
 from app.queries.changeset_query import ChangesetQuery
+from app.queries.note_query import NoteQuery
 from app.queries.user_query import UserQuery
 from app.queries.user_subscription_query import UserSubscriptionQuery
 from app.services.email_service import EmailService
+from app.services.note_service import NoteService
 from app.services.user_subscription_service import UserSubscriptionService
 
 _PROCESS_REQUEST_EVENT = Event()
@@ -108,11 +111,12 @@ class ChangesetService:
     async def close(changeset_id: ChangesetId):
         """Close a changeset."""
         user_id = auth_user(required=True)['id']
+        note_closures: list[tuple[NoteId, str]] = []
 
         async with db(True) as conn:
             row = await db_fetchrow(
                 t"""
-                    SELECT user_id, closed_at
+                    SELECT user_id, closed_at, tags
                     FROM changeset
                     WHERE id = {changeset_id}
                 """,
@@ -124,7 +128,8 @@ class ChangesetService:
 
             changeset_user_id: UserId
             closed_at: datetime | None
-            changeset_user_id, closed_at = row
+            tags: dict[str, str]
+            changeset_user_id, closed_at, tags = row
 
             if changeset_user_id != user_id:
                 raise_for.changeset_access_denied()
@@ -141,6 +146,14 @@ class ChangesetService:
                 conn=conn,
             )
             await audit('close_changeset', conn, extra={'id': changeset_id})
+            note_closures = await _get_note_closures_from_changeset_tags(tags)
+
+        for note_id, text in note_closures:
+            await NoteService.comment(
+                note_id,
+                text,
+                GetCommentsResponse_Comment_Event.Value('closed'),
+            )
 
     @staticmethod
     @asynccontextmanager
@@ -284,6 +297,53 @@ async def _close_inactive():
 
     if rowcount:
         logging.debug('Closed %d inactive changesets', rowcount)
+
+
+async def _get_note_closures_from_changeset_tags(
+    tags: dict[str, str],
+) -> list[tuple[NoteId, str]]:
+    raw_ids = tags.get('closes:note')
+    if not raw_ids:
+        return []
+
+    default_comment = tags.get('closes:note:comment') or tags.get('comment') or ''
+    per_note_comments: dict[NoteId, str] = {}
+    note_ids: list[NoteId] = []
+    seen = set[NoteId]()
+
+    for key, value in tags.items():
+        if not (key.startswith('closes:note:') and key.endswith(':comment')):
+            continue
+        raw_note_id = key[len('closes:note:') : -len(':comment')]
+        if raw_note_id == 'comment' or not raw_note_id.isdigit():
+            continue
+        per_note_comments[NoteId(int(raw_note_id))] = value
+
+    for raw_note_id in raw_ids.split(';'):
+        raw_note_id = raw_note_id.strip()
+        if not raw_note_id or not raw_note_id.isdigit():
+            continue
+        note_id = NoteId(int(raw_note_id))
+        if note_id in seen:
+            continue
+        seen.add(note_id)
+        note_ids.append(note_id)
+
+    if not note_ids:
+        return []
+
+    notes = await NoteQuery.find(note_ids=note_ids, limit=len(note_ids))
+    available = {
+        note['id']
+        for note in notes
+        if note['closed_at'] is None and note['hidden_at'] is None
+    }
+
+    return [
+        (note_id, per_note_comments.get(note_id, default_comment))
+        for note_id in note_ids
+        if note_id in available
+    ]
 
 
 async def _delete_empty():

--- a/tests/controllers/test_api06_changeset.py
+++ b/tests/controllers/test_api06_changeset.py
@@ -255,6 +255,87 @@ async def test_changeset_update_closed(client: AsyncClient):
     assert r.status_code == status.HTTP_409_CONFLICT, r.text
 
 
+async def test_changeset_close_auto_closes_notes(client: AsyncClient):
+    client.headers['Authorization'] = 'User user1'
+
+    async def create_note(text: str) -> int:
+        r = await client.post(
+            '/api/0.6/notes.json',
+            json={'lon': 0, 'lat': 0, 'text': text},
+        )
+        assert r.is_success, r.text
+        return r.json()['properties']['id']
+
+    note1_id = await create_note('changeset-close-note-1')
+    note2_id = await create_note('changeset-close-note-2')
+    note3_id = await create_note('changeset-close-note-3')
+
+    r = await client.post(
+        f'/api/0.6/notes/{note3_id}/close.json',
+        params={'text': 'already closed'},
+    )
+    assert r.is_success, r.text
+    note3_before = r.json()['properties']
+
+    r = await client.put(
+        '/api/0.6/changeset/create',
+        content=XMLToDict.unparse({
+            'osm': {
+                'changeset': {
+                    'tag': [
+                        {'@k': 'comment', '@v': 'changeset fallback'},
+                        {
+                            '@k': 'created_by',
+                            '@v': test_changeset_close_auto_closes_notes.__name__,
+                        },
+                        {'@k': 'closes:note', '@v': f'{note1_id};{note2_id};{note3_id}'},
+                        {
+                            '@k': f'closes:note:{note2_id}:comment',
+                            '@v': 'specific close message',
+                        },
+                    ]
+                }
+            }
+        }),
+    )
+    assert r.is_success, r.text
+    changeset_id = int(r.text)
+
+    r = await client.put(f'/api/0.6/changeset/{changeset_id}/close')
+    assert r.is_success, r.text
+
+    r = await client.get(f'/api/0.6/notes/{note1_id}.json')
+    assert r.is_success, r.text
+    note1 = r.json()['properties']
+    assert_model(note1, {'status': 'closed'})
+    assert_model(
+        note1['comments'][-1],
+        {
+            'user': 'user1',
+            'action': 'closed',
+            'text': 'changeset fallback',
+        },
+    )
+
+    r = await client.get(f'/api/0.6/notes/{note2_id}.json')
+    assert r.is_success, r.text
+    note2 = r.json()['properties']
+    assert_model(note2, {'status': 'closed'})
+    assert_model(
+        note2['comments'][-1],
+        {
+            'user': 'user1',
+            'action': 'closed',
+            'text': 'specific close message',
+        },
+    )
+
+    r = await client.get(f'/api/0.6/notes/{note3_id}.json')
+    assert r.is_success, r.text
+    note3 = r.json()['properties']
+    assert note3['comments'] == note3_before['comments']
+
+
 async def test_changeset_upload_closed(client: AsyncClient):
     client.headers['Authorization'] = 'User user1'
 


### PR DESCRIPTION
Closes #126

## Summary
- read closes:note ids from changeset tags during explicit changeset close
- use the changeset comment as the default close note comment
- support per-note overrides with closes:note:<id>:comment
- skip notes that are already closed or unavailable
- cover default comment, per-note override, and already-closed note behavior in API 0.6 changeset tests

## Verification
- /Users/lyy/Documents/Codex/2026-05-21/10/openstreetmap-ng/.venv/bin/python -m py_compile app/services/changeset_service.py tests/controllers/test_api06_changeset.py
- pytest not run here because the local .venv does not yet have the project test dependencies installed
