### PR TITLE
Add changeset diff action

### DIFF
--- a/app/views/index/changeset.tsx
+++ b/app/views/index/changeset.tsx
@@ -122,6 +122,26 @@ const ChangesetHeader = ({ data }: { data: DataValid }) => {
   )
 }
 
+const getAchaviChangesetDiffUrl = (changesetId: bigint) =>
+  `https://overpass-api.de/achavi/?changeset=${changesetId}`
+
+const ChangesetActions = ({ changesetId }: { changesetId: bigint }) => (
+  <div class="d-flex flex-wrap gap-2 mt-3">
+    <a
+      class="btn btn-sm btn-soft"
+      href={getAchaviChangesetDiffUrl(changesetId)}
+      target="_blank"
+      rel="noopener"
+    >
+      <i
+        class="bi bi-box-arrow-up-right me-1"
+        aria-hidden="true"
+      />
+      {t("changeset.open_changeset_diff")}
+    </a>
+  </div>
+)
+
 const SubscriptionForm = ({
   changesetId,
   isSubscribed,
@@ -377,6 +397,7 @@ const ChangesetSidebar = ({
 
             <ChangesetHeader data={d} />
             <Tags tags={d.tags} />
+            <ChangesetActions changesetId={d.id} />
 
             {/* Report button */}
             {isLoggedIn && d.user && config.userConfig!.user.id !== d.user.id && (

--- a/config/locale/extra_en.yaml
+++ b/config/locale/extra_en.yaml
@@ -39,6 +39,7 @@ map:
       title: Routing engine
 changeset:
   open: Open
+  open_changeset_diff: Open changeset diff
   this_changeset_is_state: This changeset is {{state}}
   count_one: "changeset"
   count_other: "changesets"


### PR DESCRIPTION
## Summary
- Add an external "Open changeset diff" action to the changeset sidebar.
- Open the Achavi changeset diff view in a new tab so the current OSM-NG page stays in place.
- Add the English label for the new action.

## Validation
- `git diff --check -- app/views/index/changeset.tsx config/locale/extra_en.yaml`
- `npx prettier --no-semi --single-attribute-per-line --check app/views/index/changeset.tsx config/locale/extra_en.yaml`
- `npx tsc --noEmit --pretty false` could not complete in this checkout because generated `@proto/*` TypeScript bindings are not present; the failure appears before app type-checking can run normally.

Fixes #7
/claim #7
