### PR TITLE
Close notes referenced by changeset tags

### DIFF
--- a/app/lib/changeset_note.py
+++ b/app/lib/changeset_note.py
@@ -1,0 +1,28 @@
+_MAX_NOTE_ID = (1 << 63) - 1
+
+
+def parse_note_close_actions(tags: dict[str, str]) -> list[tuple[int, str]]:
+    """Parse note ids and closing messages from changeset tags."""
+    value = tags.get('closes:note')
+    if value is None:
+        return []
+
+    default_comment = tags.get('closes:note:comment', tags.get('comment', ''))
+    actions: list[tuple[int, str]] = []
+    seen: set[int] = set()
+
+    for item in value.split(';'):
+        item = item.strip()
+        if not item.isdecimal():
+            continue
+
+        note_id = int(item)
+        if note_id <= 0 or note_id > _MAX_NOTE_ID or note_id in seen:
+            continue
+        seen.add(note_id)
+
+        comment_key = f'closes:note:{note_id}:comment'
+        comment = tags.get(comment_key, default_comment)
+        actions.append((note_id, comment))
+
+    return actions

--- a/app/lib/changeset_note.py
+++ b/app/lib/changeset_note.py
@@ -25,4 +25,5 @@ def parse_note_close_actions(tags: dict[str, str]) -> list[tuple[int, str]]:
         comment = tags.get(comment_key, default_comment)
         actions.append((note_id, comment))
 
+    actions.sort(key=lambda action: action[0])
     return actions

--- a/app/migrations/1.sql
+++ b/app/migrations/1.sql
@@ -1,0 +1,2 @@
+ALTER TABLE changeset
+ADD COLUMN note_close_authorized boolean NOT NULL DEFAULT false;

--- a/app/models/db/changeset.py
+++ b/app/models/db/changeset.py
@@ -26,6 +26,7 @@ class Changeset(TypedDict):
     num_modify: int
     num_delete: int
     union_bounds: Polygon | None
+    note_close_authorized: bool
 
     # runtime
     user: NotRequired[UserDisplay]

--- a/app/services/changeset_service.py
+++ b/app/services/changeset_service.py
@@ -7,6 +7,7 @@ from random import uniform
 from time import monotonic
 
 import cython
+from psycopg import AsyncConnection
 from sentry_sdk.api import start_transaction
 
 from app.config import (
@@ -19,6 +20,7 @@ from app.db import (
     db_delete,
     db_fetchcol,
     db_fetchrow,
+    db_fetchrows,
     db_fetchval,
     db_insert,
     db_lock,
@@ -26,7 +28,8 @@ from app.db import (
 )
 from app.exceptions.context import raise_for
 from app.lib.audit import audit
-from app.lib.auth.context import auth_user
+from app.lib.auth.context import auth_context, auth_scopes, auth_user
+from app.lib.changeset_note import parse_note_close_actions
 from app.lib.http.retry import retry
 from app.lib.telemetry.sentry import (
     SENTRY_CHANGESET_MANAGEMENT_MONITOR,
@@ -38,11 +41,18 @@ from app.models.db.changeset_comment import (
     ChangesetComment,
     changeset_comments_resolve_rich_text,
 )
-from app.models.types import ChangesetCommentId, ChangesetId, DisplayName, UserId
+from app.models.types import (
+    ChangesetCommentId,
+    ChangesetId,
+    DisplayName,
+    NoteId,
+    UserId,
+)
 from app.queries.changeset_query import ChangesetQuery
 from app.queries.user_query import UserQuery
 from app.queries.user_subscription_query import UserSubscriptionQuery
 from app.services.email_service import EmailService
+from app.services.note_service import NoteCommentSideEffect, NoteService
 from app.services.user_subscription_service import UserSubscriptionService
 
 _PROCESS_REQUEST_EVENT = Event()
@@ -54,6 +64,7 @@ class ChangesetService:
     async def create(tags: dict[str, str]) -> ChangesetId:
         """Create a new changeset and return its id."""
         user_id = auth_user(required=True)['id']
+        _require_note_write_scope(tags)
 
         async with db(True) as conn:
             row = await db_insert(
@@ -95,6 +106,7 @@ class ChangesetService:
                 raise_for.changeset_access_denied()
             if closed_at is not None:
                 raise_for.changeset_already_closed(changeset_id, closed_at)
+            _require_note_write_scope(tags)
 
             await db_update(
                 'changeset',
@@ -107,12 +119,15 @@ class ChangesetService:
     @staticmethod
     async def close(changeset_id: ChangesetId):
         """Close a changeset."""
-        user_id = auth_user(required=True)['id']
+        user = auth_user(required=True)
+        user_id = user['id']
+        tags: dict[str, str]
+        side_effects: list[NoteCommentSideEffect] = []
 
         async with db(True) as conn:
             row = await db_fetchrow(
                 t"""
-                    SELECT user_id, closed_at
+                    SELECT user_id, closed_at, tags
                     FROM changeset
                     WHERE id = {changeset_id}
                 """,
@@ -124,12 +139,13 @@ class ChangesetService:
 
             changeset_user_id: UserId
             closed_at: datetime | None
-            changeset_user_id, closed_at = row
+            changeset_user_id, closed_at, tags = row
 
             if changeset_user_id != user_id:
                 raise_for.changeset_access_denied()
             if closed_at is not None:
                 raise_for.changeset_already_closed(changeset_id, closed_at)
+            _require_note_write_scope(tags)
 
             await db_update(
                 'changeset',
@@ -141,6 +157,28 @@ class ChangesetService:
                 conn=conn,
             )
             await audit('close_changeset', conn, extra={'id': changeset_id})
+            await _close_tagged_notes(
+                tags,
+                conn=conn,
+                deferred_side_effects=side_effects,
+            )
+
+        await NoteService.run_comment_side_effects(side_effects)
+
+    @staticmethod
+    async def close_tagged_notes(
+        tags: dict[str, str],
+        *,
+        conn: AsyncConnection,
+        deferred_side_effects: list[NoteCommentSideEffect],
+    ):
+        """Close notes referenced by tags inside an existing transaction."""
+        _require_note_write_scope(tags)
+        await _close_tagged_notes(
+            tags,
+            conn=conn,
+            deferred_side_effects=deferred_side_effects,
+        )
 
     @staticmethod
     @asynccontextmanager
@@ -272,18 +310,78 @@ async def _process_task():
 
 async def _close_inactive():
     """Close all inactive changesets."""
-    rowcount = await db_update(
-        'changeset',
-        {'closed_at': t'statement_timestamp()', 'updated_at': t'DEFAULT'},
-        where=t"""closed_at IS NULL AND (
-                updated_at < statement_timestamp() - {CHANGESET_IDLE_TIMEOUT} OR
-                (updated_at >= statement_timestamp() - {CHANGESET_IDLE_TIMEOUT} AND
-                created_at < statement_timestamp() - {CHANGESET_OPEN_TIMEOUT})
-            )""",
-    )
+    side_effects: list[NoteCommentSideEffect] = []
 
-    if rowcount:
-        logging.debug('Closed %d inactive changesets', rowcount)
+    async with db(True) as conn:
+        rows: list[tuple[UserId | None, dict[str, str]]] = await db_fetchrows(
+            t"""
+                UPDATE changeset
+                SET closed_at = statement_timestamp(), updated_at = DEFAULT
+                WHERE closed_at IS NULL AND (
+                    updated_at < statement_timestamp() - {CHANGESET_IDLE_TIMEOUT} OR
+                    (updated_at >= statement_timestamp() - {CHANGESET_IDLE_TIMEOUT} AND
+                    created_at < statement_timestamp() - {CHANGESET_OPEN_TIMEOUT})
+                )
+                RETURNING user_id, tags
+            """,
+            conn=conn,
+        )
+
+        if not rows:
+            return
+
+        tagged_rows = [
+            (user_id, tags)
+            for user_id, tags in rows
+            if user_id is not None and parse_note_close_actions(tags)
+        ]
+        users = {
+            user['id']: user
+            for user in await UserQuery.find_by_ids(
+                list({user_id for user_id, _ in tagged_rows})
+            )
+        }
+        for user_id, tags in tagged_rows:
+            user = users.get(user_id)
+            if user is None:
+                continue
+            with auth_context(user):
+                await _close_tagged_notes(
+                    tags,
+                    conn=conn,
+                    deferred_side_effects=side_effects,
+                )
+
+    logging.debug('Closed %d inactive changesets', len(rows))
+    await NoteService.run_comment_side_effects(side_effects)
+
+
+def _require_note_write_scope(tags: dict[str, str]):
+    """Require note-write authorization when tags contain valid close actions."""
+    if not parse_note_close_actions(tags):
+        return
+
+    scopes = auth_scopes()
+    if 'web_user' not in scopes and 'write_notes' not in scopes:
+        raise_for.insufficient_scopes(['write_notes'])
+
+
+async def _close_tagged_notes(
+    tags: dict[str, str],
+    *,
+    conn: AsyncConnection,
+    deferred_side_effects: list[NoteCommentSideEffect],
+):
+    """Close notes referenced by a changeset within the caller's transaction."""
+    for raw_note_id, comment in parse_note_close_actions(tags):
+        await NoteService.comment(
+            NoteId(raw_note_id),
+            comment,
+            'closed',
+            ignore_closed_or_missing=True,
+            conn=conn,
+            deferred_side_effects=deferred_side_effects,
+        )
 
 
 async def _delete_empty():

--- a/app/services/changeset_service.py
+++ b/app/services/changeset_service.py
@@ -41,6 +41,7 @@ from app.models.db.changeset_comment import (
     ChangesetComment,
     changeset_comments_resolve_rich_text,
 )
+from app.models.db.user import User
 from app.models.types import (
     ChangesetCommentId,
     ChangesetId,
@@ -57,6 +58,7 @@ from app.services.user_subscription_service import UserSubscriptionService
 
 _PROCESS_REQUEST_EVENT = Event()
 _PROCESS_DONE_EVENT = Event()
+_INACTIVE_CHANGESET_BATCH_SIZE = 100
 
 
 class ChangesetService:
@@ -64,12 +66,16 @@ class ChangesetService:
     async def create(tags: dict[str, str]) -> ChangesetId:
         """Create a new changeset and return its id."""
         user_id = auth_user(required=True)['id']
-        _require_note_write_scope(tags)
+        note_close_authorized = _require_note_write_scope(tags)
 
         async with db(True) as conn:
             row = await db_insert(
                 'changeset',
-                {'user_id': user_id, 'tags': tags},
+                {
+                    'user_id': user_id,
+                    'tags': tags,
+                    'note_close_authorized': note_close_authorized,
+                },
                 returning='id',
                 conn=conn,
             )
@@ -106,11 +112,14 @@ class ChangesetService:
                 raise_for.changeset_access_denied()
             if closed_at is not None:
                 raise_for.changeset_already_closed(changeset_id, closed_at)
-            _require_note_write_scope(tags)
-
+            note_close_authorized = _require_note_write_scope(tags)
             await db_update(
                 'changeset',
-                {'tags': tags, 'updated_at': t'DEFAULT'},
+                {
+                    'tags': tags,
+                    'note_close_authorized': note_close_authorized,
+                    'updated_at': t'DEFAULT',
+                },
                 where={'id': changeset_id},
                 conn=conn,
             )
@@ -163,17 +172,19 @@ class ChangesetService:
                 deferred_side_effects=side_effects,
             )
 
-        await NoteService.run_comment_side_effects(side_effects)
+        await NoteService.run_comment_side_effects(side_effects, best_effort=True)
 
     @staticmethod
     async def close_tagged_notes(
         tags: dict[str, str],
         *,
+        note_close_authorized: bool,
         conn: AsyncConnection,
         deferred_side_effects: list[NoteCommentSideEffect],
     ):
         """Close notes referenced by tags inside an existing transaction."""
-        _require_note_write_scope(tags)
+        if not note_close_authorized:
+            return
         await _close_tagged_notes(
             tags,
             conn=conn,
@@ -309,61 +320,103 @@ async def _process_task():
 
 
 async def _close_inactive():
-    """Close all inactive changesets."""
+    """Close inactive changesets in bounded transactions."""
+    total = 0
+    while True:
+        count = await _close_inactive_batch()
+        total += count
+        if count < _INACTIVE_CHANGESET_BATCH_SIZE:
+            break
+        await asyncio.sleep(0)
+
+    if total:
+        logging.debug('Closed %d inactive changesets', total)
+
+
+async def _close_inactive_batch() -> int:
+    """Close one bounded batch of inactive changesets."""
     side_effects: list[NoteCommentSideEffect] = []
 
     async with db(True) as conn:
-        rows: list[tuple[UserId | None, dict[str, str]]] = await db_fetchrows(
+        rows: list[
+            tuple[ChangesetId, UserId | None, dict[str, str], bool]
+        ] = await db_fetchrows(
             t"""
-                UPDATE changeset
-                SET closed_at = statement_timestamp(), updated_at = DEFAULT
-                WHERE closed_at IS NULL AND (
-                    updated_at < statement_timestamp() - {CHANGESET_IDLE_TIMEOUT} OR
-                    (updated_at >= statement_timestamp() - {CHANGESET_IDLE_TIMEOUT} AND
-                    created_at < statement_timestamp() - {CHANGESET_OPEN_TIMEOUT})
+                WITH inactive AS (
+                    SELECT id
+                    FROM changeset
+                    WHERE closed_at IS NULL AND (
+                        updated_at < statement_timestamp() - {CHANGESET_IDLE_TIMEOUT} OR
+                        (
+                            updated_at >= statement_timestamp() - {CHANGESET_IDLE_TIMEOUT}
+                            AND created_at < statement_timestamp() - {CHANGESET_OPEN_TIMEOUT}
+                        )
+                    )
+                    ORDER BY id
+                    FOR UPDATE SKIP LOCKED
+                    LIMIT {_INACTIVE_CHANGESET_BATCH_SIZE}
                 )
-                RETURNING user_id, tags
+                UPDATE changeset AS c
+                SET closed_at = statement_timestamp(), updated_at = DEFAULT
+                FROM inactive
+                WHERE c.id = inactive.id
+                RETURNING c.id, c.user_id, c.tags, c.note_close_authorized
             """,
             conn=conn,
         )
 
         if not rows:
-            return
+            return 0
 
         tagged_rows = [
-            (user_id, tags)
-            for user_id, tags in rows
-            if user_id is not None and parse_note_close_actions(tags)
-        ]
-        users = {
-            user['id']: user
-            for user in await UserQuery.find_by_ids(
-                list({user_id for user_id, _ in tagged_rows})
+            (changeset_id, user_id, tags)
+            for changeset_id, user_id, tags, note_close_authorized in rows
+            if (
+                note_close_authorized
+                and user_id is not None
+                and parse_note_close_actions(tags)
             )
-        }
-        for user_id, tags in tagged_rows:
-            user = users.get(user_id)
-            if user is None:
-                continue
-            with auth_context(user):
-                await _close_tagged_notes(
-                    tags,
-                    conn=conn,
-                    deferred_side_effects=side_effects,
+        ]
+        if tagged_rows:
+            users = {
+                user['id']: user
+                for user in await UserQuery.find_by_ids(
+                    list({user_id for _, user_id, _ in tagged_rows})
+                )
+            }
+            note_actions: list[tuple[int, ChangesetId, User, str]] = []
+            for changeset_id, user_id, tags in tagged_rows:
+                user = users.get(user_id)
+                if user is None:
+                    continue
+                note_actions.extend(
+                    (note_id, changeset_id, user, comment)
+                    for note_id, comment in parse_note_close_actions(tags)
                 )
 
-    logging.debug('Closed %d inactive changesets', len(rows))
-    await NoteService.run_comment_side_effects(side_effects)
+            note_actions.sort(key=lambda action: (action[0], action[1]))
+            for note_id, _, user, comment in note_actions:
+                with auth_context(user):
+                    await _close_tagged_note(
+                        note_id,
+                        comment,
+                        conn=conn,
+                        deferred_side_effects=side_effects,
+                    )
+
+    await NoteService.run_comment_side_effects(side_effects, best_effort=True)
+    return len(rows)
 
 
-def _require_note_write_scope(tags: dict[str, str]):
+def _require_note_write_scope(tags: dict[str, str]) -> bool:
     """Require note-write authorization when tags contain valid close actions."""
     if not parse_note_close_actions(tags):
-        return
+        return False
 
     scopes = auth_scopes()
     if 'web_user' not in scopes and 'write_notes' not in scopes:
         raise_for.insufficient_scopes(['write_notes'])
+    return True
 
 
 async def _close_tagged_notes(
@@ -374,14 +427,29 @@ async def _close_tagged_notes(
 ):
     """Close notes referenced by a changeset within the caller's transaction."""
     for raw_note_id, comment in parse_note_close_actions(tags):
-        await NoteService.comment(
-            NoteId(raw_note_id),
+        await _close_tagged_note(
+            raw_note_id,
             comment,
-            'closed',
-            ignore_closed_or_missing=True,
             conn=conn,
             deferred_side_effects=deferred_side_effects,
         )
+
+
+async def _close_tagged_note(
+    raw_note_id: int,
+    comment: str,
+    *,
+    conn: AsyncConnection,
+    deferred_side_effects: list[NoteCommentSideEffect],
+):
+    await NoteService.comment(
+        NoteId(raw_note_id),
+        comment,
+        'closed',
+        ignore_closed_or_missing=True,
+        conn=conn,
+        deferred_side_effects=deferred_side_effects,
+    )
 
 
 async def _delete_empty():

--- a/app/services/note_service.py
+++ b/app/services/note_service.py
@@ -1,4 +1,6 @@
+import logging
 from asyncio import TaskGroup
+from collections.abc import Awaitable
 from datetime import datetime
 from typing import Any, TypeAlias
 
@@ -97,6 +99,10 @@ class NoteService:
     ) -> bool:
         """Comment on a note."""
         own_transaction = conn is None
+        if own_transaction and deferred_side_effects is not None:
+            raise ValueError(
+                'connection is required when deferring comment side effects'
+            )
         if not own_transaction and deferred_side_effects is None:
             raise ValueError(
                 'deferred_side_effects is required when using an existing connection'
@@ -218,21 +224,49 @@ class NoteService:
     @staticmethod
     async def run_comment_side_effects(
         side_effects: list[NoteCommentSideEffect],
+        *,
+        best_effort: bool = False,
     ):
         """Run email and subscription work after the database transaction commits."""
+        runner = (
+            _run_comment_side_effect_best_effort
+            if best_effort
+            else _run_comment_side_effect
+        )
         async with TaskGroup() as tg:
             for side_effect in side_effects:
-                tg.create_task(_run_comment_side_effect(side_effect))
+                tg.create_task(runner(side_effect))
 
 
-async def _run_comment_side_effect(side_effect: NoteCommentSideEffect):
+async def _run_comment_side_effect_best_effort(
+    side_effect: NoteCommentSideEffect,
+):
+    try:
+        await _run_comment_side_effect(side_effect, best_effort=True)
+    except Exception:
+        logging.exception('Failed to run note comment side effect')
+
+
+async def _run_comment_side_effect(
+    side_effect: NoteCommentSideEffect,
+    *,
+    best_effort: bool = False,
+):
     user, scopes, note, comment, send_activity_email = side_effect
+
+    async def run(operation: Awaitable[Any]):
+        try:
+            await operation
+        except Exception:
+            if not best_effort:
+                raise
+            logging.exception('Failed to run note comment side effect operation')
 
     with auth_context(user, scopes):
         async with TaskGroup() as tg:
             if send_activity_email:
-                tg.create_task(_send_activity_email(note, comment))
-            tg.create_task(UserSubscriptionService.subscribe('note', note['id']))
+                tg.create_task(run(_send_activity_email(note, comment)))
+            tg.create_task(run(UserSubscriptionService.subscribe('note', note['id'])))
 
 
 async def _send_activity_email(note: Note, comment: NoteComment):

--- a/app/services/note_service.py
+++ b/app/services/note_service.py
@@ -1,14 +1,15 @@
 from asyncio import TaskGroup
 from datetime import datetime
-from typing import Any
+from typing import Any, TypeAlias
 
 import cython
+from psycopg import AsyncConnection
 from shapely import Point, get_coordinates
 
 from app.db import db, db_fetchone, db_insert, db_update
 from app.exceptions.context import raise_for
 from app.lib.audit import audit
-from app.lib.auth.context import auth_scopes, auth_user
+from app.lib.auth.context import auth_context, auth_scopes, auth_user
 from app.lib.http.client import HTTPError
 from app.lib.text.translation import t, translation_context
 from app.middlewares.request_context_middleware import get_request_ip
@@ -17,8 +18,9 @@ from app.models.db.note_comment import (
     NoteComment,
     note_comments_resolve_rich_text,
 )
-from app.models.db.user import user_is_moderator
+from app.models.db.user import User, user_is_moderator
 from app.models.proto.note_types import GetCommentsResponse_Comment_Event
+from app.models.scope import Scope
 from app.models.types import DisplayName, NoteCommentId, NoteId
 from app.queries.nominatim_query import NominatimQuery
 from app.queries.note_query import NoteCommentQuery
@@ -26,6 +28,14 @@ from app.queries.user_subscription_query import UserSubscriptionQuery
 from app.services.email_service import EmailService
 from app.services.user_subscription_service import UserSubscriptionService
 from app.validators.geometry import validate_geometry
+
+NoteCommentSideEffect: TypeAlias = tuple[
+    User,
+    frozenset[Scope],
+    Note,
+    NoteComment,
+    bool,
+]
 
 
 class NoteService:
@@ -77,9 +87,22 @@ class NoteService:
 
     @staticmethod
     async def comment(
-        note_id: NoteId, text: str, event: GetCommentsResponse_Comment_Event
-    ):
+        note_id: NoteId,
+        text: str,
+        event: GetCommentsResponse_Comment_Event,
+        *,
+        ignore_closed_or_missing: bool = False,
+        conn: AsyncConnection | None = None,
+        deferred_side_effects: list[NoteCommentSideEffect] | None = None,
+    ) -> bool:
         """Comment on a note."""
+        own_transaction = conn is None
+        if not own_transaction and deferred_side_effects is None:
+            raise ValueError(
+                'deferred_side_effects is required when using an existing connection'
+            )
+
+        side_effects = [] if deferred_side_effects is None else deferred_side_effects
         user = auth_user(required=True)
         user_id = user['id']
         send_activity_email: cython.bint = False
@@ -87,7 +110,7 @@ class NoteService:
         # Only show hidden notes to moderators
         hidden_filter = t'' if user_is_moderator(user) else t'AND hidden_at IS NULL'
 
-        async with db(True) as conn:
+        async with db(True, conn) as conn:
             note = await db_fetchone(
                 Note,
                 t"""
@@ -99,12 +122,16 @@ class NoteService:
                 conn=conn,
             )
             if note is None:
+                if ignore_closed_or_missing:
+                    return False
                 raise_for.note_not_found(note_id)
 
             updates: dict[str, Any] = {}
 
             if event == 'closed':
                 if note['closed_at'] is not None:
+                    if ignore_closed_or_missing:
+                        return False
                     raise_for.note_closed(note_id, note['closed_at'])
                 updates['closed_at'] = t'statement_timestamp()'
                 send_activity_email = True
@@ -175,11 +202,37 @@ class NoteService:
             'created_at': created_at,
             'user': user,  # type: ignore
         }
+        side_effects.append((
+            user,
+            auth_scopes(),
+            note,
+            comment,
+            bool(send_activity_email),
+        ))
 
+        if own_transaction:
+            await NoteService.run_comment_side_effects(side_effects)
+
+        return True
+
+    @staticmethod
+    async def run_comment_side_effects(
+        side_effects: list[NoteCommentSideEffect],
+    ):
+        """Run email and subscription work after the database transaction commits."""
+        async with TaskGroup() as tg:
+            for side_effect in side_effects:
+                tg.create_task(_run_comment_side_effect(side_effect))
+
+
+async def _run_comment_side_effect(side_effect: NoteCommentSideEffect):
+    user, scopes, note, comment, send_activity_email = side_effect
+
+    with auth_context(user, scopes):
         async with TaskGroup() as tg:
             if send_activity_email:
                 tg.create_task(_send_activity_email(note, comment))
-            tg.create_task(UserSubscriptionService.subscribe('note', note_id))
+            tg.create_task(UserSubscriptionService.subscribe('note', note['id']))
 
 
 async def _send_activity_email(note: Note, comment: NoteComment):

--- a/app/services/optimistic_diff/__init__.py
+++ b/app/services/optimistic_diff/__init__.py
@@ -11,6 +11,8 @@ from app.db import db
 from app.exceptions.optimistic_diff_error import OptimisticDiffError
 from app.models.db.element import ElementInit
 from app.models.element import TypedElementId
+from app.services.changeset_service import ChangesetService
+from app.services.note_service import NoteCommentSideEffect, NoteService
 from app.services.optimistic_diff.apply import OptimisticDiffApply
 from app.services.optimistic_diff.prepare import OptimisticDiffPrepare
 
@@ -33,11 +35,19 @@ class OptimisticDiff:
         attempt: cython.size_t = 0
 
         while True:
+            side_effects: list[NoteCommentSideEffect] = []
             try:
                 async with db(True) as conn:
                     prep = OptimisticDiffPrepare(conn, elements)
                     await prep.prepare()
-                    return await OptimisticDiffApply.apply(prep)
+                    result = await OptimisticDiffApply.apply(prep)
+
+                    if prep.apply_elements and 'size_limit_reached' in prep.changeset:
+                        await ChangesetService.close_tagged_notes(
+                            prep.changeset['tags'],
+                            conn=conn,
+                            deferred_side_effects=side_effects,
+                        )
             except* (OptimisticDiffError, OperationalError) as e:
                 attempt += 1
 
@@ -65,3 +75,6 @@ class OptimisticDiff:
                 await asyncio.sleep(sleep)
                 sleep = uniform(sleep * 1.5, sleep * 2.5)
                 sleep = min(sleep, sleep_limit)
+            else:
+                await NoteService.run_comment_side_effects(side_effects)
+                return result

--- a/app/services/optimistic_diff/__init__.py
+++ b/app/services/optimistic_diff/__init__.py
@@ -45,6 +45,9 @@ class OptimisticDiff:
                     if prep.apply_elements and 'size_limit_reached' in prep.changeset:
                         await ChangesetService.close_tagged_notes(
                             prep.changeset['tags'],
+                            note_close_authorized=prep.changeset[
+                                'note_close_authorized'
+                            ],
                             conn=conn,
                             deferred_side_effects=side_effects,
                         )
@@ -76,5 +79,8 @@ class OptimisticDiff:
                 sleep = uniform(sleep * 1.5, sleep * 2.5)
                 sleep = min(sleep, sleep_limit)
             else:
-                await NoteService.run_comment_side_effects(side_effects)
+                await NoteService.run_comment_side_effects(
+                    side_effects,
+                    best_effort=True,
+                )
                 return result

--- a/tests/controllers/test_api06_changeset.py
+++ b/tests/controllers/test_api06_changeset.py
@@ -358,7 +358,13 @@ async def test_changeset_tagged_notes_require_write_notes(
 
     r = await client.put(
         '/api/0.6/changeset/create',
-        content=XMLToDict.unparse({'osm': {'changeset': {}}}),
+        content=XMLToDict.unparse({
+            'osm': {
+                'changeset': {
+                    'tag': [{'@k': 'created_by', '@v': 'tests'}],
+                }
+            }
+        }),
     )
     assert r.is_success, r.text
     changeset_id = int(r.text)
@@ -617,7 +623,13 @@ async def test_inactive_legacy_changeset_does_not_close_tagged_note(
 
     r = await client.put(
         '/api/0.6/changeset/create',
-        content=XMLToDict.unparse({'osm': {'changeset': {}}}),
+        content=XMLToDict.unparse({
+            'osm': {
+                'changeset': {
+                    'tag': [{'@k': 'created_by', '@v': 'tests'}],
+                }
+            }
+        }),
     )
     assert r.is_success, r.text
     changeset_id = int(r.text)

--- a/tests/controllers/test_api06_changeset.py
+++ b/tests/controllers/test_api06_changeset.py
@@ -1,18 +1,23 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
-from annotated_types import Gt
+from annotated_types import Gt, Len
 from httpx import AsyncClient
 from starlette import status
 
 from app.config import (
+    CHANGESET_IDLE_TIMEOUT,
     LEGACY_HIGH_PRECISION_TIME,
     TAGS_KEY_MAX_LENGTH,
     TAGS_LIMIT,
     TAGS_MAX_SIZE,
 )
+from app.db import db
 from app.format import Format06
+from app.lib.auth.user_limits import UserRoleLimits
 from app.lib.io.xml_codec import XMLToDict
+from app.services.changeset_service import ChangesetService
+from app.services.note_service import NoteService
 from tests.utils.assert_model import assert_model
 
 
@@ -253,6 +258,296 @@ async def test_changeset_update_closed(client: AsyncClient):
         }),
     )
     assert r.status_code == status.HTTP_409_CONFLICT, r.text
+
+
+async def test_changeset_close_closes_tagged_notes(client: AsyncClient):
+    client.headers['Authorization'] = 'User user1'
+
+    async def create_note(text: str) -> int:
+        r = await client.post(
+            '/api/0.6/notes.json', json={'lon': 0, 'lat': 0, 'text': text}
+        )
+        assert r.is_success, r.text
+        return r.json()['properties']['id']
+
+    fallback_note_id = await create_note('fallback close note')
+    global_note_id = await create_note('global close note')
+    specific_note_id = await create_note('specific close note')
+    already_closed_note_id = await create_note('already closed note')
+
+    r = await client.post(
+        f'/api/0.6/notes/{already_closed_note_id}/close.json',
+        params={'text': 'closed before changeset'},
+    )
+    assert r.is_success, r.text
+    already_closed_comments = r.json()['properties']['comments']
+
+    r = await client.put(
+        '/api/0.6/changeset/create',
+        content=XMLToDict.unparse({
+            'osm': {
+                'changeset': {
+                    'tag': [
+                        {'@k': 'comment', '@v': 'changeset fallback'},
+                        {'@k': 'closes:note', '@v': str(fallback_note_id)},
+                    ]
+                }
+            }
+        }),
+    )
+    assert r.is_success, r.text
+    fallback_changeset_id = int(r.text)
+
+    r = await client.put(f'/api/0.6/changeset/{fallback_changeset_id}/close')
+    assert r.is_success, r.text
+
+    r = await client.put(
+        '/api/0.6/changeset/create',
+        content=XMLToDict.unparse({
+            'osm': {
+                'changeset': {
+                    'tag': [
+                        {'@k': 'comment', '@v': 'changeset fallback'},
+                        {
+                            '@k': 'closes:note',
+                            '@v': (
+                                f'{global_note_id};invalid;0;-1;{specific_note_id};'
+                                f'{specific_note_id};{already_closed_note_id};'
+                                '9223372036854775808;999999999999'
+                            ),
+                        },
+                        {'@k': 'closes:note:comment', '@v': 'global close message'},
+                        {
+                            '@k': f'closes:note:{specific_note_id}:comment',
+                            '@v': 'specific close message',
+                        },
+                    ]
+                }
+            }
+        }),
+    )
+    assert r.is_success, r.text
+    changeset_id = int(r.text)
+
+    r = await client.put(f'/api/0.6/changeset/{changeset_id}/close')
+    assert r.is_success, r.text
+
+    for note_id, expected_comment in (
+        (fallback_note_id, 'changeset fallback'),
+        (global_note_id, 'global close message'),
+        (specific_note_id, 'specific close message'),
+    ):
+        r = await client.get(f'/api/0.6/notes/{note_id}.json')
+        assert r.is_success, r.text
+        note = r.json()['properties']
+        assert_model(note, {'status': 'closed', 'comments': Len(2, 2)})
+        assert_model(
+            note['comments'][-1],
+            {'user': 'user1', 'action': 'closed', 'text': expected_comment},
+        )
+
+    r = await client.get(f'/api/0.6/notes/{already_closed_note_id}.json')
+    assert r.is_success, r.text
+    assert r.json()['properties']['comments'] == already_closed_comments
+
+
+async def test_changeset_tagged_notes_require_write_notes(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+):
+    client.headers['Authorization'] = 'User user1'
+    monkeypatch.setattr(
+        'app.services.changeset_service.auth_scopes',
+        lambda: frozenset({'write_api'}),
+    )
+
+    r = await client.put(
+        '/api/0.6/changeset/create',
+        content=XMLToDict.unparse({
+            'osm': {
+                'changeset': {
+                    'tag': [{'@k': 'closes:note', '@v': '1'}],
+                }
+            }
+        }),
+    )
+
+    assert r.status_code == status.HTTP_403_FORBIDDEN, r.text
+    assert (
+        'The request requires higher privileges than authorized (write_notes)' in r.text
+    )
+
+
+async def test_changeset_note_closes_are_atomic(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+):
+    client.headers['Authorization'] = 'User user1'
+
+    note_ids: list[int] = []
+    for index in range(2):
+        r = await client.post(
+            '/api/0.6/notes.json',
+            json={'lon': index, 'lat': 0, 'text': f'atomic note {index}'},
+        )
+        assert r.is_success, r.text
+        note_ids.append(r.json()['properties']['id'])
+
+    r = await client.put(
+        '/api/0.6/changeset/create',
+        content=XMLToDict.unparse({
+            'osm': {
+                'changeset': {
+                    'tag': [
+                        {'@k': 'closes:note', '@v': ';'.join(map(str, note_ids))},
+                    ]
+                }
+            }
+        }),
+    )
+    assert r.is_success, r.text
+    changeset_id = int(r.text)
+
+    original_comment = NoteService.comment
+
+    async def fail_after_second_note(*args, **kwargs):
+        result = await original_comment(*args, **kwargs)
+        if args[0] == note_ids[1]:
+            raise RuntimeError('injected note close failure')
+        return result
+
+    monkeypatch.setattr(
+        NoteService,
+        'comment',
+        staticmethod(fail_after_second_note),
+    )
+
+    with pytest.raises(RuntimeError, match='injected note close failure'):
+        await client.put(f'/api/0.6/changeset/{changeset_id}/close')
+
+    r = await client.get(f'/api/0.6/changeset/{changeset_id}.json')
+    assert r.is_success, r.text
+    assert r.json()['changesets'][0]['open'] is True
+
+    for note_id in note_ids:
+        r = await client.get(f'/api/0.6/notes/{note_id}.json')
+        assert r.is_success, r.text
+        assert_model(r.json()['properties'], {'status': 'open', 'comments': Len(1, 1)})
+
+
+async def test_changeset_size_limit_closes_tagged_note(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+):
+    client.headers['Authorization'] = 'User user1'
+
+    r = await client.post(
+        '/api/0.6/notes.json',
+        json={
+            'lon': 0,
+            'lat': 0,
+            'text': test_changeset_size_limit_closes_tagged_note.__name__,
+        },
+    )
+    assert r.is_success, r.text
+    note_id = r.json()['properties']['id']
+
+    r = await client.put(
+        '/api/0.6/changeset/create',
+        content=XMLToDict.unparse({
+            'osm': {
+                'changeset': {
+                    'tag': [
+                        {'@k': 'comment', '@v': 'size limit close message'},
+                        {'@k': 'closes:note', '@v': str(note_id)},
+                    ]
+                }
+            }
+        }),
+    )
+    assert r.is_success, r.text
+    changeset_id = int(r.text)
+
+    monkeypatch.setattr(
+        UserRoleLimits,
+        'get_changeset_max_size',
+        staticmethod(lambda _roles: 1),
+    )
+    r = await client.post(
+        f'/api/0.6/changeset/{changeset_id}/upload',
+        content=XMLToDict.unparse({
+            'osmChange': {
+                'create': [('node', {'@id': -1, '@lat': 0, '@lon': 0})],
+            }
+        }),
+    )
+    assert r.is_success, r.text
+
+    r = await client.get(f'/api/0.6/changeset/{changeset_id}.json')
+    assert r.is_success, r.text
+    assert r.json()['changesets'][0]['open'] is False
+
+    r = await client.get(f'/api/0.6/notes/{note_id}.json')
+    assert r.is_success, r.text
+    note = r.json()['properties']
+    assert_model(note, {'status': 'closed', 'comments': Len(2, 2)})
+    assert_model(
+        note['comments'][-1],
+        {
+            'user': 'user1',
+            'action': 'closed',
+            'text': 'size limit close message',
+        },
+    )
+
+
+async def test_inactive_changeset_closes_tagged_note(client: AsyncClient):
+    client.headers['Authorization'] = 'User user1'
+
+    r = await client.post(
+        '/api/0.6/notes.json',
+        json={
+            'lon': 0,
+            'lat': 0,
+            'text': test_inactive_changeset_closes_tagged_note.__name__,
+        },
+    )
+    assert r.is_success, r.text
+    note_id = r.json()['properties']['id']
+
+    r = await client.put(
+        '/api/0.6/changeset/create',
+        content=XMLToDict.unparse({
+            'osm': {
+                'changeset': {
+                    'tag': [
+                        {'@k': 'comment', '@v': 'inactive close message'},
+                        {'@k': 'closes:note', '@v': str(note_id)},
+                    ]
+                }
+            }
+        }),
+    )
+    assert r.is_success, r.text
+    changeset_id = int(r.text)
+
+    async with db(True) as conn:
+        assert conn is not None
+        await conn.execute(
+            t"""
+                UPDATE changeset
+                SET updated_at = statement_timestamp() - {CHANGESET_IDLE_TIMEOUT + timedelta(seconds=1)}
+                WHERE id = {changeset_id}
+            """
+        )
+
+    await ChangesetService.force_process()
+
+    r = await client.get(f'/api/0.6/notes/{note_id}.json')
+    assert r.is_success, r.text
+    note = r.json()['properties']
+    assert_model(note, {'status': 'closed', 'comments': Len(2, 2)})
+    assert_model(
+        note['comments'][-1],
+        {'user': 'user1', 'action': 'closed', 'text': 'inactive close message'},
+    )
 
 
 async def test_changeset_upload_closed(client: AsyncClient):

--- a/tests/controllers/test_api06_changeset.py
+++ b/tests/controllers/test_api06_changeset.py
@@ -355,6 +355,14 @@ async def test_changeset_tagged_notes_require_write_notes(
     client: AsyncClient, monkeypatch: pytest.MonkeyPatch
 ):
     client.headers['Authorization'] = 'User user1'
+
+    r = await client.put(
+        '/api/0.6/changeset/create',
+        content=XMLToDict.unparse({'osm': {'changeset': {}}}),
+    )
+    assert r.is_success, r.text
+    changeset_id = int(r.text)
+
     monkeypatch.setattr(
         'app.services.changeset_service.auth_scopes',
         lambda: frozenset({'write_api'}),
@@ -375,6 +383,30 @@ async def test_changeset_tagged_notes_require_write_notes(
     assert (
         'The request requires higher privileges than authorized (write_notes)' in r.text
     )
+
+    r = await client.put(
+        f'/api/0.6/changeset/{changeset_id}',
+        content=XMLToDict.unparse({
+            'osm': {
+                'changeset': {
+                    'tag': [{'@k': 'closes:note', '@v': '1'}],
+                }
+            }
+        }),
+    )
+    assert r.status_code == status.HTTP_403_FORBIDDEN, r.text
+
+    async with db(True) as conn:
+        await conn.execute(
+            t"""
+                UPDATE changeset
+                SET tags = {'closes:note=>1'}::hstore
+                WHERE id = {changeset_id}
+            """
+        )
+
+    r = await client.put(f'/api/0.6/changeset/{changeset_id}/close')
+    assert r.status_code == status.HTTP_403_FORBIDDEN, r.text
 
 
 async def test_changeset_note_closes_are_atomic(
@@ -498,7 +530,78 @@ async def test_changeset_size_limit_closes_tagged_note(
     )
 
 
-async def test_inactive_changeset_closes_tagged_note(client: AsyncClient):
+async def test_inactive_changeset_closes_tagged_note(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    client.headers['Authorization'] = 'User user1'
+
+    note_ids: list[int] = []
+    for index in range(2):
+        r = await client.post(
+            '/api/0.6/notes.json',
+            json={
+                'lon': index,
+                'lat': 0,
+                'text': f'{test_inactive_changeset_closes_tagged_note.__name__} {index}',
+            },
+        )
+        assert r.is_success, r.text
+        note_ids.append(r.json()['properties']['id'])
+
+    changeset_ids: list[int] = []
+    for note_id in reversed(note_ids):
+        r = await client.put(
+            '/api/0.6/changeset/create',
+            content=XMLToDict.unparse({
+                'osm': {
+                    'changeset': {
+                        'tag': [
+                            {'@k': 'comment', '@v': f'close note {note_id}'},
+                            {'@k': 'closes:note', '@v': str(note_id)},
+                        ]
+                    }
+                }
+            }),
+        )
+        assert r.is_success, r.text
+        changeset_ids.append(int(r.text))
+
+    async with db(True) as conn:
+        await conn.execute(
+            t"""
+                UPDATE changeset
+                SET updated_at = statement_timestamp() - {CHANGESET_IDLE_TIMEOUT + timedelta(seconds=1)}
+                WHERE id = ANY({changeset_ids})
+            """
+        )
+
+    original_comment = NoteService.comment
+    closed_note_ids: list[int] = []
+
+    async def track_note_close(note_id, *args, **kwargs):
+        closed_note_ids.append(note_id)
+        return await original_comment(note_id, *args, **kwargs)
+
+    monkeypatch.setattr(NoteService, 'comment', staticmethod(track_note_close))
+
+    await ChangesetService.force_process()
+
+    assert closed_note_ids == note_ids
+    for note_id in note_ids:
+        r = await client.get(f'/api/0.6/notes/{note_id}.json')
+        assert r.is_success, r.text
+        note = r.json()['properties']
+        assert_model(note, {'status': 'closed', 'comments': Len(2, 2)})
+        assert_model(
+            note['comments'][-1],
+            {'user': 'user1', 'action': 'closed', 'text': f'close note {note_id}'},
+        )
+
+
+async def test_inactive_legacy_changeset_does_not_close_tagged_note(
+    client: AsyncClient,
+):
     client.headers['Authorization'] = 'User user1'
 
     r = await client.post(
@@ -506,7 +609,7 @@ async def test_inactive_changeset_closes_tagged_note(client: AsyncClient):
         json={
             'lon': 0,
             'lat': 0,
-            'text': test_inactive_changeset_closes_tagged_note.__name__,
+            'text': test_inactive_legacy_changeset_does_not_close_tagged_note.__name__,
         },
     )
     assert r.is_success, r.text
@@ -514,40 +617,31 @@ async def test_inactive_changeset_closes_tagged_note(client: AsyncClient):
 
     r = await client.put(
         '/api/0.6/changeset/create',
-        content=XMLToDict.unparse({
-            'osm': {
-                'changeset': {
-                    'tag': [
-                        {'@k': 'comment', '@v': 'inactive close message'},
-                        {'@k': 'closes:note', '@v': str(note_id)},
-                    ]
-                }
-            }
-        }),
+        content=XMLToDict.unparse({'osm': {'changeset': {}}}),
     )
     assert r.is_success, r.text
     changeset_id = int(r.text)
 
     async with db(True) as conn:
-        assert conn is not None
         await conn.execute(
             t"""
                 UPDATE changeset
-                SET updated_at = statement_timestamp() - {CHANGESET_IDLE_TIMEOUT + timedelta(seconds=1)}
+                SET
+                    tags = {f'closes:note=>{note_id}'}::hstore,
+                    updated_at = statement_timestamp() - {CHANGESET_IDLE_TIMEOUT + timedelta(seconds=1)}
                 WHERE id = {changeset_id}
             """
         )
 
     await ChangesetService.force_process()
 
+    r = await client.get(f'/api/0.6/changeset/{changeset_id}.json')
+    assert r.is_success, r.text
+    assert r.json()['changesets'][0]['open'] is False
+
     r = await client.get(f'/api/0.6/notes/{note_id}.json')
     assert r.is_success, r.text
-    note = r.json()['properties']
-    assert_model(note, {'status': 'closed', 'comments': Len(2, 2)})
-    assert_model(
-        note['comments'][-1],
-        {'user': 'user1', 'action': 'closed', 'text': 'inactive close message'},
-    )
+    assert_model(r.json()['properties'], {'status': 'open', 'comments': Len(1, 1)})
 
 
 async def test_changeset_upload_closed(client: AsyncClient):

--- a/tests/lib/test_changeset_note.py
+++ b/tests/lib/test_changeset_note.py
@@ -19,6 +19,21 @@ def test_parse_note_close_actions_comment_precedence():
     ]
 
 
+def test_parse_note_close_actions_sorts_note_ids():
+    actions = parse_note_close_actions({
+        'closes:note': '20;3;10',
+        'closes:note:20:comment': 'twenty',
+        'closes:note:3:comment': 'three',
+        'closes:note:10:comment': 'ten',
+    })
+
+    assert actions == [
+        (3, 'three'),
+        (10, 'ten'),
+        (20, 'twenty'),
+    ]
+
+
 @pytest.mark.parametrize(
     ('tags', 'expected'),
     [

--- a/tests/lib/test_changeset_note.py
+++ b/tests/lib/test_changeset_note.py
@@ -1,0 +1,36 @@
+import pytest
+
+from app.lib.changeset_note import parse_note_close_actions
+
+
+def test_parse_note_close_actions_comment_precedence():
+    actions = parse_note_close_actions({
+        'closes:note': '10; 20;30',
+        'comment': 'changeset comment',
+        'closes:note:comment': 'global comment',
+        'closes:note:20:comment': 'specific comment',
+        'closes:note:30:comment': '',
+    })
+
+    assert actions == [
+        (10, 'global comment'),
+        (20, 'specific comment'),
+        (30, ''),
+    ]
+
+
+@pytest.mark.parametrize(
+    ('tags', 'expected'),
+    [
+        ({}, []),
+        ({'closes:note': '1;1;2'}, [(1, ''), (2, '')]),
+        ({'closes:note': 'invalid;0;-1;3'}, [(3, '')]),
+        ({'closes:note': str(1 << 63)}, []),
+        (
+            {'closes:note': '4', 'comment': 'changeset comment'},
+            [(4, 'changeset comment')],
+        ),
+    ],
+)
+def test_parse_note_close_actions(tags, expected):
+    assert parse_note_close_actions(tags) == expected

--- a/tests/services/test_changeset_service.py
+++ b/tests/services/test_changeset_service.py
@@ -12,6 +12,7 @@ from app.db import db
 from app.lib.time.date_utils import utcnow
 from app.models.types import ChangesetId
 from app.queries.changeset_query import ChangesetQuery
+from app.services import changeset_service
 from app.services.changeset_service import ChangesetService
 
 
@@ -34,6 +35,34 @@ async def test_changeset_inactive_close():
     assert changeset['closed_at'] is not None, (
         'Changeset must be closed after processing'
     )
+
+
+async def test_changeset_inactive_close_is_batched(monkeypatch):
+    monkeypatch.setattr(
+        'app.services.changeset_service._INACTIVE_CHANGESET_BATCH_SIZE',
+        2,
+    )
+    inactive_time = utcnow() - CHANGESET_IDLE_TIMEOUT - timedelta(seconds=1)
+    changeset_ids = [
+        await _create_changeset(updated_at=inactive_time) for _ in range(3)
+    ]
+    batch_calls = 0
+    original_db_fetchrows = changeset_service.db_fetchrows
+
+    async def tracked_db_fetchrows(*args: Any, **kwargs: Any):
+        nonlocal batch_calls
+        batch_calls += 1
+        return await original_db_fetchrows(*args, **kwargs)
+
+    monkeypatch.setattr(changeset_service, 'db_fetchrows', tracked_db_fetchrows)
+
+    await ChangesetService.force_process()
+
+    changesets = [
+        await ChangesetQuery.find_by_id(changeset_id) for changeset_id in changeset_ids
+    ]
+    assert all(c is not None and c['closed_at'] is not None for c in changesets)
+    assert batch_calls >= 2
 
 
 async def test_changeset_inactive_open():

--- a/tests/services/test_note_service.py
+++ b/tests/services/test_note_service.py
@@ -1,0 +1,68 @@
+import asyncio
+from typing import cast
+
+import pytest
+
+from app.models.types import NoteId
+from app.services import note_service
+from app.services.note_service import NoteCommentSideEffect, NoteService
+
+
+async def test_comment_rejects_deferred_side_effects_without_connection():
+    with pytest.raises(ValueError, match='connection is required'):
+        await NoteService.comment(
+            NoteId(1),
+            '',
+            'closed',
+            deferred_side_effects=[],
+        )
+
+
+async def test_run_comment_side_effects_best_effort(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    completed_emails: list[int] = []
+    completed_subscriptions: list[int] = []
+
+    async def send_activity_email(note, _comment):
+        if note['id'] == 1:
+            await asyncio.sleep(0)
+            raise RuntimeError('injected delivery failure')
+        await asyncio.sleep(0.01)
+        completed_emails.append(note['id'])
+
+    async def subscribe(_type, note_id):
+        await asyncio.sleep(0.01)
+        completed_subscriptions.append(note_id)
+
+    monkeypatch.setattr(note_service, '_send_activity_email', send_activity_email)
+    monkeypatch.setattr(
+        note_service.UserSubscriptionService,
+        'subscribe',
+        staticmethod(subscribe),
+    )
+
+    def side_effect(note_id: int):
+        return cast(
+            NoteCommentSideEffect,
+            (
+                {
+                    'id': 1,
+                    'email': 'user@example.com',
+                    'display_name': 'user',
+                    'timezone': None,
+                },
+                frozenset({'web_user'}),
+                {'id': note_id},
+                {},
+                True,
+            ),
+        )
+
+    await NoteService.run_comment_side_effects(
+        [side_effect(1), side_effect(2)],
+        best_effort=True,
+    )
+
+    assert completed_emails == [2]
+    assert sorted(completed_subscriptions) == [1, 2]


### PR DESCRIPTION
Closes #126

## Summary

- Parse semicolon-separated note IDs from `closes:note`, ignoring invalid and duplicate values.
- Close referenced open notes when a changeset is explicitly closed, expires after inactivity, or reaches its size limit.
- Apply per-note, global, then changeset comment precedence while preserving intentional empty overrides.
- Commit the changeset and all note state changes atomically, then run email and subscription side effects after commit.
- Reuse the normal note comment workflow so note comments, status audits, email, and subscription behavior remain intact.
- Skip missing, hidden, and already-closed notes without blocking changeset closure.
- Require `write_notes` (or a web session) when valid note-closing tags are created, updated, or acted on.

## Testing

- `pytest tests/lib/test_changeset_note.py tests/controllers/test_api06_changeset.py` (`26 passed`)
- Regression coverage for OAuth scope enforcement, transaction rollback, and size-limit auto-close
- Python 3.14 byte compilation
- Ruff 0.15.13 lint and format checks
- Focused Pyright (`0 errors`)
- `git diff --check`
