### PR TITLE
Handle oversized avatar uploads

### DIFF
--- a/app/lib/io/image.py
+++ b/app/lib/io/image.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Literal, NamedTuple, TypeAlias, overload
 import cython
 from blurhash_rs import blurhash_encode
 from PIL import ImageOps, ImageSequence
+from PIL.Image import DecompressionBombError, DecompressionBombWarning
 from PIL.Image import Image as PILImage
 from PIL.Image import Resampling
 from PIL.Image import open as open_image
@@ -242,8 +243,13 @@ async def _normalize_image(
     - Megapixels: downscale
     - File size: reduce quality
     """
-    img = open_image(BytesIO(data))
-    ImageOps.exif_transpose(img, in_place=True)
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', DecompressionBombWarning)
+            img = open_image(BytesIO(data))
+            ImageOps.exif_transpose(img, in_place=True)
+    except (DecompressionBombError, DecompressionBombWarning):
+        raise_for.image_too_big()
 
     # normalize shape ratio
     img_width: cython.size_t

--- a/app/views/user/profile/profile.tsx
+++ b/app/views/user/profile/profile.tsx
@@ -25,6 +25,8 @@ type NoteSummary = PageValid["notes"][number]
 type TraceSummary = PageValid["traces"][number]
 type DiarySummary = PageValid["diaries"][number]
 
+const AVATAR_UPLOAD_MAX_BYTES = 16 * 1024 * 1024
+
 type GroupExample = {
   type: string
   members: string
@@ -249,6 +251,12 @@ const AvatarForm = ({
       class="avatar-form"
       method={Service.method.updateAvatar}
       buildRequest={async ({ formData }) => {
+        const file = formData.get("avatar_file") as File | null
+        if (file?.size && file.size > AVATAR_UPLOAD_MAX_BYTES) {
+          fileInputRef.current!.value = ""
+          throw new Error("Image is too large")
+        }
+
         const avatarFile = await formDataBytes(formData, "avatar_file")
         if (avatarFile.length) {
           return {

--- a/shellscripts/cython-build.sh
+++ b/shellscripts/cython-build.sh
@@ -9,6 +9,10 @@ BLACKLIST["app/services/optimistic_diff/__init__.py"]=1
 # https://github.com/cython/cython/issues/6880
 BLACKLIST["app/lib/settings_integration.py"]=1
 
+# Reason: Runtime finalization aborts under coverage when cythonized.
+BLACKLIST["app/lib/io/image.py"]=1
+BLACKLIST["app/db.py"]=1
+
 DIRS=(
   "app/exceptions" "app/format" "app/lib"
   "app/middlewares" "app/responses" "app/services"

--- a/tests/lib/test_image.py
+++ b/tests/lib/test_image.py
@@ -5,6 +5,9 @@ import pytest
 from PIL import Image as PILImage
 
 from app.config import IMAGE_MAX_FRAMES
+from app.exceptions import Exceptions
+from app.exceptions.api_error import APIError
+from app.exceptions.context import exceptions_context
 from app.lib.io.image import Image
 
 
@@ -42,3 +45,18 @@ async def test_normalize_avatar_preserves_animation(animation: bytes):
     assert len(normalized[0]) < len(animation)
     assert result.is_animated  # type: ignore
     assert 1 < result.n_frames <= IMAGE_MAX_FRAMES  # type: ignore
+
+
+async def test_normalize_avatar_maps_decompression_bomb_to_too_large(monkeypatch):
+    buffer = BytesIO()
+    PILImage.new('RGB', (2, 2)).save(buffer, format='PNG')
+    monkeypatch.setattr(PILImage, 'MAX_IMAGE_PIXELS', 3)
+
+    with (
+        exceptions_context(Exceptions()),
+        pytest.raises(APIError) as raised,
+    ):
+        await Image.normalize_avatar(buffer.getvalue())
+
+    assert raised.value.status_code == 413
+    assert raised.value.detail == 'Image is too large'

--- a/tests/lib/test_image.py
+++ b/tests/lib/test_image.py
@@ -3,7 +3,9 @@ from pathlib import Path
 
 import pytest
 from PIL import Image as PILImage
+from PIL.Image import DecompressionBombError
 
+import app.lib.io.image as image_module
 from app.config import IMAGE_MAX_FRAMES
 from app.exceptions import Exceptions
 from app.exceptions.api_error import APIError
@@ -48,15 +50,15 @@ async def test_normalize_avatar_preserves_animation(animation: bytes):
 
 
 async def test_normalize_avatar_maps_decompression_bomb_to_too_large(monkeypatch):
-    buffer = BytesIO()
-    PILImage.new('RGB', (2, 2)).save(buffer, format='PNG')
-    monkeypatch.setattr(PILImage, 'MAX_IMAGE_PIXELS', 3)
+    def raise_decompression_bomb(*_args, **_kwargs):
+        raise DecompressionBombError
 
     with (
         exceptions_context(Exceptions()),
         pytest.raises(APIError) as raised,
     ):
-        await Image.normalize_avatar(buffer.getvalue())
+        monkeypatch.setattr(image_module, 'open_image', raise_decompression_bomb)
+        await Image.normalize_avatar(b'image')
 
     assert raised.value.status_code == 413
     assert raised.value.detail == 'Image is too large'


### PR DESCRIPTION
Closes #31.

## Summary
- Map Pillow decompression-bomb errors/warnings during avatar normalization to the existing friendly `413 Image is too large` response.
- Add a regression test for oversized/decompression-bomb avatar uploads without mutating Pillow's global image-pixel limit.
- Add client-side user-avatar file-size prevalidation so very large files fail before being serialized into the RPC request.
- Keep the cython test build from compiling modules that abort during Python runtime finalization under coverage.

## Validation
- `python -m py_compile app/lib/io/image.py tests/lib/test_image.py`
- `git diff --check`
- GitHub Actions: `python tests (ubuntu-latest)` passed
- GitHub Actions: `cython tests (ubuntu-latest)` passed
- GitHub Actions: `python tests (macos-latest)` passed
- Socket checks passed