### PR TITLE
feat: append note creation hashtag

### DIFF
--- a/app/services/note_service.py
+++ b/app/services/note_service.py
@@ -27,12 +27,15 @@ from app.services.email_service import EmailService
 from app.services.user_subscription_service import UserSubscriptionService
 from app.validators.geometry import validate_geometry
 
+_NOTE_CREATE_HASHTAG = '#osm-ng'
+
 
 class NoteService:
     @staticmethod
     async def create(lon: float, lat: float, text: str) -> NoteId:
         """Create a note and return its id."""
         point = validate_geometry(Point(lon, lat))
+        text = _with_note_create_hashtag(text)
 
         user = auth_user()
         if user is not None:
@@ -247,6 +250,12 @@ async def _send_activity_email(note: Note, comment: NoteComment):
                     ref=ref,
                 )
             )
+
+
+def _with_note_create_hashtag(text: str):
+    if _NOTE_CREATE_HASHTAG.lower() in text.lower():
+        return text
+    return f'{text}\n\n{_NOTE_CREATE_HASHTAG}'
 
 
 @cython.cfunc


### PR DESCRIPTION
Closes #76

## Summary
- append #osm-ng to newly created notes by default
- keep the behavior centralized in NoteService.create so API and RPC note creation stay in sync
- avoid duplicating the hashtag when the note text already includes it
- cover XML, JSON, anonymous, and no-duplicate creation flows in API 0.6 note tests

## Verification
- /Users/lyy/Documents/Codex/2026-05-21/10/openstreetmap-ng/.venv/bin/python -m py_compile app/services/note_service.py tests/controllers/test_api06_note.py
- pytest not run here because the local .venv does not yet have the project test dependencies installed
