### PR TITLE
feat: close tagged notes on changeset close

### DIFF
--- a/app/services/changeset_service.py
+++ b/app/services/changeset_service.py
@@ -7,6 +7,7 @@ from random import uniform
 from time import monotonic
 
 import cython
+from psycopg import AsyncConnection
 from sentry_sdk.api import start_transaction
 
 from app.config import (
@@ -19,6 +20,7 @@ from app.db import (
     db_delete,
     db_fetchcol,
     db_fetchrow,
+    db_fetchrows,
     db_fetchval,
     db_insert,
     db_lock,
@@ -38,11 +40,18 @@ from app.models.db.changeset_comment import (
     ChangesetComment,
     changeset_comments_resolve_rich_text,
 )
-from app.models.types import ChangesetCommentId, ChangesetId, DisplayName, UserId
+from app.models.types import (
+    ChangesetCommentId,
+    ChangesetId,
+    DisplayName,
+    NoteId,
+    UserId,
+)
 from app.queries.changeset_query import ChangesetQuery
 from app.queries.user_query import UserQuery
 from app.queries.user_subscription_query import UserSubscriptionQuery
 from app.services.email_service import EmailService
+from app.services.note_service import NoteService
 from app.services.user_subscription_service import UserSubscriptionService
 
 _PROCESS_REQUEST_EVENT = Event()
@@ -112,7 +121,7 @@ class ChangesetService:
         async with db(True) as conn:
             row = await db_fetchrow(
                 t"""
-                    SELECT user_id, closed_at
+                    SELECT user_id, closed_at, tags
                     FROM changeset
                     WHERE id = {changeset_id}
                 """,
@@ -124,7 +133,8 @@ class ChangesetService:
 
             changeset_user_id: UserId
             closed_at: datetime | None
-            changeset_user_id, closed_at = row
+            tags: dict[str, str]
+            changeset_user_id, closed_at, tags = row
 
             if changeset_user_id != user_id:
                 raise_for.changeset_access_denied()
@@ -141,6 +151,7 @@ class ChangesetService:
                 conn=conn,
             )
             await audit('close_changeset', conn, extra={'id': changeset_id})
+            await _close_tagged_notes(conn, changeset_user_id, tags)
 
     @staticmethod
     @asynccontextmanager
@@ -272,18 +283,67 @@ async def _process_task():
 
 async def _close_inactive():
     """Close all inactive changesets."""
-    rowcount = await db_update(
-        'changeset',
-        {'closed_at': t'statement_timestamp()', 'updated_at': t'DEFAULT'},
-        where=t"""closed_at IS NULL AND (
-                updated_at < statement_timestamp() - {CHANGESET_IDLE_TIMEOUT} OR
-                (updated_at >= statement_timestamp() - {CHANGESET_IDLE_TIMEOUT} AND
-                created_at < statement_timestamp() - {CHANGESET_OPEN_TIMEOUT})
-            )""",
-    )
+    async with db(True) as conn:
+        rows = await db_fetchrows(
+            t"""
+                UPDATE changeset
+                SET closed_at = statement_timestamp(), updated_at = DEFAULT
+                WHERE closed_at IS NULL AND (
+                    updated_at < statement_timestamp() - {CHANGESET_IDLE_TIMEOUT} OR
+                    (updated_at >= statement_timestamp() - {CHANGESET_IDLE_TIMEOUT} AND
+                    created_at < statement_timestamp() - {CHANGESET_OPEN_TIMEOUT})
+                )
+                RETURNING user_id, tags
+            """,
+            conn=conn,
+        )
+        if rows:
+            for user_id, tags in rows:
+                await _close_tagged_notes(conn, user_id, tags)
+            logging.debug('Closed %d inactive changesets', len(rows))
 
-    if rowcount:
-        logging.debug('Closed %d inactive changesets', rowcount)
+
+def _parse_note_closure_tags(tags: dict[str, str] | None) -> dict[NoteId, str]:
+    """
+    Parse ``closes:note`` changeset tags into a {note_id: comment} mapping.
+
+    Tag format:
+        closes:note = "1;2;3"             # semicolon-separated note ids
+        closes:note:comment = "global"    # optional default comment for all notes
+        closes:note:ID:comment = "text"   # optional per-note comment override
+
+    The changeset's own ``comment`` tag is used as the default comment when
+    ``closes:note:comment`` is absent. Invalid ids (non-numeric, zero, or
+    duplicates) are silently skipped.
+    """
+    if not tags:
+        return {}
+
+    raw = tags.get('closes:note')
+    if not raw:
+        return {}
+
+    default_comment = tags.get('closes:note:comment', tags.get('comment', ''))
+    result: dict[NoteId, str] = {}
+    for part in raw.split(';'):
+        part = part.strip()
+        if not part.isdecimal():
+            continue
+        note_id = NoteId(int(part))
+        if note_id == 0 or note_id in result:
+            continue
+        result[note_id] = tags.get(f'closes:note:{note_id}:comment', default_comment)
+    return result
+
+
+async def _close_tagged_notes(
+    conn: AsyncConnection,
+    user_id: UserId | None,
+    tags: dict[str, str] | None,
+) -> None:
+    """Close all notes referenced by ``closes:note`` changeset tags."""
+    for note_id, comment in _parse_note_closure_tags(tags).items():
+        await NoteService.close_if_open(note_id, comment, user_id, conn=conn)
 
 
 async def _delete_empty():

--- a/app/services/note_service.py
+++ b/app/services/note_service.py
@@ -3,6 +3,8 @@ from datetime import datetime
 from typing import Any
 
 import cython
+from app.models.proto.note_types import GetCommentsResponse_Comment_Event
+from psycopg import AsyncConnection
 from shapely import Point, get_coordinates
 
 from app.db import db, db_fetchone, db_insert, db_update
@@ -18,8 +20,7 @@ from app.models.db.note_comment import (
     note_comments_resolve_rich_text,
 )
 from app.models.db.user import user_is_moderator
-from app.models.proto.note_types import GetCommentsResponse_Comment_Event
-from app.models.types import DisplayName, NoteCommentId, NoteId
+from app.models.types import DisplayName, NoteCommentId, NoteId, UserId
 from app.queries.nominatim_query import NominatimQuery
 from app.queries.note_query import NoteCommentQuery
 from app.queries.user_subscription_query import UserSubscriptionQuery
@@ -180,6 +181,86 @@ class NoteService:
             if send_activity_email:
                 tg.create_task(_send_activity_email(note, comment))
             tg.create_task(UserSubscriptionService.subscribe('note', note_id))
+
+    @staticmethod
+    async def close_if_open(
+        note_id: NoteId,
+        text: str,
+        user_id: UserId | None,
+        *,
+        conn: AsyncConnection,
+    ) -> bool:
+        """
+        Close a note as the given user.
+
+        Returns False when the note cannot be closed (missing, hidden, already
+        closed, or anonymous user). Used by changeset close to process
+        ``closes:note`` tags without raising on already-closed notes.
+
+        Unlike ``comment``, this method does not send an activity email and
+        accepts an explicit connection + user_id so it can run inside a
+        changeset transaction (including the background inactive-closer).
+        """
+        if user_id is None:
+            return False
+
+        note = await db_fetchone(
+            Note,
+            t"""
+                SELECT * FROM note
+                WHERE id = {note_id}
+                  AND closed_at IS NULL
+                  AND hidden_at IS NULL
+                FOR UPDATE
+            """,
+            conn=conn,
+        )
+        if note is None:
+            return False
+
+        comment_id: NoteCommentId
+        created_at: datetime
+        comment_id, created_at = await db_insert(
+            'note_comment',
+            {
+                'user_id': user_id,
+                'user_ip': None,
+                'note_id': note_id,
+                'event': 'closed',
+                'body': text,
+            },
+            returning='id, created_at',
+            conn=conn,
+        )
+
+        await db_update(
+            'note',
+            {'closed_at': created_at, 'updated_at': created_at},
+            where={'id': note_id},
+            conn=conn,
+        )
+
+        if text:
+            await audit(
+                'create_note_comment',
+                conn,
+                user_id=user_id,
+                extra={'id': comment_id, 'note': note_id},
+            )
+        await audit(
+            'update_note_status',
+            conn,
+            user_id=user_id,
+            extra={'id': note_id, 'event': 'closed'},
+        )
+
+        await db_insert(
+            'user_subscription',
+            {'user_id': user_id, 'target': 'note', 'target_id': note_id},
+            on_conflict=t'DO NOTHING',
+            conn=conn,
+        )
+        return True
 
 
 async def _send_activity_email(note: Note, comment: NoteComment):

--- a/tests/services/test_changeset_service.py
+++ b/tests/services/test_changeset_service.py
@@ -2,17 +2,25 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from psycopg.sql import SQL, Identifier
+from shapely import Point
 
 from app.config import (
     CHANGESET_EMPTY_DELETE_TIMEOUT,
     CHANGESET_IDLE_TIMEOUT,
     CHANGESET_OPEN_TIMEOUT,
 )
-from app.db import db
+from app.db import db, db_fetchone, db_insert
+from app.exceptions.api06 import Exceptions06
+from app.exceptions.context import exceptions_context
+from app.lib.auth.context import auth_context
 from app.lib.time.date_utils import utcnow
-from app.models.types import ChangesetId
+from app.models.db.note import Note
+from app.models.db.note_comment import NoteComment
+from app.models.types import ChangesetId, DisplayName, NoteId, UserId
 from app.queries.changeset_query import ChangesetQuery
+from app.queries.user_query import UserQuery
 from app.services.changeset_service import ChangesetService
+from app.services.note_service import NoteService
 
 
 async def test_changeset_inactive_close():
@@ -136,13 +144,229 @@ async def test_changeset_dont_delete_empty_recent():
     assert changeset is not None, 'Recent empty changeset must not be deleted'
 
 
+# === Tests for closes:note tag processing (issue #126) ===
+
+
+async def test_changeset_close_closes_tagged_notes():
+    user = await UserQuery.find_by_display_name(DisplayName('user1'))
+    assert user is not None, 'Test user "user1" must exist'
+    user_id = user['id']
+
+    note_id = await _create_note(user_id, 'issue reported')
+    changeset_id = await _create_changeset(
+        user_id=user_id,
+        tags={'closes:note': str(note_id), 'closes:note:comment': 'resolved'},
+    )
+
+    with exceptions_context(Exceptions06()), auth_context(user):
+        await ChangesetService.close(changeset_id)
+
+    note = await _get_note(note_id)
+    assert note is not None, 'Note must exist'
+    assert note['closed_at'] is not None, 'Note must be closed after changeset close'
+
+    comment = await _get_close_comment(note_id)
+    assert comment is not None, 'Close comment must exist'
+    assert comment['event'] == 'closed'
+    assert comment['body'] == 'resolved'
+    assert comment['user_id'] == user_id
+
+
+async def test_changeset_close_tagged_notes_per_note_comment():
+    user = await UserQuery.find_by_display_name(DisplayName('user1'))
+    assert user is not None, 'Test user "user1" must exist'
+    user_id = user['id']
+
+    note_id = await _create_note(user_id)
+    changeset_id = await _create_changeset(
+        user_id=user_id,
+        tags={
+            'closes:note': str(note_id),
+            'closes:note:comment': 'global default',
+            f'closes:note:{note_id}:comment': 'per-note override',
+        },
+    )
+
+    with exceptions_context(Exceptions06()), auth_context(user):
+        await ChangesetService.close(changeset_id)
+
+    comment = await _get_close_comment(note_id)
+    assert comment is not None, 'Close comment must exist'
+    assert comment['body'] == 'per-note override'
+
+
+async def test_changeset_close_tagged_notes_global_comment():
+    user = await UserQuery.find_by_display_name(DisplayName('user1'))
+    assert user is not None, 'Test user "user1" must exist'
+    user_id = user['id']
+
+    note1_id = await _create_note(user_id)
+    note2_id = await _create_note(user_id)
+    changeset_id = await _create_changeset(
+        user_id=user_id,
+        tags={
+            'closes:note': f'{note1_id};{note2_id}',
+            'closes:note:comment': 'global comment text',
+        },
+    )
+
+    with exceptions_context(Exceptions06()), auth_context(user):
+        await ChangesetService.close(changeset_id)
+
+    c1 = await _get_close_comment(note1_id)
+    assert c1 is not None, 'Close comment for note1 must exist'
+    assert c1['body'] == 'global comment text'
+
+    c2 = await _get_close_comment(note2_id)
+    assert c2 is not None, 'Close comment for note2 must exist'
+    assert c2['body'] == 'global comment text'
+
+
+async def test_changeset_close_tagged_notes_changeset_comment():
+    user = await UserQuery.find_by_display_name(DisplayName('user1'))
+    assert user is not None, 'Test user "user1" must exist'
+    user_id = user['id']
+
+    note_id = await _create_note(user_id)
+    changeset_id = await _create_changeset(
+        user_id=user_id,
+        tags={
+            'closes:note': str(note_id),
+            'comment': 'changeset comment text',
+        },
+    )
+
+    with exceptions_context(Exceptions06()), auth_context(user):
+        await ChangesetService.close(changeset_id)
+
+    comment = await _get_close_comment(note_id)
+    assert comment is not None, 'Close comment must exist'
+    assert comment['body'] == 'changeset comment text'
+
+
+async def test_changeset_close_tagged_notes_no_comment():
+    user = await UserQuery.find_by_display_name(DisplayName('user1'))
+    assert user is not None, 'Test user "user1" must exist'
+    user_id = user['id']
+
+    note_id = await _create_note(user_id)
+    changeset_id = await _create_changeset(
+        user_id=user_id,
+        tags={'closes:note': str(note_id)},
+    )
+
+    with exceptions_context(Exceptions06()), auth_context(user):
+        await ChangesetService.close(changeset_id)
+
+    note = await _get_note(note_id)
+    assert note is not None, 'Note must exist'
+    assert note['closed_at'] is not None, 'Note must be closed even without comment'
+
+    comment = await _get_close_comment(note_id)
+    assert comment is not None, 'Close comment must exist'
+    assert comment['event'] == 'closed'
+    assert comment['body'] == ''
+
+
+async def test_changeset_close_tagged_notes_already_closed():
+    user = await UserQuery.find_by_display_name(DisplayName('user1'))
+    assert user is not None, 'Test user "user1" must exist'
+    user_id = user['id']
+
+    note_id = await _create_note(user_id)
+
+    # Close the note first using close_if_open directly
+    async with db(True) as conn:
+        closed = await NoteService.close_if_open(
+            note_id, 'first close', user_id, conn=conn
+        )
+    assert closed, 'Initial close should succeed'
+
+    # Create a changeset referencing the already-closed note
+    changeset_id = await _create_changeset(
+        user_id=user_id,
+        tags={
+            'closes:note': str(note_id),
+            'closes:note:comment': 'should not apply',
+        },
+    )
+
+    with exceptions_context(Exceptions06()), auth_context(user):
+        await ChangesetService.close(changeset_id)
+
+    # The original close comment must remain unchanged (no new comment added)
+    comment = await _get_close_comment(note_id)
+    assert comment is not None, 'Close comment must exist'
+    assert comment['body'] == 'first close', (
+        'Already-closed note must not get new close comment'
+    )
+
+
+async def test_changeset_close_tagged_notes_invalid_ids():
+    user = await UserQuery.find_by_display_name(DisplayName('user1'))
+    assert user is not None, 'Test user "user1" must exist'
+    user_id = user['id']
+
+    note_id = await _create_note(user_id)
+    # Include invalid ids: non-numeric, zero, duplicate — only the valid one counts
+    changeset_id = await _create_changeset(
+        user_id=user_id,
+        tags={
+            'closes:note': f'{note_id};abc;0;{note_id}',
+            'closes:note:comment': 'ok',
+        },
+    )
+
+    with exceptions_context(Exceptions06()), auth_context(user):
+        await ChangesetService.close(changeset_id)
+
+    # Only the valid note should be closed, exactly once
+    note = await _get_note(note_id)
+    assert note is not None, 'Note must exist'
+    assert note['closed_at'] is not None, 'Valid note must be closed'
+
+    comment = await _get_close_comment(note_id)
+    assert comment is not None, 'Close comment must exist'
+    assert comment['body'] == 'ok'
+
+
+async def test_changeset_close_tagged_notes_inactive():
+    user = await UserQuery.find_by_display_name(DisplayName('user1'))
+    assert user is not None, 'Test user "user1" must exist'
+    user_id = user['id']
+
+    note_id = await _create_note(user_id)
+    inactive_time = utcnow() - CHANGESET_IDLE_TIMEOUT - timedelta(seconds=1)
+    await _create_changeset(
+        user_id=user_id,
+        tags={'closes:note': str(note_id), 'closes:note:comment': 'auto-closed'},
+        updated_at=inactive_time,
+    )
+
+    # Force process closes inactive changesets, which should also close tagged notes
+    await ChangesetService.force_process()
+
+    note = await _get_note(note_id)
+    assert note is not None, 'Note must exist'
+    assert note['closed_at'] is not None, (
+        'Note must be closed via inactive changeset processing'
+    )
+
+    comment = await _get_close_comment(note_id)
+    assert comment is not None, 'Close comment must exist'
+    assert comment['body'] == 'auto-closed'
+
+
 async def _create_changeset(
     created_at: datetime | None = None,
     updated_at: datetime | None = None,
     closed_at: datetime | None = None,
+    *,
+    user_id: UserId | None = None,
+    tags: dict[str, str] | None = None,
 ) -> ChangesetId:
     columns = ['user_id', 'tags']
-    params: list[Any] = [None, {}]
+    params: list[Any] = [user_id, tags or {}]
 
     if created_at is not None:
         columns.append('created_at')
@@ -171,3 +395,47 @@ async def _create_changeset(
 
     async with db(True) as conn, await conn.execute(query, params) as r:
         return (await r.fetchone())[0]  # type: ignore
+
+
+async def _create_note(user_id: UserId, text: str = 'test note') -> NoteId:
+    """Create a note with an 'opened' comment and return its id."""
+    async with db(True) as conn:
+        note_id: NoteId
+        note_created_at: datetime
+        note_id, note_created_at = await db_insert(
+            'note',
+            {'point': t'ST_QuantizeCoordinates({Point(0, 0)}, 7)'},
+            returning='id, created_at',
+            conn=conn,
+        )
+        await db_insert(
+            'note_comment',
+            {
+                'user_id': user_id,
+                'user_ip': None,
+                'note_id': note_id,
+                'event': 'opened',
+                'body': text,
+                'created_at': note_created_at,
+            },
+            conn=conn,
+        )
+    return note_id
+
+
+async def _get_note(note_id: NoteId) -> Note | None:
+    """Fetch a note by id."""
+    return await db_fetchone(Note, t'SELECT * FROM note WHERE id = {note_id}')
+
+
+async def _get_close_comment(note_id: NoteId) -> NoteComment | None:
+    """Fetch the latest 'closed' comment for a note."""
+    return await db_fetchone(
+        NoteComment,
+        t"""
+            SELECT * FROM note_comment
+            WHERE note_id = {note_id} AND event = 'closed'
+            ORDER BY id DESC
+            LIMIT 1
+        """,
+    )


### PR DESCRIPTION
Closes #126

## Summary

Implements automatic note closing when a changeset is closed, via the `closes:note` changeset tag.

When a changeset with `closes:note` tags is closed (either manually or by the inactive-closer), the referenced notes are automatically closed by the changeset author.

## Tag format

| Tag | Purpose |
|---|---|
| `closes:note` | Semicolon-separated note ids to close (e.g. `"1;2;3"`) |
| `closes:note:comment` | Default comment for all closed notes |
| `closes:note:ID:comment` | Per-note comment override |
| `comment` | Changeset comment, used as default when `closes:note:comment` is absent |

Comment priority: per-note > `closes:note:comment` > changeset `comment`.

Invalid ids (non-numeric, zero, duplicates) are silently skipped. Already-closed or hidden notes are skipped without error.

## Changes

- **`app/services/note_service.py`**: Add `NoteService.close_if_open()` — closes a note without raising on already-closed/hidden/missing notes (returns `False`). Accepts an explicit connection + user_id so it can run inside a changeset transaction, including the background inactive-closer. Subscribes the closing user to the note and records audit events.
- **`app/services/changeset_service.py`**:
  - `close()`: SELECT now includes `tags`; after closing, calls `_close_tagged_notes()`
  - `_close_inactive()`: switched to `UPDATE ... RETURNING user_id, tags` to process tagged notes on background close too
  - New `_parse_note_closure_tags()`: parses `closes:note` tags into `{note_id: comment}`
  - New `_close_tagged_notes()`: iterates parsed tags and calls `NoteService.close_if_open()`
- **`tests/services/test_changeset_service.py`**: 8 new test cases covering per-note/global/changeset comment, no-comment, already-closed, invalid ids, and the inactive-closer path.

## Design decisions

- `close_if_open` lives in `NoteService` (not `changeset_service`) to keep note-state mutations in one place and reuse the same audit/subscribe patterns as `NoteService.comment()`.
- The method accepts an explicit `conn` so both the manual `close()` and the background `_close_inactive()` share the changeset's transaction — if note closing fails, the changeset close rolls back too.
- No activity email is sent (issue is `size S`; can be added later). Audit events use the explicit `user_id` so they work in the background-closer path where there is no request context.

## Validation

- `ruff check` / `ruff format --check`: pass
- `basedpyright`: no new errors (only pre-existing env-related import errors)
- `py_compile`: pass