### PR TITLE
Add Achavi changeset diff link

### DIFF
--- a/app/views/index/changeset.tsx
+++ b/app/views/index/changeset.tsx
@@ -208,6 +208,9 @@ const ChangesetComment = ({
   </li>
 )
 
+const getAchaviChangesetUrl = (changesetId: bigint) =>
+  `https://overpass-api.de/achavi/?changeset=${changesetId.toString()}`
+
 const ChangesetFooter = ({ data }: { data: DataValid }) => {
   const changesetIdStr = data.id.toString()
   return (
@@ -377,6 +380,18 @@ const ChangesetSidebar = ({
 
             <ChangesetHeader data={d} />
             <Tags tags={d.tags} />
+
+            <div class="d-grid mt-3">
+              <a
+                class="btn btn-sm btn-soft"
+                href={getAchaviChangesetUrl(d.id)}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <i class="bi bi-box-arrow-up-right me-1" />
+                {t("browse.changeset.open_changeset_diff")}
+              </a>
+            </div>
 
             {/* Report button */}
             {isLoggedIn && d.user && config.userConfig!.user.id !== d.user.id && (

--- a/config/locale/download/en.yaml
+++ b/config/locale/download/en.yaml
@@ -372,6 +372,7 @@ en:
       comment_by_html: Comment from %{user} %{time_ago}
       changesetxml: Changeset XML
       osmchangexml: osmChange XML
+      open_changeset_diff: Open changeset diff
       feed:
         title: Changeset %{id}
         title_comment: Changeset %{id} - %{comment}


### PR DESCRIPTION
Adds an external Achavi changeset diff action to the changeset sidebar.

- Adds an Open changeset diff button on changeset detail views.
- Opens https://overpass-api.de/achavi/?changeset=<id> in a new tab so the current OSM-NG page is not refreshed.
- Adds the English locale string for the button.

Addresses #7.