### PR TITLE
Close tagged notes from changesets

### DIFF
--- a/app/services/changeset_service.py
+++ b/app/services/changeset_service.py
@@ -299,10 +299,11 @@ async def _close_inactive():
             conn=conn,
         )
 
-        for user_id, tags in rows:
-            await _close_tagged_notes(conn, user_id, tags)
-
     if rows:
+        async with db(True) as conn:
+            for user_id, tags in rows:
+                await _close_tagged_notes(conn, user_id, tags)
+
         logging.debug('Closed %d inactive changesets', len(rows))
 
 

--- a/app/services/changeset_service.py
+++ b/app/services/changeset_service.py
@@ -7,6 +7,7 @@ from random import uniform
 from time import monotonic
 
 import cython
+from psycopg import AsyncConnection
 from sentry_sdk.api import start_transaction
 
 from app.config import (
@@ -19,6 +20,7 @@ from app.db import (
     db_delete,
     db_fetchcol,
     db_fetchrow,
+    db_fetchrows,
     db_fetchval,
     db_insert,
     db_lock,
@@ -38,11 +40,18 @@ from app.models.db.changeset_comment import (
     ChangesetComment,
     changeset_comments_resolve_rich_text,
 )
-from app.models.types import ChangesetCommentId, ChangesetId, DisplayName, UserId
+from app.models.types import (
+    ChangesetCommentId,
+    ChangesetId,
+    DisplayName,
+    NoteId,
+    UserId,
+)
 from app.queries.changeset_query import ChangesetQuery
 from app.queries.user_query import UserQuery
 from app.queries.user_subscription_query import UserSubscriptionQuery
 from app.services.email_service import EmailService
+from app.services.note_service import NoteService
 from app.services.user_subscription_service import UserSubscriptionService
 
 _PROCESS_REQUEST_EVENT = Event()
@@ -112,7 +121,7 @@ class ChangesetService:
         async with db(True) as conn:
             row = await db_fetchrow(
                 t"""
-                    SELECT user_id, closed_at
+                    SELECT user_id, closed_at, tags
                     FROM changeset
                     WHERE id = {changeset_id}
                 """,
@@ -124,7 +133,8 @@ class ChangesetService:
 
             changeset_user_id: UserId
             closed_at: datetime | None
-            changeset_user_id, closed_at = row
+            tags: dict[str, str]
+            changeset_user_id, closed_at, tags = row
 
             if changeset_user_id != user_id:
                 raise_for.changeset_access_denied()
@@ -141,6 +151,7 @@ class ChangesetService:
                 conn=conn,
             )
             await audit('close_changeset', conn, extra={'id': changeset_id})
+            await _close_tagged_notes(conn, changeset_user_id, tags)
 
     @staticmethod
     @asynccontextmanager
@@ -272,18 +283,65 @@ async def _process_task():
 
 async def _close_inactive():
     """Close all inactive changesets."""
-    rowcount = await db_update(
-        'changeset',
-        {'closed_at': t'statement_timestamp()', 'updated_at': t'DEFAULT'},
-        where=t"""closed_at IS NULL AND (
-                updated_at < statement_timestamp() - {CHANGESET_IDLE_TIMEOUT} OR
-                (updated_at >= statement_timestamp() - {CHANGESET_IDLE_TIMEOUT} AND
-                created_at < statement_timestamp() - {CHANGESET_OPEN_TIMEOUT})
-            )""",
-    )
+    async with db(True) as conn:
+        rows: list[tuple[UserId | None, dict[str, str]]] = await db_fetchrows(
+            t"""
+                UPDATE changeset
+                SET closed_at = statement_timestamp(),
+                    updated_at = DEFAULT
+                WHERE closed_at IS NULL AND (
+                    updated_at < statement_timestamp() - {CHANGESET_IDLE_TIMEOUT} OR
+                    (updated_at >= statement_timestamp() - {CHANGESET_IDLE_TIMEOUT} AND
+                    created_at < statement_timestamp() - {CHANGESET_OPEN_TIMEOUT})
+                )
+                RETURNING user_id, tags
+            """,
+            conn=conn,
+        )
 
-    if rowcount:
-        logging.debug('Closed %d inactive changesets', rowcount)
+        for user_id, tags in rows:
+            await _close_tagged_notes(conn, user_id, tags)
+
+    if rows:
+        logging.debug('Closed %d inactive changesets', len(rows))
+
+
+def _parse_tagged_note_closures(tags: dict[str, str]) -> dict[NoteId, str]:
+    raw_ids = tags.get('closes:note')
+    if not raw_ids:
+        return {}
+
+    default_comment = (
+        tags['closes:note:comment']
+        if 'closes:note:comment' in tags
+        else tags.get('comment', '')
+    )
+    result: dict[NoteId, str] = {}
+
+    for raw_note_id in raw_ids.split(';'):
+        raw_note_id = raw_note_id.strip()
+        if not raw_note_id.isdecimal():
+            continue
+
+        note_id_int = int(raw_note_id)
+        if note_id_int <= 0:
+            continue
+
+        note_id = NoteId(note_id_int)
+        result.setdefault(
+            note_id, tags.get(f'closes:note:{note_id}:comment', default_comment)
+        )
+
+    return result
+
+
+async def _close_tagged_notes(
+    conn: AsyncConnection,
+    user_id: UserId | None,
+    tags: dict[str, str],
+):
+    for note_id, comment in _parse_tagged_note_closures(tags).items():
+        await NoteService.close_if_open(note_id, comment, user_id, conn=conn)
 
 
 async def _delete_empty():

--- a/app/services/note_service.py
+++ b/app/services/note_service.py
@@ -3,6 +3,8 @@ from datetime import datetime
 from typing import Any
 
 import cython
+from app.models.proto.note_types import GetCommentsResponse_Comment_Event
+from psycopg import AsyncConnection
 from shapely import Point, get_coordinates
 
 from app.db import db, db_fetchone, db_insert, db_update
@@ -18,8 +20,7 @@ from app.models.db.note_comment import (
     note_comments_resolve_rich_text,
 )
 from app.models.db.user import user_is_moderator
-from app.models.proto.note_types import GetCommentsResponse_Comment_Event
-from app.models.types import DisplayName, NoteCommentId, NoteId
+from app.models.types import DisplayName, NoteCommentId, NoteId, UserId
 from app.queries.nominatim_query import NominatimQuery
 from app.queries.note_query import NoteCommentQuery
 from app.queries.user_subscription_query import UserSubscriptionQuery
@@ -180,6 +181,74 @@ class NoteService:
             if send_activity_email:
                 tg.create_task(_send_activity_email(note, comment))
             tg.create_task(UserSubscriptionService.subscribe('note', note_id))
+
+    @staticmethod
+    async def close_if_open(
+        note_id: NoteId,
+        text: str,
+        user_id: UserId | None,
+        *,
+        conn: AsyncConnection,
+    ) -> bool:
+        """
+        Close a note as the given user, returning False for notes that cannot be
+        closed because they are missing, hidden, already closed, or anonymous.
+        """
+        if user_id is None:
+            return False
+
+        async with await conn.execute(
+            t"""
+                WITH target_note AS (
+                    SELECT id
+                    FROM note
+                    WHERE id = {note_id}
+                    AND closed_at IS NULL
+                    AND hidden_at IS NULL
+                    FOR UPDATE
+                ),
+                inserted_comment AS (
+                    INSERT INTO note_comment (
+                        user_id, user_ip, note_id, event, body
+                    )
+                    SELECT {user_id}, NULL, id, 'closed', {text}
+                    FROM target_note
+                    RETURNING id, note_id, created_at
+                )
+                UPDATE note
+                SET closed_at = inserted_comment.created_at,
+                    updated_at = inserted_comment.created_at
+                FROM inserted_comment
+                WHERE note.id = inserted_comment.note_id
+                RETURNING inserted_comment.id
+            """,
+        ) as r:
+            row = await r.fetchone()
+
+        if row is None:
+            return False
+
+        comment_id: NoteCommentId = row[0]
+        await db_insert(
+            'user_subscription',
+            {'user_id': user_id, 'target': 'note', 'target_id': note_id},
+            on_conflict=t'DO NOTHING',
+            conn=conn,
+        )
+        if text:
+            await audit(
+                'create_note_comment',
+                conn,
+                user_id=user_id,
+                extra={'id': comment_id, 'note': note_id},
+            )
+        await audit(
+            'update_note_status',
+            conn,
+            user_id=user_id,
+            extra={'id': note_id, 'event': 'closed'},
+        )
+        return True
 
 
 async def _send_activity_email(note: Note, comment: NoteComment):

--- a/app/services/note_service.py
+++ b/app/services/note_service.py
@@ -235,13 +235,12 @@ class NoteService:
             on_conflict=t'DO NOTHING',
             conn=conn,
         )
-        if text:
-            await audit(
-                'create_note_comment',
-                conn,
-                user_id=user_id,
-                extra={'id': comment_id, 'note': note_id},
-            )
+        await audit(
+            'create_note_comment',
+            conn,
+            user_id=user_id,
+            extra={'id': comment_id, 'note': note_id},
+        )
         await audit(
             'update_note_status',
             conn,

--- a/tests/controllers/test_api06_changeset.py
+++ b/tests/controllers/test_api06_changeset.py
@@ -305,7 +305,6 @@ async def test_changeset_close_closes_tagged_notes(client: AsyncClient):
                             '@k': f'closes:note:{specific_note_id}:comment',
                             '@v': 'specific close message',
                         },
-                        {'@k': f'closes:note:{empty_note_id}:comment', '@v': ''},
                     ]
                 }
             }
@@ -313,6 +312,21 @@ async def test_changeset_close_closes_tagged_notes(client: AsyncClient):
     )
     assert r.is_success, r.text
     changeset_id = int(r.text)
+
+    # Empty OSM tag values are invalid at the API boundary, but existing
+    # database records may still contain them.
+    async with db(True) as conn:
+        await conn.execute(
+            """
+            UPDATE changeset
+            SET tags = tags || hstore(%(key)s, '')
+            WHERE id = %(changeset_id)s
+            """,
+            {
+                'key': f'closes:note:{empty_note_id}:comment',
+                'changeset_id': changeset_id,
+            },
+        )
 
     r = await client.put(f'/api/0.6/changeset/{changeset_id}/close')
     assert r.is_success, r.text

--- a/tests/controllers/test_api06_changeset.py
+++ b/tests/controllers/test_api06_changeset.py
@@ -12,10 +12,9 @@ from app.config import (
     TAGS_LIMIT,
     TAGS_MAX_SIZE,
 )
-from app.db import db_update
+from app.db import db
 from app.format import Format06
 from app.lib.io.xml_codec import XMLToDict
-from app.lib.time.date_utils import utcnow
 from app.services.changeset_service import ChangesetService
 from tests.utils.assert_model import assert_model
 
@@ -385,12 +384,18 @@ async def test_inactive_changeset_closes_tagged_notes(client: AsyncClient):
     assert r.is_success, r.text
     changeset_id = int(r.text)
 
-    inactive_time = utcnow() - CHANGESET_IDLE_TIMEOUT - timedelta(seconds=1)
-    await db_update(
-        'changeset',
-        {'updated_at': inactive_time},
-        where={'id': changeset_id},
-    )
+    async with db(True) as conn:
+        await conn.execute(
+            """
+            UPDATE changeset
+            SET updated_at = statement_timestamp() - %(inactive_age)s
+            WHERE id = %(changeset_id)s
+            """,
+            {
+                'inactive_age': CHANGESET_IDLE_TIMEOUT + timedelta(seconds=1),
+                'changeset_id': changeset_id,
+            },
+        )
 
     await ChangesetService.force_process()
 

--- a/tests/controllers/test_api06_changeset.py
+++ b/tests/controllers/test_api06_changeset.py
@@ -1,18 +1,22 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
-from annotated_types import Gt
+from annotated_types import Gt, Len
 from httpx import AsyncClient
 from starlette import status
 
 from app.config import (
+    CHANGESET_IDLE_TIMEOUT,
     LEGACY_HIGH_PRECISION_TIME,
     TAGS_KEY_MAX_LENGTH,
     TAGS_LIMIT,
     TAGS_MAX_SIZE,
 )
+from app.db import db_update
 from app.format import Format06
 from app.lib.io.xml_codec import XMLToDict
+from app.lib.time.date_utils import utcnow
+from app.services.changeset_service import ChangesetService
 from tests.utils.assert_model import assert_model
 
 
@@ -253,6 +257,151 @@ async def test_changeset_update_closed(client: AsyncClient):
         }),
     )
     assert r.status_code == status.HTTP_409_CONFLICT, r.text
+
+
+async def test_changeset_close_closes_tagged_notes(client: AsyncClient):
+    client.headers['Authorization'] = 'User user1'
+
+    async def create_note(text: str) -> int:
+        r = await client.post(
+            '/api/0.6/notes.json',
+            json={'lon': 0, 'lat': 0, 'text': text},
+        )
+        assert r.is_success, r.text
+        return r.json()['properties']['id']
+
+    global_note_id = await create_note('global close note')
+    specific_note_id = await create_note('specific close note')
+    empty_note_id = await create_note('empty close note')
+    already_closed_note_id = await create_note('already closed note')
+
+    r = await client.post(
+        f'/api/0.6/notes/{already_closed_note_id}/close.json',
+        params={'text': 'already closed'},
+    )
+    assert r.is_success, r.text
+    already_closed_before = r.json()['properties']
+
+    r = await client.put(
+        '/api/0.6/changeset/create',
+        content=XMLToDict.unparse({
+            'osm': {
+                'changeset': {
+                    'tag': [
+                        {'@k': 'comment', '@v': 'changeset fallback'},
+                        {
+                            '@k': 'created_by',
+                            '@v': test_changeset_close_closes_tagged_notes.__name__,
+                        },
+                        {
+                            '@k': 'closes:note',
+                            '@v': (
+                                f'{global_note_id};invalid;0;{specific_note_id};'
+                                f'{specific_note_id};{empty_note_id};'
+                                f'{already_closed_note_id};999999999'
+                            ),
+                        },
+                        {'@k': 'closes:note:comment', '@v': 'global close message'},
+                        {
+                            '@k': f'closes:note:{specific_note_id}:comment',
+                            '@v': 'specific close message',
+                        },
+                        {'@k': f'closes:note:{empty_note_id}:comment', '@v': ''},
+                    ]
+                }
+            }
+        }),
+    )
+    assert r.is_success, r.text
+    changeset_id = int(r.text)
+
+    r = await client.put(f'/api/0.6/changeset/{changeset_id}/close')
+    assert r.is_success, r.text
+
+    r = await client.get(f'/api/0.6/notes/{global_note_id}.json')
+    assert r.is_success, r.text
+    global_note = r.json()['properties']
+    assert_model(global_note, {'status': 'closed', 'comments': Len(2, 2)})
+    assert_model(
+        global_note['comments'][-1],
+        {'user': 'user1', 'action': 'closed', 'text': 'global close message'},
+    )
+
+    r = await client.get(f'/api/0.6/notes/{specific_note_id}.json')
+    assert r.is_success, r.text
+    specific_note = r.json()['properties']
+    assert_model(specific_note, {'status': 'closed', 'comments': Len(2, 2)})
+    assert_model(
+        specific_note['comments'][-1],
+        {'user': 'user1', 'action': 'closed', 'text': 'specific close message'},
+    )
+
+    r = await client.get(f'/api/0.6/notes/{empty_note_id}.json')
+    assert r.is_success, r.text
+    empty_note = r.json()['properties']
+    assert_model(empty_note, {'status': 'closed', 'comments': Len(2, 2)})
+    assert_model(
+        empty_note['comments'][-1],
+        {'user': 'user1', 'action': 'closed', 'text': ''},
+    )
+
+    r = await client.get(f'/api/0.6/notes/{already_closed_note_id}.json')
+    assert r.is_success, r.text
+    already_closed_note = r.json()['properties']
+    assert already_closed_note['comments'] == already_closed_before['comments']
+
+
+async def test_inactive_changeset_closes_tagged_notes(client: AsyncClient):
+    client.headers['Authorization'] = 'User user1'
+
+    r = await client.post(
+        '/api/0.6/notes.json',
+        json={
+            'lon': 0,
+            'lat': 0,
+            'text': test_inactive_changeset_closes_tagged_notes.__name__,
+        },
+    )
+    assert r.is_success, r.text
+    note_id = r.json()['properties']['id']
+
+    r = await client.put(
+        '/api/0.6/changeset/create',
+        content=XMLToDict.unparse({
+            'osm': {
+                'changeset': {
+                    'tag': [
+                        {
+                            '@k': 'created_by',
+                            '@v': test_inactive_changeset_closes_tagged_notes.__name__,
+                        },
+                        {'@k': 'comment', '@v': 'inactive close message'},
+                        {'@k': 'closes:note', '@v': str(note_id)},
+                    ]
+                }
+            }
+        }),
+    )
+    assert r.is_success, r.text
+    changeset_id = int(r.text)
+
+    inactive_time = utcnow() - CHANGESET_IDLE_TIMEOUT - timedelta(seconds=1)
+    await db_update(
+        'changeset',
+        {'updated_at': inactive_time},
+        where={'id': changeset_id},
+    )
+
+    await ChangesetService.force_process()
+
+    r = await client.get(f'/api/0.6/notes/{note_id}.json')
+    assert r.is_success, r.text
+    note = r.json()['properties']
+    assert_model(note, {'status': 'closed', 'comments': Len(2, 2)})
+    assert_model(
+        note['comments'][-1],
+        {'user': 'user1', 'action': 'closed', 'text': 'inactive close message'},
+    )
 
 
 async def test_changeset_upload_closed(client: AsyncClient):


### PR DESCRIPTION
Closes #126.

Bounty context: this resolves the $20 bounty issue for automatic note closing on changeset close.

## Summary
- close notes listed in `closes:note` when a changeset is closed explicitly or by the inactive changeset worker
- support changeset comments, `closes:note:comment`, and per-note `closes:note:<id>:comment` overrides, including intentionally empty override values
- skip invalid, duplicate, missing, hidden, no-user, or already closed notes without blocking changeset close
- record note close comments/status audits and subscribe the closing user to the affected notes

## Validation
- `py -3.14 -m py_compile app\services\changeset_service.py app\services\note_service.py tests\controllers\test_api06_changeset.py`
- `uvx ruff format app\services\changeset_service.py app\services\note_service.py tests\controllers\test_api06_changeset.py`
- `uvx ruff check app\services\changeset_service.py app\services\note_service.py tests\controllers\test_api06_changeset.py`
- `git diff --check`

Note: I could not run the focused pytest file in this Windows checkout because Python 3.14 has no project pytest environment installed, and the repo's `run-tests` wrapper requires dev services started through the Nix shell (not available here).