### PR TITLE
Handle oversized avatar uploads gracefully

### DIFF
--- a/app/lib/io/image.py
+++ b/app/lib/io/image.py
@@ -11,6 +11,7 @@ import cython
 from blurhash_rs import blurhash_encode
 from PIL import ImageOps, ImageSequence
 from PIL.Image import Image as PILImage
+from PIL.Image import DecompressionBombError
 from PIL.Image import Resampling
 from PIL.Image import open as open_image
 from sizestr import sizestr
@@ -242,8 +243,11 @@ async def _normalize_image(
     - Megapixels: downscale
     - File size: reduce quality
     """
-    img = open_image(BytesIO(data))
-    ImageOps.exif_transpose(img, in_place=True)
+    try:
+        img = open_image(BytesIO(data))
+        ImageOps.exif_transpose(img, in_place=True)
+    except DecompressionBombError:
+        raise_for.image_too_big()
 
     # normalize shape ratio
     img_width: cython.size_t

--- a/app/views/settings/applications/edit.tsx
+++ b/app/views/settings/applications/edit.tsx
@@ -12,6 +12,9 @@ import { useRef } from "preact/hooks"
 import { Nav } from "../nav"
 import { ApplicationsNav } from "./_nav"
 
+const AVATAR_MAX_FILE_SIZE = 80 * 1024
+const AVATAR_TOO_BIG_MESSAGE = "Image is too large"
+
 mountProtoPage(
   EditPageSchema,
   ({
@@ -247,10 +250,20 @@ mountProtoPage(
                         class="avatar-form"
                         formRef={avatarFormRef}
                         method={Service.method.updateAvatar}
-                        buildRequest={async ({ formData }) => ({
-                          id,
-                          avatarFile: await formDataBytes(formData, "avatar_file"),
-                        })}
+                        buildRequest={async ({ formData }) => {
+                          const avatarFileEntry = formData.get("avatar_file")
+                          if (
+                            avatarFileEntry instanceof Blob &&
+                            avatarFileEntry.size > AVATAR_MAX_FILE_SIZE
+                          ) {
+                            throw new Error(AVATAR_TOO_BIG_MESSAGE)
+                          }
+
+                          return {
+                            id,
+                            avatarFile: await formDataBytes(formData, "avatar_file"),
+                          }
+                        }}
                         onSuccess={(resp) => (avatarUrl.value = resp.avatarUrl)}
                       >
                         <input

--- a/app/views/user/profile/profile.tsx
+++ b/app/views/user/profile/profile.tsx
@@ -35,6 +35,9 @@ type GroupExample = {
   exclusive?: boolean
 }
 
+const AVATAR_MAX_FILE_SIZE = 80 * 1024
+const AVATAR_TOO_BIG_MESSAGE = "Image is too large"
+
 const GROUP_EXAMPLES: readonly GroupExample[] = [
   {
     type: "Invite-only",
@@ -249,6 +252,14 @@ const AvatarForm = ({
       class="avatar-form"
       method={Service.method.updateAvatar}
       buildRequest={async ({ formData }) => {
+        const avatarFileEntry = formData.get("avatar_file")
+        if (
+          avatarFileEntry instanceof Blob &&
+          avatarFileEntry.size > AVATAR_MAX_FILE_SIZE
+        ) {
+          throw new Error(AVATAR_TOO_BIG_MESSAGE)
+        }
+
         const avatarFile = await formDataBytes(formData, "avatar_file")
         if (avatarFile.length) {
           return {

--- a/tests/lib/test_image.py
+++ b/tests/lib/test_image.py
@@ -2,9 +2,11 @@ from io import BytesIO
 from pathlib import Path
 
 import pytest
+from fastapi import status
 from PIL import Image as PILImage
 
 from app.config import IMAGE_MAX_FRAMES
+from app.exceptions.api_error import APIError
 from app.lib.io.image import Image
 
 
@@ -42,3 +44,16 @@ async def test_normalize_avatar_preserves_animation(animation: bytes):
     assert len(normalized[0]) < len(animation)
     assert result.is_animated  # type: ignore
     assert 1 < result.n_frames <= IMAGE_MAX_FRAMES  # type: ignore
+
+
+async def test_normalize_avatar_handles_decompression_bomb(monkeypatch):
+    buffer = BytesIO()
+    PILImage.new('RGB', (10, 10), 'white').save(buffer, format='PNG')
+
+    monkeypatch.setattr(PILImage, 'MAX_IMAGE_PIXELS', 1)
+
+    with pytest.raises(APIError) as e:
+        await Image.normalize_avatar(buffer.getvalue())
+
+    assert e.value.status_code == status.HTTP_413_CONTENT_TOO_LARGE
+    assert e.value.detail == 'Image is too large'


### PR DESCRIPTION
Fixes #31.

## Summary
- reject avatar files larger than the configured 80 KiB limit before converting them to RPC bytes in the profile and app avatar forms
- translate Pillow decompression-bomb failures into the existing friendly 413 Image is too large API error
- add a focused unit test for the decompression-bomb path

## Verification
- python -m py_compile app\\lib\\io\\image.py tests\\lib\\test_image.py
- Pillow smoke check confirms the test fixture triggers DecompressionBombError

I also attempted pytest tests/lib/test_image.py -q, but this checkout lacks generated protobuf Python modules (pp.models.proto.audit_types) unless the repo bootstrap/proto pipeline is run.