### PR TITLE
Recompress uploaded trace files in the background

### DIFF
--- a/app/lib/io/trace_file.py
+++ b/app/lib/io/trace_file.py
@@ -32,7 +32,6 @@ class _CompressResult(NamedTuple):
 
 
 _ZSTD_SUFFIX = '.zst'
-_ZSTD_METADATA: dict[str, str] = {'zstd_level': str(TRACE_FILE_COMPRESS_ZSTD_LEVEL)}
 _ZSTD_OPTIONS: dict[int, int] = {
     zstd.CompressionParameter.compression_level: TRACE_FILE_COMPRESS_ZSTD_LEVEL,
     zstd.CompressionParameter.nb_workers: TRACE_FILE_COMPRESS_ZSTD_THREADS,
@@ -75,15 +74,18 @@ class TraceFile:
         raise_for.trace_file_archive_too_deep()
 
     @staticmethod
-    async def compress(buffer: bytes):
+    async def compress(buffer: bytes, *, level: int = TRACE_FILE_COMPRESS_ZSTD_LEVEL):
         """Compress the trace file buffer. Returns the compressed buffer and the file name suffix."""
         result = await to_thread(
             zstd.compress,
             buffer,
-            options=_ZSTD_OPTIONS,
+            options={
+                **_ZSTD_OPTIONS,
+                zstd.CompressionParameter.compression_level: level,
+            },
         )
         logging.debug('Trace file zstd-compressed size is %s', sizestr(len(result)))
-        return _CompressResult(result, _ZSTD_SUFFIX, _ZSTD_METADATA)
+        return _CompressResult(result, _ZSTD_SUFFIX, {'zstd_level': str(level)})
 
     @staticmethod
     def decompress_if_needed(buffer: bytes, file_id: StorageKey):

--- a/app/services/trace_service.py
+++ b/app/services/trace_service.py
@@ -1,6 +1,8 @@
 import logging
+from asyncio import CancelledError, Task, create_task
 from typing import Any
 
+from app.models.proto.trace_types import Visibility
 from fastapi import UploadFile
 
 from app.config import TRACE_FILE_UPLOAD_MAX_SIZE
@@ -20,9 +22,10 @@ from app.models.db.trace import (
     TraceMetaInitValidator,
     normalize_trace_tags,
 )
-from app.models.proto.trace_types import Visibility
 from app.models.types import StorageKey, TraceId
 from app.queries.trace_query import TraceQuery
+
+_RECOMPRESS_TASKS: set[Task] = set()
 
 
 class TraceService:
@@ -111,12 +114,19 @@ class TraceService:
                         'visibility': trace_init['visibility'],
                     },
                 )
-                return trace_id
 
         except Exception:
             # Clean up trace file on error
             await TRACE_STORAGE.delete(trace_init['file_id'])
             raise
+
+        # Start only after the insert transaction has committed.
+        task = create_task(
+            _recompress(trace_id, trace_init['file_id'], file, len(result.data))
+        )
+        _RECOMPRESS_TASKS.add(task)
+        task.add_done_callback(_RECOMPRESS_TASKS.discard)
+        return trace_id
 
     @staticmethod
     async def update(
@@ -172,7 +182,7 @@ class TraceService:
         async with db(True) as conn:
             file_id = await db_fetchval(
                 StorageKey,
-                t'SELECT file_id FROM trace WHERE id = {trace_id}',
+                t'SELECT file_id FROM trace WHERE id = {trace_id} FOR UPDATE',
                 conn=conn,
             )
             if file_id is None:
@@ -191,3 +201,33 @@ class TraceService:
 
         # After successful delete, also remove the file
         await TRACE_STORAGE.delete(file_id)
+
+
+async def _recompress(
+    trace_id: TraceId, old_file_id: StorageKey, buffer: bytes, old_size: int
+):
+    """Replace an uploaded file with a smaller level-22 version off the request path."""
+    try:
+        result = await TraceFile.compress(buffer, level=22)
+        if len(result.data) >= old_size:
+            return
+
+        new_file_id = await TRACE_STORAGE.save(
+            result.data, result.suffix, result.metadata
+        )
+        try:
+            async with db(True) as conn:
+                updated = await db_update(
+                    'trace',
+                    {'file_id': new_file_id},
+                    where={'id': trace_id, 'file_id': old_file_id},
+                    conn=conn,
+                )
+        except Exception, CancelledError:
+            await TRACE_STORAGE.delete(new_file_id)
+            raise
+
+        # A deleted or replaced trace no longer owns this compression result.
+        await TRACE_STORAGE.delete(old_file_id if updated else new_file_id)
+    except Exception:
+        logging.exception('Failed to recompress trace %d', trace_id)

--- a/app/services/trace_service.py
+++ b/app/services/trace_service.py
@@ -1,5 +1,5 @@
 import logging
-from asyncio import CancelledError, Task, create_task
+from asyncio import Task, create_task
 from typing import Any
 
 from app.models.proto.trace_types import Visibility
@@ -223,7 +223,8 @@ async def _recompress(
                     where={'id': trace_id, 'file_id': old_file_id},
                     conn=conn,
                 )
-        except Exception, CancelledError:
+        except BaseException:
+            # Also clean up on cancellation before propagating the exception.
             await TRACE_STORAGE.delete(new_file_id)
             raise
 

--- a/tests/lib/test_trace_file.py
+++ b/tests/lib/test_trace_file.py
@@ -1,3 +1,4 @@
+from app.config import TRACE_FILE_COMPRESS_ZSTD_LEVEL
 from app.lib.io.trace_file import TraceFile
 from app.models.types import StorageKey
 
@@ -9,3 +10,11 @@ async def test_trace_file_compression():
         == b'hello'
     )
     assert TraceFile.decompress_if_needed(result.data, StorageKey('test')) != b'hello'
+    assert result.metadata['zstd_level'] == str(TRACE_FILE_COMPRESS_ZSTD_LEVEL)
+
+
+async def test_trace_file_high_compression():
+    data = b'<gpx>repeated trace data</gpx>' * 1000
+    result = await TraceFile.compress(data, level=22)
+    assert result.metadata == {'zstd_level': '22'}
+    assert TraceFile.decompress_if_needed(result.data, StorageKey('test.zst')) == data

--- a/tests/services/test_trace_recompression.py
+++ b/tests/services/test_trace_recompression.py
@@ -1,0 +1,75 @@
+from asyncio import CancelledError
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.models.types import StorageKey, TraceId
+from app.services import trace_service
+from app.services.trace_service import _recompress
+
+
+@pytest.fixture
+def recompression(monkeypatch):
+    @asynccontextmanager
+    async def transaction(*args, **kwargs):
+        yield object()
+
+    compress = AsyncMock(
+        return_value=SimpleNamespace(
+            data=b'compressed', suffix='.zst', metadata={'zstd_level': '22'}
+        )
+    )
+    storage = SimpleNamespace(
+        save=AsyncMock(return_value=StorageKey('new.zst')),
+        delete=AsyncMock(),
+    )
+    update = AsyncMock(return_value=1)
+    monkeypatch.setattr(trace_service.TraceFile, 'compress', compress)
+    monkeypatch.setattr(trace_service, 'TRACE_STORAGE', storage)
+    monkeypatch.setattr(trace_service, 'db', transaction)
+    monkeypatch.setattr(trace_service, 'db_update', update)
+    return compress, storage, update
+
+
+@pytest.mark.parametrize('updated,removed', [(1, 'old.zst'), (0, 'new.zst')])
+async def test_recompress_replacement(recompression, updated, removed):
+    compress, storage, update = recompression
+    update.return_value = updated
+    await _recompress(TraceId(1), StorageKey('old.zst'), b'input', 100)
+    compress.assert_awaited_once_with(b'input', level=22)
+    assert update.call_args.kwargs['where'] == {'id': 1, 'file_id': 'old.zst'}
+    storage.delete.assert_awaited_once_with(removed)
+
+
+async def test_recompress_keeps_smaller_original(recompression):
+    _, storage, update = recompression
+    await _recompress(TraceId(1), StorageKey('old.zst'), b'input', 2)
+    storage.save.assert_not_awaited()
+    storage.delete.assert_not_awaited()
+    update.assert_not_awaited()
+
+
+async def test_recompress_update_failure_preserves_original(recompression):
+    _, storage, update = recompression
+    update.side_effect = RuntimeError('database unavailable')
+    await _recompress(TraceId(1), StorageKey('old.zst'), b'input', 100)
+    storage.delete.assert_awaited_once_with('new.zst')
+
+
+async def test_recompress_failure_preserves_original(recompression):
+    compress, storage, update = recompression
+    compress.side_effect = RuntimeError('compression failed')
+    await _recompress(TraceId(1), StorageKey('old.zst'), b'input', 100)
+    storage.save.assert_not_awaited()
+    storage.delete.assert_not_awaited()
+    update.assert_not_awaited()
+
+
+async def test_recompress_cancellation_cleans_uncommitted_file(recompression):
+    _, storage, update = recompression
+    update.side_effect = CancelledError()
+    with pytest.raises(CancelledError):
+        await _recompress(TraceId(1), StorageKey('old.zst'), b'input', 100)
+    storage.delete.assert_awaited_once_with('new.zst')


### PR DESCRIPTION
Trace uploads currently retain their initial fast Zstandard compression. This adds a level-22 pass after the upload transaction commits, keeping the CPU work off the request path and retaining the original when recompression does not save space.

The replacement compares the original file key before updating the trace, discards an unused new file when the trace has changed or disappeared, and locks the file-key lookup during deletion so it cannot race with a committed replacement. Background update failures clean up the uncommitted result; cancellation is propagated after that cleanup. This remains best-effort background work, not a durable restartable queue.

Closes #100.

Validation of head `9310e60f49b21c378610fbbe86f5a66b27bb011e`:
- Ruff checks, formatting, and Python 3.14 compilation passed for the changed files.
- Full repository extended Python jobs passed on Linux and macOS in [independent fork CI](https://github.com/moyuziya/openstreetmap-ng/actions/runs/34323912274). The workflow checks out the exact PR head and retains the original setup, services, matrix, and test commands.
- Cython compiled successfully and completed **613 tests passed**, including the cancellation-cleanup regression. The job then aborted during Python finalization with `gilstate_tss_set: failed to set current tstate (TSS)`, so it is still a failed job, not a clean CI run.
- A [controlled run of the unchanged upstream base `0f27e65`](https://github.com/moyuziya/openstreetmap-ng/actions/runs/34324982972) passed both Python jobs and reproduced the **same Cython finalization crash after 606 tests passed**. The shutdown fault therefore reproduces without this patch; its root cause has not been diagnosed.
- No test, failure exit status, or shutdown check was suppressed. Both full Cython job logs are available in the linked runs.

Prepared with OpenAI Codex assistance; no third-party patch was copied. Submitted for the advertised bounty; acceptance and payment remain at the maintainers' discretion under the contributor incentive rules.
